### PR TITLE
feat(azure): add role-based skill portfolio with grounded references

### DIFF
--- a/.claude/evals/azure-role-skills-reference-refactor.md
+++ b/.claude/evals/azure-role-skills-reference-refactor.md
@@ -1,0 +1,27 @@
+## EVAL DEFINITION: azure-role-skills-reference-refactor
+
+### Capability evals
+
+1. Every Azure role-based skill keeps a lean `SKILL.md` entrypoint and moves heavy detail into lazy-loaded `references/`.
+2. Every Azure role-based skill exposes a consistent reference split:
+   - `references/mcp-and-evidence.md`
+   - `references/workflow-and-output.md`
+   - `references/official-sources.md`
+3. Every Azure role-based skill still preserves:
+   - role or purpose framing,
+   - trigger guidance,
+   - explicit progressive-disclosure reference links.
+
+### Regression evals
+
+1. `catalog/skills.json` remains valid after the refactor.
+2. `catalog/skill-manifest.json` is refreshed to match the changed skill contents.
+3. Offline link validation still passes.
+
+### Deterministic checks
+
+- Count Azure skills and ensure each has the three reference files.
+- Ensure each Azure `SKILL.md` links to the three local reference files.
+- Ensure each Azure `SKILL.md` no longer carries direct Microsoft Learn URLs inline.
+- Run `npm run manifest:write`.
+- Run `npm run validate`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,8 @@
 - Update catalog JSON when adding, moving, or removing cataloged assets.
 - Regenerate skill manifest after any intentional change under cataloged `skills/**`.
 - Keep README human-friendly; keep this file agent-focused and compressed.
+- For provider-specific `README.md` files, add the matching cloud-provider logo near the top using a repo-local asset from `assets/logos/cloud/<provider>/`.
+- Do not add a provider logo to neutral or multi-cloud READMEs unless one provider is clearly the primary subject.
 - Do not add secrets, credentials, tokens, wallets, tenant IDs, or customer data.
 - Prefer official docs and live evidence over memory for cloud/compliance claims.
 - Treat broad permissions, destructive automation, and MCP mutation paths as high-risk.

--- a/catalog/skill-manifest.json
+++ b/catalog/skill-manifest.json
@@ -21,19 +21,642 @@
       ]
     },
     {
+      "id": "azure-ai-foundry-ops-governor",
+      "path": "skills/azure/azure-ai-foundry-ops-governor",
+      "aggregate_sha256": "2159ed4c7c077667fe3d2fbb2d0923f31a557c0fbfa7ff64d197a5a952add536",
+      "files": [
+        {
+          "path": "skills/azure/azure-ai-foundry-ops-governor/SKILL.md",
+          "sha256": "3e4ae26d61ab2c3123f7284a30f82e947a286b6dec2725b20f44bdb61346497d",
+          "bytes": 2911
+        },
+        {
+          "path": "skills/azure/azure-ai-foundry-ops-governor/metadata.json",
+          "sha256": "9d52ec5ffedfb30bfcd7f42d23a6e26cdb8ac3b8c3b5e8c2423a8a5acf72e534",
+          "bytes": 1770
+        },
+        {
+          "path": "skills/azure/azure-ai-foundry-ops-governor/references/mcp-and-evidence.md",
+          "sha256": "00c868461f574788332b312232c34269a4b990f1a09a29e0230356f8f951c4f6",
+          "bytes": 1926
+        },
+        {
+          "path": "skills/azure/azure-ai-foundry-ops-governor/references/official-sources.md",
+          "sha256": "15220ae41f0805692f8ccb192f1e125760aea16c0efc1f949d2aa8ed2effabdc",
+          "bytes": 1571
+        },
+        {
+          "path": "skills/azure/azure-ai-foundry-ops-governor/references/workflow-and-output.md",
+          "sha256": "5e2ff6183d800272c6c1e489e2f82e721ad810e283715813e9ab66b2b9ca1dfd",
+          "bytes": 4104
+        }
+      ]
+    },
+    {
+      "id": "azure-aks-platform-operator",
+      "path": "skills/azure/azure-aks-platform-operator",
+      "aggregate_sha256": "36b3c16045c541459b15dae5c2f09983c6cb14a6a24e471988c1c50398ad037b",
+      "files": [
+        {
+          "path": "skills/azure/azure-aks-platform-operator/SKILL.md",
+          "sha256": "79c35340116652e4078486b0bd16eedf1b1b70cbec509a564b67e447746f365a",
+          "bytes": 3117
+        },
+        {
+          "path": "skills/azure/azure-aks-platform-operator/metadata.json",
+          "sha256": "22af8ca2df16f7c68769bc93d935ce944b601d300153329fb383b8734e7852f4",
+          "bytes": 1458
+        },
+        {
+          "path": "skills/azure/azure-aks-platform-operator/references/mcp-and-evidence.md",
+          "sha256": "005679e5654530646aed4bd99462309dd8b8681eae0d68dcb22d20bf0bd974e8",
+          "bytes": 1769
+        },
+        {
+          "path": "skills/azure/azure-aks-platform-operator/references/official-sources.md",
+          "sha256": "d3118ea7406459389c6393fdfd71878abb07728adcb632176db575f0469e6285",
+          "bytes": 889
+        },
+        {
+          "path": "skills/azure/azure-aks-platform-operator/references/workflow-and-output.md",
+          "sha256": "96f7b624d37bc47403864752d011ceb6c58a9f395aab7fbd457e5f8e4cf1c68f",
+          "bytes": 4403
+        }
+      ]
+    },
+    {
+      "id": "azure-app-service-production-readiness",
+      "path": "skills/azure/azure-app-service-production-readiness",
+      "aggregate_sha256": "24492a00c202432ca9e408ab085ae20ab8cb7e005f29f315f556f56141fcb5d8",
+      "files": [
+        {
+          "path": "skills/azure/azure-app-service-production-readiness/SKILL.md",
+          "sha256": "25b41e2afdaea8f66166a5f44c7f6d880d0b28c2d986a7d54cd90b47b7b2b77a",
+          "bytes": 4063
+        },
+        {
+          "path": "skills/azure/azure-app-service-production-readiness/metadata.json",
+          "sha256": "d1c97a6976256dd30bf3b1a5dc89943c26c3db4bcb01e01581de17dda182a374",
+          "bytes": 2435
+        },
+        {
+          "path": "skills/azure/azure-app-service-production-readiness/references/mcp-and-evidence.md",
+          "sha256": "4073bae9a125d6d5ec61aa3cd497229ff506fc81ed97e6c3e79fdf59a86731c9",
+          "bytes": 2799
+        },
+        {
+          "path": "skills/azure/azure-app-service-production-readiness/references/official-sources.md",
+          "sha256": "0e9b098a5cfdc5b33217f70cfc32e2092d852dc98dbdb08bb16fbf63197665ee",
+          "bytes": 3388
+        },
+        {
+          "path": "skills/azure/azure-app-service-production-readiness/references/workflow-and-output.md",
+          "sha256": "7258adc57284617a9d7a48a141682bd7e9be8217e2acbfd2eb7348acbf94ff0e",
+          "bytes": 6314
+        }
+      ]
+    },
+    {
+      "id": "azure-cost-estimation-review",
+      "path": "skills/azure/azure-cost-estimation-review",
+      "aggregate_sha256": "a019042e1e72a04b956e7cb0f3778acb239263787b3273a9ad6a1e75e760ca2b",
+      "files": [
+        {
+          "path": "skills/azure/azure-cost-estimation-review/SKILL.md",
+          "sha256": "6008c1557cec2c42c49571caa25a61958d00e4ba2165a88f71c9df27e855bdf2",
+          "bytes": 2951
+        },
+        {
+          "path": "skills/azure/azure-cost-estimation-review/metadata.json",
+          "sha256": "870b9fc244a517feb7ad86c1f1fd690aecdc144635218516ad88085d6f9343c4",
+          "bytes": 1555
+        },
+        {
+          "path": "skills/azure/azure-cost-estimation-review/references/mcp-and-evidence.md",
+          "sha256": "b7f9c0bc4a06cb1c554208553e9ad09fec129b0cfc44a446f120d0dc069db0bb",
+          "bytes": 2444
+        },
+        {
+          "path": "skills/azure/azure-cost-estimation-review/references/official-sources.md",
+          "sha256": "aa00c08cbec680effbe219e6c84881c586ae8e8c9c304e023b15fb0059868423",
+          "bytes": 2806
+        },
+        {
+          "path": "skills/azure/azure-cost-estimation-review/references/workflow-and-output.md",
+          "sha256": "d11a8fa5de83804f658a59e943dfda3e576b9b9c24d1099a24f277d730aa2215",
+          "bytes": 4081
+        }
+      ]
+    },
+    {
+      "id": "azure-cost-optimization-governor",
+      "path": "skills/azure/azure-cost-optimization-governor",
+      "aggregate_sha256": "b849309efc2237758ecd01c9c2d03c0c0eac34c3a117fadcc0c47677dfefb8a5",
+      "files": [
+        {
+          "path": "skills/azure/azure-cost-optimization-governor/SKILL.md",
+          "sha256": "3dcf11c205e446ddd28081e54df7e2fb5d9822cbc1095e38861a480c62c2981d",
+          "bytes": 3178
+        },
+        {
+          "path": "skills/azure/azure-cost-optimization-governor/metadata.json",
+          "sha256": "09f5d1386be5a43be7364e2d750e47b2a0ff866c30091e236bb7b345d8a4ea71",
+          "bytes": 1815
+        },
+        {
+          "path": "skills/azure/azure-cost-optimization-governor/references/mcp-and-evidence.md",
+          "sha256": "6db0b390ba3a533235ee5f406f2276e7790b78ed0daa210cc040c4f2b6cad876",
+          "bytes": 2393
+        },
+        {
+          "path": "skills/azure/azure-cost-optimization-governor/references/official-sources.md",
+          "sha256": "1787ec5a417061301f04eae050f0d991b57bafbcd45c3ea9e90920007314521e",
+          "bytes": 2011
+        },
+        {
+          "path": "skills/azure/azure-cost-optimization-governor/references/workflow-and-output.md",
+          "sha256": "7e94b4f96b8f13afd7f7706ddfa5bf08a4e4843de4ebc3b9d20c68a9ade36804",
+          "bytes": 3592
+        }
+      ]
+    },
+    {
+      "id": "azure-governance-policy-guardrails",
+      "path": "skills/azure/azure-governance-policy-guardrails",
+      "aggregate_sha256": "903d18de032b36db4a4259b022e113f718af5f467b586bce5d406583844a6b0c",
+      "files": [
+        {
+          "path": "skills/azure/azure-governance-policy-guardrails/SKILL.md",
+          "sha256": "6aed7cba3db8271e3912db8886db7d8c466b46d0f063d8907447535f16e5ad25",
+          "bytes": 2243
+        },
+        {
+          "path": "skills/azure/azure-governance-policy-guardrails/metadata.json",
+          "sha256": "6347cf29a5340eec1da0029fc68959dc7e00ababccecadf6c444cf38ee424c58",
+          "bytes": 1745
+        },
+        {
+          "path": "skills/azure/azure-governance-policy-guardrails/references/mcp-and-evidence.md",
+          "sha256": "fafd648f4a35a1810a5c21b761c063d8b8bef712a1fc032191fe5a77917f129a",
+          "bytes": 1531
+        },
+        {
+          "path": "skills/azure/azure-governance-policy-guardrails/references/official-sources.md",
+          "sha256": "4325a97e24fd74a687d1c1925df299c8432962c177ba3e8e75a5ebe1e0c3a160",
+          "bytes": 2314
+        },
+        {
+          "path": "skills/azure/azure-governance-policy-guardrails/references/workflow-and-output.md",
+          "sha256": "ba12083d584c3371bf707caf4b4440fb30b4a517fa8b97a7051a21c2ebfbb36e",
+          "bytes": 3954
+        }
+      ]
+    },
+    {
+      "id": "azure-identity-governance-review",
+      "path": "skills/azure/azure-identity-governance-review",
+      "aggregate_sha256": "30f2993e1e194c0a77e47c66e1d065d5984f24234638b374e64b9c3f531a3579",
+      "files": [
+        {
+          "path": "skills/azure/azure-identity-governance-review/SKILL.md",
+          "sha256": "1f3039610fe0113537f3422c5794c1e0805f754cad7952daf99b5bb6127c814a",
+          "bytes": 3188
+        },
+        {
+          "path": "skills/azure/azure-identity-governance-review/metadata.json",
+          "sha256": "5ef39ca4c9db286c0653817ede402d189f7d950aec63d493dea04618fb558ce9",
+          "bytes": 1952
+        },
+        {
+          "path": "skills/azure/azure-identity-governance-review/references/mcp-and-evidence.md",
+          "sha256": "d0a9f25839ff1c58cfa0fb45e6da7969167d1aa2c81c0a618af300638045ff2f",
+          "bytes": 2270
+        },
+        {
+          "path": "skills/azure/azure-identity-governance-review/references/official-sources.md",
+          "sha256": "ebb803795a48aefd96d22582bbce90a09bd1193a479225bdb91c7e56d8dd92c1",
+          "bytes": 1686
+        },
+        {
+          "path": "skills/azure/azure-identity-governance-review/references/workflow-and-output.md",
+          "sha256": "23637a0b6587c9694fe5927bfe6f60c9725bae2cc05a2a4b3b64e2c4e4daaa6f",
+          "bytes": 3698
+        }
+      ]
+    },
+    {
+      "id": "azure-key-vault-secret-lifecycle-auditor",
+      "path": "skills/azure/azure-key-vault-secret-lifecycle-auditor",
+      "aggregate_sha256": "2a0f3947b90fade768a02f2eb8b20fb8f01f11be55ffb50b69da6240ca556134",
+      "files": [
+        {
+          "path": "skills/azure/azure-key-vault-secret-lifecycle-auditor/SKILL.md",
+          "sha256": "11e1235f53943fd9f1c82cec78effe053d20e4d4b849e4e309ff97b6deb5580d",
+          "bytes": 3134
+        },
+        {
+          "path": "skills/azure/azure-key-vault-secret-lifecycle-auditor/metadata.json",
+          "sha256": "d86b139ec38bd831fd7e79be8c057eb2876ea1ec27d9769180166c3f4d170b37",
+          "bytes": 1705
+        },
+        {
+          "path": "skills/azure/azure-key-vault-secret-lifecycle-auditor/references/mcp-and-evidence.md",
+          "sha256": "052b3b8e9c3d4a3f18cd0c9f18ff7e2ec3c24ed357f865da3d3a634615394f75",
+          "bytes": 1779
+        },
+        {
+          "path": "skills/azure/azure-key-vault-secret-lifecycle-auditor/references/official-sources.md",
+          "sha256": "a90b434ddc66a63447d0112cf80a3a29eb8b6f1c20a5ccc70220d5eff85c866e",
+          "bytes": 1251
+        },
+        {
+          "path": "skills/azure/azure-key-vault-secret-lifecycle-auditor/references/workflow-and-output.md",
+          "sha256": "4f5e0767a485f69dcedc6933b395569ad241bba61ef1b9924814bce0d27d4ab4",
+          "bytes": 3684
+        }
+      ]
+    },
+    {
+      "id": "azure-landing-zone-architect",
+      "path": "skills/azure/azure-landing-zone-architect",
+      "aggregate_sha256": "c38a47932e9e352c4da8310129e23d5bcbbcbb8a1dbfa28b28508294997f7568",
+      "files": [
+        {
+          "path": "skills/azure/azure-landing-zone-architect/SKILL.md",
+          "sha256": "1e062b0ae0f4c87b69ed26768fb25cbffcf6e253b4af189c8d8db0a8fa3dc4be",
+          "bytes": 2777
+        },
+        {
+          "path": "skills/azure/azure-landing-zone-architect/metadata.json",
+          "sha256": "c001c5852896eb25c59a450c0b36b787f4f61f83edcb1166107ac4b8a196ae7f",
+          "bytes": 1467
+        },
+        {
+          "path": "skills/azure/azure-landing-zone-architect/references/mcp-and-evidence.md",
+          "sha256": "1f7397cfc545b9731c3f1cca0be1b4797bce12d303104026eb070bfa43ee28cc",
+          "bytes": 800
+        },
+        {
+          "path": "skills/azure/azure-landing-zone-architect/references/official-sources.md",
+          "sha256": "549efb9d68fb8771e9cddd1e591ff9a9f05093c67f30efade3798e8e9fb1058a",
+          "bytes": 2703
+        },
+        {
+          "path": "skills/azure/azure-landing-zone-architect/references/workflow-and-output.md",
+          "sha256": "b9cbf69a0fbdefa59983e3cae93b0579e795191090038cd7942947e4139e2c81",
+          "bytes": 4135
+        }
+      ]
+    },
+    {
+      "id": "azure-migrate-landing-zone-cutover",
+      "path": "skills/azure/azure-migrate-landing-zone-cutover",
+      "aggregate_sha256": "07c15294f777c30b86362b3b9f60f40b4632b512aaeac7f43ddce9f720bee24d",
+      "files": [
+        {
+          "path": "skills/azure/azure-migrate-landing-zone-cutover/SKILL.md",
+          "sha256": "db38963f358d9e863d10d49774c083480ffc93bc47436011617cdf8e3f651f24",
+          "bytes": 2931
+        },
+        {
+          "path": "skills/azure/azure-migrate-landing-zone-cutover/metadata.json",
+          "sha256": "8f53235c32e841cf7df376bc957234b4b16784a97efcf9a7086705231134731c",
+          "bytes": 1437
+        },
+        {
+          "path": "skills/azure/azure-migrate-landing-zone-cutover/references/mcp-and-evidence.md",
+          "sha256": "9526cfee42bc5fe3737dae2327110ea5e5af04b4ef34903a22d7c02ff9773379",
+          "bytes": 1773
+        },
+        {
+          "path": "skills/azure/azure-migrate-landing-zone-cutover/references/official-sources.md",
+          "sha256": "3b5fcea17765f4aafef8499f63e5bfe89d19faaca35830e6c6a39b9110111117",
+          "bytes": 842
+        },
+        {
+          "path": "skills/azure/azure-migrate-landing-zone-cutover/references/workflow-and-output.md",
+          "sha256": "a359eb77429a100f5be0047962acb63699451026786ac966f99ce823733cb189",
+          "bytes": 3856
+        }
+      ]
+    },
+    {
+      "id": "azure-network-topology-review",
+      "path": "skills/azure/azure-network-topology-review",
+      "aggregate_sha256": "c7b9c564ff59a974522466a32270ded520ff279e45e34607a3b0000381c3664e",
+      "files": [
+        {
+          "path": "skills/azure/azure-network-topology-review/SKILL.md",
+          "sha256": "486827570abe1b4807cce63c4964ac30f9583454de72ab4536998483b2eec0fe",
+          "bytes": 3147
+        },
+        {
+          "path": "skills/azure/azure-network-topology-review/metadata.json",
+          "sha256": "4f1a6f5aef532a723b819cbdbf1c63cc67902331727864181108982a20d957ab",
+          "bytes": 1215
+        },
+        {
+          "path": "skills/azure/azure-network-topology-review/references/mcp-and-evidence.md",
+          "sha256": "2a92f506c4e71da1e73a618b420e83f64ffe7b3c1e70a7c006e008e779ae2720",
+          "bytes": 1183
+        },
+        {
+          "path": "skills/azure/azure-network-topology-review/references/official-sources.md",
+          "sha256": "cc1de06d5d5378a77d3cad62c969556cf69a96d28d4407c5e0432514d90a72c3",
+          "bytes": 2278
+        },
+        {
+          "path": "skills/azure/azure-network-topology-review/references/workflow-and-output.md",
+          "sha256": "e401ec229b4a3801d4e9510a98c792d88e2c19811f56896701f02db0e9bd136f",
+          "bytes": 6222
+        }
+      ]
+    },
+    {
+      "id": "azure-observability-investigator",
+      "path": "skills/azure/azure-observability-investigator",
+      "aggregate_sha256": "1e27aa4fd61cb660f675d9e6b07e25b4348fba20288c5486f1ef5f483bd78705",
+      "files": [
+        {
+          "path": "skills/azure/azure-observability-investigator/SKILL.md",
+          "sha256": "9b38adf9528f9209167e94848baa10328940c7c779ac69839baf8d6064bdf693",
+          "bytes": 2827
+        },
+        {
+          "path": "skills/azure/azure-observability-investigator/metadata.json",
+          "sha256": "65bc4a88408ef8853ce98e7e531400285b12c4ef943252eb95059a84929ff7d8",
+          "bytes": 2143
+        },
+        {
+          "path": "skills/azure/azure-observability-investigator/references/mcp-and-evidence.md",
+          "sha256": "77851825b94b2b7ff7bf59c7dd6ae6f11990cb976520b4f0e89d07422c9e38bc",
+          "bytes": 2170
+        },
+        {
+          "path": "skills/azure/azure-observability-investigator/references/official-sources.md",
+          "sha256": "ebf7d75ce4a250caa46becfe0884f7f643e8ac010f86a62b33b9be7b5c96dc52",
+          "bytes": 2354
+        },
+        {
+          "path": "skills/azure/azure-observability-investigator/references/workflow-and-output.md",
+          "sha256": "b25b6f76497c8b3b3793f28d8db632f70342416bfa69701c700b05db3d2522f4",
+          "bytes": 5718
+        }
+      ]
+    },
+    {
+      "id": "azure-platform-automation-devops",
+      "path": "skills/azure/azure-platform-automation-devops",
+      "aggregate_sha256": "4710f64edfaf15b85b44b31acea8bba09d635e1ec6d97110687e16e9292f62f5",
+      "files": [
+        {
+          "path": "skills/azure/azure-platform-automation-devops/SKILL.md",
+          "sha256": "8b94a2521f19077b5b13f10d09e8e038d7054bac467dbc30c94be7c660110a77",
+          "bytes": 3526
+        },
+        {
+          "path": "skills/azure/azure-platform-automation-devops/metadata.json",
+          "sha256": "0f3ed1dbe53d2f7b88d36a9abe1b509f3c0a4f2f78a4f2b64522c610c8d2dc97",
+          "bytes": 1896
+        },
+        {
+          "path": "skills/azure/azure-platform-automation-devops/references/mcp-and-evidence.md",
+          "sha256": "45d71c40d9447015cb7d65b6085da6e63f0df356cd55e8b0897fffcdb8de7f71",
+          "bytes": 2404
+        },
+        {
+          "path": "skills/azure/azure-platform-automation-devops/references/official-sources.md",
+          "sha256": "84d2b7b7719223e065e4a614a6f19121515b5acba2e16a72e5dae75d32d186af",
+          "bytes": 2261
+        },
+        {
+          "path": "skills/azure/azure-platform-automation-devops/references/workflow-and-output.md",
+          "sha256": "54d8a3105a2c4de774aebbbd61bbae8f7d0eb2ece369e85b35b651ffd3e4da61",
+          "bytes": 5302
+        }
+      ]
+    },
+    {
+      "id": "azure-private-endpoint-adoption-planner",
+      "path": "skills/azure/azure-private-endpoint-adoption-planner",
+      "aggregate_sha256": "3a74700868c427a93292601eab780dacc0892dea07dc179d0c60378f611b4102",
+      "files": [
+        {
+          "path": "skills/azure/azure-private-endpoint-adoption-planner/SKILL.md",
+          "sha256": "2fc5341ee53bbe86eac3a4457d03a854a28ac899551e3a6630c4a9b6621dff2d",
+          "bytes": 3379
+        },
+        {
+          "path": "skills/azure/azure-private-endpoint-adoption-planner/metadata.json",
+          "sha256": "26831446e780f27bfae48cffaf381290827b9d9bf960029e37f9ab0d77c9c4d2",
+          "bytes": 1527
+        },
+        {
+          "path": "skills/azure/azure-private-endpoint-adoption-planner/references/mcp-and-evidence.md",
+          "sha256": "a3251c7492e3443697385a3930465b770ed0380ef5f5a897e881a5aa54a83bb3",
+          "bytes": 1784
+        },
+        {
+          "path": "skills/azure/azure-private-endpoint-adoption-planner/references/official-sources.md",
+          "sha256": "25fe185810a196272674d1fc063fa9a12c0641f87b44c2237443bb73fb37fb42",
+          "bytes": 1283
+        },
+        {
+          "path": "skills/azure/azure-private-endpoint-adoption-planner/references/workflow-and-output.md",
+          "sha256": "10eaeb2a61b8cf55d2c3853f79d887b9722e5c4e5a0675678cffec0031965b9c",
+          "bytes": 4323
+        }
+      ]
+    },
+    {
       "id": "azure-rbac-review",
       "path": "skills/azure/azure-rbac-review",
-      "aggregate_sha256": "81ac2d2ba34c4fc86b7b8cd2cb1e8dc961878ff75cf097523e799ed3ec4ed1ce",
+      "aggregate_sha256": "354bdbc9433f0423b1fa172f90b6535ca3d95b9ba13f4a8ccbafbd92651bde19",
       "files": [
         {
           "path": "skills/azure/azure-rbac-review/SKILL.md",
-          "sha256": "1cfe0666a67eab8baf89c371517eba77cd788190ee5c7b6c3ccc56e6599b388f",
-          "bytes": 1429
+          "sha256": "ee66c2c93571aae454539a8a5c1140258354d630423a5bff9f8b266c9dee3c1f",
+          "bytes": 1646
         },
         {
           "path": "skills/azure/azure-rbac-review/metadata.json",
           "sha256": "4e55895a62142b0356d14f7af55c265fff3d927dde213cd93d64d1001df8cbf9",
           "bytes": 827
+        },
+        {
+          "path": "skills/azure/azure-rbac-review/references/mcp-and-evidence.md",
+          "sha256": "089e224125365fe8a88a3701cff3fbc02d17ac82f69e96a193e8c278a2dcd274",
+          "bytes": 663
+        },
+        {
+          "path": "skills/azure/azure-rbac-review/references/official-sources.md",
+          "sha256": "5410d22de41cff322962aae6ba73cf90a8698ee461e930ce84d0f0826d6681f0",
+          "bytes": 2079
+        },
+        {
+          "path": "skills/azure/azure-rbac-review/references/workflow-and-output.md",
+          "sha256": "629eb8d39bc765d043a91435498ac674656ccc3eadf96b2487bc121b2d205a2e",
+          "bytes": 1298
+        }
+      ]
+    },
+    {
+      "id": "azure-resilience-bcdr-review",
+      "path": "skills/azure/azure-resilience-bcdr-review",
+      "aggregate_sha256": "439c1862de68fa997eca076cd870f2205bda1e645924fd7c2ffa09e2bf8c4451",
+      "files": [
+        {
+          "path": "skills/azure/azure-resilience-bcdr-review/SKILL.md",
+          "sha256": "d0d090807a75f0371d8806fe60122e152d53d94e4d94aafd928147d7bfcb632b",
+          "bytes": 3055
+        },
+        {
+          "path": "skills/azure/azure-resilience-bcdr-review/metadata.json",
+          "sha256": "354b5ff0b04c535b8a1b24e8258dd37221a425036a067a5445e6a390bb684717",
+          "bytes": 1575
+        },
+        {
+          "path": "skills/azure/azure-resilience-bcdr-review/references/mcp-and-evidence.md",
+          "sha256": "4a6069cb187a10298fe61685cd479ade6ef829b9fab38def9b44127c1303335c",
+          "bytes": 1705
+        },
+        {
+          "path": "skills/azure/azure-resilience-bcdr-review/references/official-sources.md",
+          "sha256": "eacf2033968e3837e4810d92f66f6587d4c3de32bf33bb7aa394a9559db244fe",
+          "bytes": 992
+        },
+        {
+          "path": "skills/azure/azure-resilience-bcdr-review/references/workflow-and-output.md",
+          "sha256": "9aba169c9b82ba4ecb1ff1d7b590e07c950aa94a16abb08a757aa20107ca4691",
+          "bytes": 3628
+        }
+      ]
+    },
+    {
+      "id": "azure-resource-health-incident-triage",
+      "path": "skills/azure/azure-resource-health-incident-triage",
+      "aggregate_sha256": "2eec0e26e40efdfbaab76a50f3e448eee28174e4fb75780b0738852f6c492688",
+      "files": [
+        {
+          "path": "skills/azure/azure-resource-health-incident-triage/SKILL.md",
+          "sha256": "b8467672c0d8e880edafa445ad806d6648b171f9c4aa2b138f67bb066e5cb49a",
+          "bytes": 3286
+        },
+        {
+          "path": "skills/azure/azure-resource-health-incident-triage/metadata.json",
+          "sha256": "c984b45e1e19c4ca2d248a5d627e2cba83f2ceea385664eb5f360d92f458d86c",
+          "bytes": 1698
+        },
+        {
+          "path": "skills/azure/azure-resource-health-incident-triage/references/mcp-and-evidence.md",
+          "sha256": "d2b3b14f427091c20d99e0f43ad1e67490378dd15569ce524e049d11028b3bb4",
+          "bytes": 2019
+        },
+        {
+          "path": "skills/azure/azure-resource-health-incident-triage/references/official-sources.md",
+          "sha256": "cfbc28d7f5d79c9709004473af3394d4663ae43df827083fd770cd4b53f5e4d8",
+          "bytes": 1268
+        },
+        {
+          "path": "skills/azure/azure-resource-health-incident-triage/references/workflow-and-output.md",
+          "sha256": "7bb775807d57efb2c2479ab9086bb261b2fac0b9b5f5e8a559bf400e688ca0ab",
+          "bytes": 3831
+        }
+      ]
+    },
+    {
+      "id": "azure-role-selector",
+      "path": "skills/azure/azure-role-selector",
+      "aggregate_sha256": "cc5e93e19d16654164a795b99bc53eec068547d3a244b5f482930f6971e665a6",
+      "files": [
+        {
+          "path": "skills/azure/azure-role-selector/SKILL.md",
+          "sha256": "71d4f59931f3644c9e90c49f59d773f34e13db1d1ff704c715d1b77383131d51",
+          "bytes": 2214
+        },
+        {
+          "path": "skills/azure/azure-role-selector/metadata.json",
+          "sha256": "ceef512e7b8e2bbdbd0a7596c2e8bc5d24d7ef93c44c2af97ada7bba13ea065b",
+          "bytes": 1219
+        },
+        {
+          "path": "skills/azure/azure-role-selector/references/mcp-and-evidence.md",
+          "sha256": "1e6c7a73d6ece4be54f03c3725e04d5a5bb5af5c3abe4d5880ca791c7851bf5e",
+          "bytes": 671
+        },
+        {
+          "path": "skills/azure/azure-role-selector/references/official-sources.md",
+          "sha256": "2d76a45fadb6f59d87b56b8d8b051d3ad784cf397cdcc84632d1f7084510ec4b",
+          "bytes": 1985
+        },
+        {
+          "path": "skills/azure/azure-role-selector/references/workflow-and-output.md",
+          "sha256": "0034fa1cf62e98c2abf3e692ba1656900462312224aade70d0abb745c78399c6",
+          "bytes": 4286
+        }
+      ]
+    },
+    {
+      "id": "azure-security-posture-hardening",
+      "path": "skills/azure/azure-security-posture-hardening",
+      "aggregate_sha256": "989cbd783295e3fe61899b56965fba33438bde7bb73ba7d79f56b40559b84ca3",
+      "files": [
+        {
+          "path": "skills/azure/azure-security-posture-hardening/SKILL.md",
+          "sha256": "7aa5e0670aac2be804a995446416a8cf53ede05bdf86d7eb6fa45c1c5d78d4cd",
+          "bytes": 2577
+        },
+        {
+          "path": "skills/azure/azure-security-posture-hardening/metadata.json",
+          "sha256": "66cb65e803b77eb5be52a4806b41ae677c7ddf0f60f641112e933d69368f8f3c",
+          "bytes": 1922
+        },
+        {
+          "path": "skills/azure/azure-security-posture-hardening/references/mcp-and-evidence.md",
+          "sha256": "b8eeb4da72eed46606b7601324c820dda96d0559059f99464ee11ba21f39d441",
+          "bytes": 850
+        },
+        {
+          "path": "skills/azure/azure-security-posture-hardening/references/official-sources.md",
+          "sha256": "440cc24c857c0a062155b9c02992d59dd722e5769d420aa1fdda394c1ea0b7e8",
+          "bytes": 1455
+        },
+        {
+          "path": "skills/azure/azure-security-posture-hardening/references/workflow-and-output.md",
+          "sha256": "30600677e655d5ed8d3b40254c527aa88d3cc8a39636397cfe2fb285864482fc",
+          "bytes": 4921
+        }
+      ]
+    },
+    {
+      "id": "azure-subscription-resource-organization",
+      "path": "skills/azure/azure-subscription-resource-organization",
+      "aggregate_sha256": "172ba2fac8439b61ab6a3605320a3adfc40130aec18555e24668e0f6e41e35e3",
+      "files": [
+        {
+          "path": "skills/azure/azure-subscription-resource-organization/SKILL.md",
+          "sha256": "71ba6f22ba05dbd37c5cbdab33f3f6d3589ae88015b58f65b8062679484fb3bf",
+          "bytes": 3285
+        },
+        {
+          "path": "skills/azure/azure-subscription-resource-organization/metadata.json",
+          "sha256": "876e9451ce0be2ac9fc39ecb787ea056b236222d33e5a3a196950d3f0773994d",
+          "bytes": 1675
+        },
+        {
+          "path": "skills/azure/azure-subscription-resource-organization/references/mcp-and-evidence.md",
+          "sha256": "44bb2027f6c607b79f2866f52f220dd2040e409f769dbe5138f57631c0aafdbb",
+          "bytes": 1927
+        },
+        {
+          "path": "skills/azure/azure-subscription-resource-organization/references/official-sources.md",
+          "sha256": "479b3f1ec2aae6c615b0fcd83858435593af69d68ddf0248af88cf8e98b7f5c3",
+          "bytes": 1815
+        },
+        {
+          "path": "skills/azure/azure-subscription-resource-organization/references/workflow-and-output.md",
+          "sha256": "a91c42b6509651dd6db09bbc55ada0507dcc5a6de1a98ba83cb9e633effdc756",
+          "bytes": 3869
         }
       ]
     },

--- a/catalog/skills.json
+++ b/catalog/skills.json
@@ -24,6 +24,442 @@
     "author": "github: Raishin"
   },
   {
+    "id": "azure-ai-foundry-ops-governor",
+    "name": "Azure AI Foundry Ops Governor",
+    "type": "skill",
+    "provider": "azure",
+    "harnesses": [
+      "codex",
+      "claude-code",
+      "cursor",
+      "gemini",
+      "kiro",
+      "other"
+    ],
+    "summary": "Govern Microsoft Foundry and Azure AI Foundry operations across resource-versus-project boundaries, RBAC, quotas, network isolation, logging, and safe MCP-backed execution.",
+    "source_type": "original",
+    "official_docs": [
+      "https://learn.microsoft.com/en-us/azure/foundry/concepts/architecture",
+      "https://learn.microsoft.com/en-us/azure/foundry/concepts/rbac-foundry",
+      "https://learn.microsoft.com/en-us/azure/foundry/concepts/planning",
+      "https://learn.microsoft.com/en-us/azure/foundry/mcp/security-best-practices?view=foundry",
+      "https://learn.microsoft.com/en-us/azure/foundry/how-to/configure-private-link",
+      "https://learn.microsoft.com/en-us/azure/foundry/how-to/managed-virtual-network",
+      "https://learn.microsoft.com/en-us/azure/foundry/how-to/quota",
+      "https://learn.microsoft.com/en-us/azure/foundry/foundry-models/quotas-limits",
+      "https://learn.microsoft.com/en-us/azure/foundry/foundry-models/how-to/monitor-models",
+      "https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/"
+    ],
+    "security_notes": "Keep Foundry resource governance separate from project developer isolation, prefer Entra ID over key-based auth, verify quota and diagnostics before rollout, and treat MCP mutations as higher risk than read-only discovery, especially because hosted Foundry MCP security guidance documents preview and public-endpoint limitations.",
+    "last_verified": "2026-04-27",
+    "path": "skills/azure/azure-ai-foundry-ops-governor",
+    "author": "github: Raishin"
+  },
+  {
+    "id": "azure-aks-platform-operator",
+    "name": "Azure AKS Platform Operator",
+    "type": "skill",
+    "provider": "azure",
+    "harnesses": [
+      "codex",
+      "claude-code",
+      "cursor",
+      "gemini",
+      "kiro",
+      "other"
+    ],
+    "summary": "Review AKS platform design and operations with a production operator lens across node pools, identity, network policy, scaling, upgrades, rollback safety, and observability readiness.",
+    "source_type": "original",
+    "official_docs": [
+      "https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/",
+      "https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/azure-kubernetes",
+      "https://learn.microsoft.com/en-us/azure/architecture/reference-architectures/containers/aks/baseline-aks",
+      "https://learn.microsoft.com/en-us/azure/aks/upgrade-options",
+      "https://learn.microsoft.com/en-us/azure/aks/upgrade-conceptual",
+      "https://learn.microsoft.com/en-us/azure/aks/workload-identity-overview",
+      "https://learn.microsoft.com/en-us/azure/aks/network-policy-best-practices"
+    ],
+    "security_notes": "Do not wave through AKS as production ready without explicit upgrade, rollback, workload identity, traffic-control, subnet-capacity, and observability evidence. Treat flat pod networking, static secrets, and untested drain behavior as high-risk.",
+    "last_verified": "2026-04-27",
+    "path": "skills/azure/azure-aks-platform-operator",
+    "author": "github: Raishin"
+  },
+  {
+    "id": "azure-app-service-production-readiness",
+    "name": "Azure App Service Production Readiness",
+    "type": "skill",
+    "provider": "azure",
+    "harnesses": [
+      "codex",
+      "claude-code",
+      "cursor",
+      "gemini",
+      "kiro",
+      "other"
+    ],
+    "summary": "Review Azure App Service and Web Apps for production readiness across plan fit, slots, networking, private ingress, identities, secrets, scaling, diagnostics, resilience, backup, rollback, and operator ownership with explicit evidence-versus-inference handling.",
+    "source_type": "original",
+    "official_docs": [
+      "https://learn.microsoft.com/en-us/azure/well-architected/service-guides/app-service-web-apps",
+      "https://learn.microsoft.com/en-us/azure/app-service/deploy-best-practices",
+      "https://learn.microsoft.com/en-us/azure/app-service/deploy-staging-slots",
+      "https://learn.microsoft.com/en-us/azure/app-service/app-service-best-practices",
+      "https://learn.microsoft.com/en-us/azure/app-service/manage-scale-up",
+      "https://learn.microsoft.com/en-us/azure/app-service/configure-vnet-integration-enable",
+      "https://learn.microsoft.com/en-us/azure/app-service/configure-vnet-integration-routing",
+      "https://learn.microsoft.com/en-us/azure/app-service/overview-private-endpoint",
+      "https://learn.microsoft.com/en-us/azure/app-service/overview-access-restrictions",
+      "https://learn.microsoft.com/en-us/azure/app-service/app-service-key-vault-references",
+      "https://learn.microsoft.com/en-us/azure/app-service/monitor-instances-health-check",
+      "https://learn.microsoft.com/en-us/azure/app-service/manage-backup",
+      "https://learn.microsoft.com/en-us/azure/app-service/configure-zone-redundancy",
+      "https://learn.microsoft.com/en-us/azure/reliability/reliability-app-service",
+      "https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/",
+      "https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/azure-app-service"
+    ],
+    "security_notes": "Do not confuse plan SKU with readiness, public access restrictions with true private ingress, or backup configuration with recovery readiness. Prefer managed identity and Key Vault references over embedded secrets, treat app settings as sensitive, and do not invent unsupported Azure MCP namespaces or operations.",
+    "last_verified": "2026-04-27",
+    "path": "skills/azure/azure-app-service-production-readiness",
+    "author": "github: Raishin"
+  },
+  {
+    "id": "azure-cost-estimation-review",
+    "name": "Azure Cost Estimation Review",
+    "type": "skill",
+    "provider": "azure",
+    "harnesses": [
+      "codex",
+      "claude-code",
+      "cursor",
+      "gemini",
+      "kiro",
+      "other"
+    ],
+    "summary": "Review Azure cost estimates for pricing-calculator assumptions, SKU and region realism, production versus nonproduction sizing, omission risk, and explicit uncertainty labeling.",
+    "source_type": "original",
+    "official_docs": [
+      "https://learn.microsoft.com/en-us/azure/cost-management-billing/understand/plan-manage-costs",
+      "https://learn.microsoft.com/en-us/azure/cost-management-billing/costs/pricing-calculator",
+      "https://learn.microsoft.com/en-us/azure/cost-management-billing/",
+      "https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/design-area/governance",
+      "https://learn.microsoft.com/en-us/azure/cost-management-billing/savings-plan/manage-savings-plan",
+      "https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/",
+      "https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/azure-pricing"
+    ],
+    "security_notes": "Do not present calculator output as invoice truth, do not hide missing sizing assumptions, and do not imply unsupported Azure MCP pricing or billing capabilities. Treat negotiated pricing, discount posture, and future utilization as explicit uncertainty unless verified.",
+    "last_verified": "2026-04-27",
+    "path": "skills/azure/azure-cost-estimation-review",
+    "author": "github: Raishin"
+  },
+  {
+    "id": "azure-cost-optimization-governor",
+    "name": "Azure Cost Optimization Governor",
+    "type": "skill",
+    "provider": "azure",
+    "harnesses": [
+      "codex",
+      "claude-code",
+      "cursor",
+      "gemini",
+      "kiro",
+      "other"
+    ],
+    "summary": "Review Azure FinOps and spend-governance posture across budgets, alerts, cost analysis visibility, tagging, exports, and reservation or savings-plan awareness with explicit ownership and evidence handling.",
+    "source_type": "original",
+    "official_docs": [
+      "https://learn.microsoft.com/en-us/azure/cost-management-billing/understand/plan-manage-costs",
+      "https://learn.microsoft.com/en-us/azure/cost-management-billing/costs/tutorial-acm-create-budgets",
+      "https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/design-area/governance",
+      "https://learn.microsoft.com/en-us/azure/cost-management-billing/costs/reporting-get-started",
+      "https://learn.microsoft.com/en-us/azure/cost-management-billing/costs/tutorial-improved-exports",
+      "https://learn.microsoft.com/en-us/azure/advisor/advisor-reference-cost-recommendations",
+      "https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/",
+      "https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/azure-pricing",
+      "https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/azure-advisor"
+    ],
+    "security_notes": "Do not promise savings without utilization evidence, treat budgets as alerts rather than enforcement, keep billing and export data sanitized, and require named ownership for alerts, tags, exports, and optimization follow-up before calling the FinOps posture credible.",
+    "last_verified": "2026-04-27",
+    "path": "skills/azure/azure-cost-optimization-governor",
+    "author": "github: Raishin"
+  },
+  {
+    "id": "azure-governance-policy-guardrails",
+    "name": "Azure Governance Policy Guardrails",
+    "type": "skill",
+    "provider": "azure",
+    "harnesses": [
+      "codex",
+      "claude-code",
+      "cursor",
+      "gemini",
+      "kiro",
+      "other"
+    ],
+    "summary": "Design and review Azure Policy guardrails, initiatives, assignment scope, exclusions, remediation risk, and staged governance rollout patterns.",
+    "source_type": "original",
+    "official_docs": [
+      "https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/design-area/governance",
+      "https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/tailoring-alz",
+      "https://learn.microsoft.com/en-us/azure/governance/policy/overview",
+      "https://learn.microsoft.com/en-us/azure/governance/policy/concepts/initiative-definition-structure",
+      "https://learn.microsoft.com/en-us/azure/governance/policy/assign-policy-portal",
+      "https://learn.microsoft.com/en-us/azure/governance/policy/how-to/remediate-resources",
+      "https://learn.microsoft.com/en-us/azure/governance/policy/concepts/exemption-structure",
+      "https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/design-area/migrate-azure-landing-zone-policies",
+      "https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/",
+      "https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/azure-policy"
+    ],
+    "security_notes": "Do not recommend broad-scope deny or remediation-first rollout without blast-radius review, inheritance analysis, exception handling, and rollback notes.",
+    "last_verified": "2026-04-27",
+    "path": "skills/azure/azure-governance-policy-guardrails",
+    "author": "github: Raishin"
+  },
+  {
+    "id": "azure-identity-governance-review",
+    "name": "Azure Identity Governance Review",
+    "type": "skill",
+    "provider": "azure",
+    "harnesses": [
+      "codex",
+      "claude-code",
+      "cursor",
+      "gemini",
+      "kiro",
+      "other"
+    ],
+    "summary": "Review Microsoft Entra identity governance posture for Azure operators, focusing on PIM, access reviews, entitlement management, standing access, and ownership gaps.",
+    "source_type": "original",
+    "official_docs": [
+      "https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/design-area/identity-access",
+      "https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/design-area/identity-access-landing-zones",
+      "https://learn.microsoft.com/en-us/azure/active-directory/roles/best-practices",
+      "https://learn.microsoft.com/en-us/entra/id-governance/privileged-identity-management/",
+      "https://learn.microsoft.com/en-us/entra/id-governance/privileged-identity-management/pim-resource-roles-assign-roles",
+      "https://learn.microsoft.com/en-us/entra/id-governance/access-reviews-overview",
+      "https://learn.microsoft.com/en-us/entra/id-governance/manage-access-review",
+      "https://learn.microsoft.com/en-us/entra/id-governance/privileged-identity-management/pim-perform-roles-and-resource-roles-review",
+      "https://learn.microsoft.com/en-us/entra/id-governance/entitlement-management-overview",
+      "https://learn.microsoft.com/en-us/entra/id-governance/entitlement-management-access-reviews-create",
+      "https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/"
+    ],
+    "security_notes": "Challenge standing privileged access by default. Do not treat PIM, access reviews, or entitlement management as sufficient unless scope, ownership, cadence, and removal behavior are explicit.",
+    "last_verified": "2026-04-27",
+    "path": "skills/azure/azure-identity-governance-review",
+    "author": "github: Raishin"
+  },
+  {
+    "id": "azure-key-vault-secret-lifecycle-auditor",
+    "name": "Azure Key Vault Secret Lifecycle Auditor",
+    "type": "skill",
+    "provider": "azure",
+    "harnesses": [
+      "codex",
+      "claude-code",
+      "cursor",
+      "gemini",
+      "kiro",
+      "other"
+    ],
+    "summary": "Audit Azure Key Vault secret lifecycle posture across RBAC, soft delete, purge protection, expiration, rotation, metadata hygiene, eventing, and recovery readiness without exposing secret values.",
+    "source_type": "original",
+    "official_docs": [
+      "https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/",
+      "https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/azure-key-vault",
+      "https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/services/azure-mcp-server-for-key-vault",
+      "https://learn.microsoft.com/en-us/azure/key-vault/secrets/secure-secrets",
+      "https://learn.microsoft.com/en-us/azure/key-vault/general/autorotation",
+      "https://learn.microsoft.com/en-us/azure/key-vault/general/rbac-guide",
+      "https://learn.microsoft.com/en-us/azure/key-vault/general/soft-delete-overview",
+      "https://learn.microsoft.com/en-us/azure/key-vault/general/key-vault-recovery",
+      "https://learn.microsoft.com/en-us/azure/key-vault/policy-reference"
+    ],
+    "security_notes": "Avoid retrieving secret values unless absolutely necessary. Treat purge authority, missing soft delete, missing purge protection, and unproven rotation or recovery paths as high-risk. Prefer RBAC least privilege and metadata-based audits over content access.",
+    "last_verified": "2026-04-27",
+    "path": "skills/azure/azure-key-vault-secret-lifecycle-auditor",
+    "author": "github: Raishin"
+  },
+  {
+    "id": "azure-landing-zone-architect",
+    "name": "Azure Landing Zone Architect",
+    "type": "skill",
+    "provider": "azure",
+    "harnesses": [
+      "codex",
+      "claude-code",
+      "cursor",
+      "gemini",
+      "kiro",
+      "other"
+    ],
+    "summary": "Design or review Azure landing-zone architecture across management groups, subscriptions, governance, security, networking, and operations dependencies.",
+    "source_type": "original",
+    "official_docs": [
+      "https://learn.microsoft.com/azure/cloud-adoption-framework/ready/landing-zone/design-areas",
+      "https://learn.microsoft.com/azure/cloud-adoption-framework/ready/landing-zone/design-area/identity-access",
+      "https://learn.microsoft.com/azure/cloud-adoption-framework/ready/landing-zone/design-area/governance",
+      "https://learn.microsoft.com/azure/cloud-adoption-framework/ready/landing-zone/design-area/security",
+      "https://learn.microsoft.com/azure/cloud-adoption-framework/ready/landing-zone/implementation-options",
+      "https://learn.microsoft.com/azure/architecture/networking/architecture/hub-spoke",
+      "https://learn.microsoft.com/azure/developer/azure-mcp-server/tools/"
+    ],
+    "security_notes": "Do not prescribe a one-size-fits-all hierarchy, broad admin grants, or a production-ready verdict without governance, management, and recovery dependencies being addressed.",
+    "last_verified": "2026-04-27",
+    "path": "skills/azure/azure-landing-zone-architect",
+    "author": "github: Raishin"
+  },
+  {
+    "id": "azure-migrate-landing-zone-cutover",
+    "name": "Azure Migrate Landing Zone Cutover",
+    "type": "skill",
+    "provider": "azure",
+    "harnesses": [
+      "codex",
+      "claude-code",
+      "cursor",
+      "gemini",
+      "kiro",
+      "other"
+    ],
+    "summary": "Stress-test Azure migration cutovers across assessment quality, landing-zone readiness, dependency sequencing, permissions, rollback, and post-cutover operating ownership.",
+    "source_type": "original",
+    "official_docs": [
+      "https://learn.microsoft.com/en-us/azure/migrate/concepts-overview?view=migrate",
+      "https://learn.microsoft.com/en-us/azure/migrate/assessment-prerequisites?view=migrate",
+      "https://learn.microsoft.com/en-us/azure/migrate/review-application-assessment?view=migrate",
+      "https://learn.microsoft.com/en-us/azure/migrate/platform-landing-zone?view=migrate",
+      "https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/ready-azure-landing-zone",
+      "https://learn.microsoft.com/en-us/azure/migrate/whats-new?view=migrate"
+    ],
+    "security_notes": "Do not equate Azure readiness with cutover readiness. Treat stale assessments, weak dependency mapping, broad migration permissions, missing rollback checkpoints, and incomplete landing-zone connectivity or monitoring as high-risk blockers.",
+    "last_verified": "2026-04-27",
+    "path": "skills/azure/azure-migrate-landing-zone-cutover",
+    "author": "github: Raishin"
+  },
+  {
+    "id": "azure-network-topology-review",
+    "name": "Azure Network Topology Review",
+    "type": "skill",
+    "provider": "azure",
+    "harnesses": [
+      "codex",
+      "claude-code",
+      "cursor",
+      "gemini",
+      "kiro",
+      "other"
+    ],
+    "summary": "Review Azure hub-spoke and related network topologies for routing, DNS, shared-services boundaries, security implications, and platform-versus-workload control ownership.",
+    "source_type": "original",
+    "official_docs": [
+      "https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/design-areas",
+      "https://learn.microsoft.com/en-us/azure/architecture/networking/architecture/hub-spoke",
+      "https://learn.microsoft.com/en-us/azure/architecture/networking/guide/private-link-hub-spoke-network",
+      "https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/"
+    ],
+    "security_notes": "Do not recommend flat or over-centralized network patterns by default. Always address routing, DNS, shared-service blast radius, and platform-versus-workload control boundaries before calling a topology safe.",
+    "last_verified": "2026-04-27",
+    "path": "skills/azure/azure-network-topology-review",
+    "author": "github: Raishin"
+  },
+  {
+    "id": "azure-observability-investigator",
+    "name": "Azure Observability Investigator",
+    "type": "skill",
+    "provider": "azure",
+    "harnesses": [
+      "codex",
+      "claude-code",
+      "cursor",
+      "gemini",
+      "kiro",
+      "other"
+    ],
+    "summary": "Investigate Azure Monitor, Log Analytics, Application Insights, alerting, KQL triage, telemetry gaps, and observability workflows with explicit evidence-versus-inference handling.",
+    "source_type": "original",
+    "official_docs": [
+      "https://learn.microsoft.com/en-us/azure/azure-monitor/overview",
+      "https://learn.microsoft.com/en-us/azure/azure-monitor/best-practices-analysis",
+      "https://learn.microsoft.com/en-us/azure/azure-monitor/alerts/alerts-overview",
+      "https://learn.microsoft.com/en-us/azure/azure-monitor/alerts/action-groups",
+      "https://learn.microsoft.com/en-us/azure/azure-monitor/alerts/alerts-processing-rules",
+      "https://learn.microsoft.com/en-us/azure/azure-monitor/logs/log-analytics-workspace-overview",
+      "https://learn.microsoft.com/en-us/azure/azure-monitor/logs/workspace-design",
+      "https://learn.microsoft.com/en-us/azure/azure-monitor/logs/get-started-queries",
+      "https://learn.microsoft.com/en-us/azure/azure-monitor/app/app-insights-overview",
+      "https://learn.microsoft.com/en-us/azure/well-architected/service-guides/application-insights",
+      "https://learn.microsoft.com/en-us/azure/azure-monitor/visualize/workbooks-overview",
+      "https://learn.microsoft.com/en-us/azure/azure-monitor/visualize/visualize-grafana-overview",
+      "https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/",
+      "https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/monitor",
+      "https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/azure-monitor"
+    ],
+    "security_notes": "Do not over-attribute symptoms as root cause, ignore missing telemetry, or recommend broad alerting changes without signal-quality review, routing checks, and bounded verification steps.",
+    "last_verified": "2026-04-27",
+    "path": "skills/azure/azure-observability-investigator",
+    "author": "github: Raishin"
+  },
+  {
+    "id": "azure-platform-automation-devops",
+    "name": "Azure Platform Automation DevOps",
+    "type": "skill",
+    "provider": "azure",
+    "harnesses": [
+      "codex",
+      "claude-code",
+      "cursor",
+      "gemini",
+      "kiro",
+      "other"
+    ],
+    "summary": "Design and review Azure platform automation delivery across landing-zone IaC choices, bootstrap-versus-run separation, infra-versus-app pipelines, secret handling, validation gates, and safe rollout patterns.",
+    "source_type": "original",
+    "official_docs": [
+      "https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/",
+      "https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/implementation-options",
+      "https://learn.microsoft.com/en-us/azure/architecture/landing-zones/bicep/landing-zone-bicep",
+      "https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/terraform-landing-zone",
+      "https://learn.microsoft.com/en-us/azure/app-service/deploy-best-practices",
+      "https://learn.microsoft.com/en-us/azure/app-service/deploy-staging-slots?view=azure-devops-2020",
+      "https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/",
+      "https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/azure-deploy",
+      "https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/bicep-mcp-server",
+      "https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/"
+    ],
+    "security_notes": "Keep bootstrap and steady-state delivery separate, do not mix platform and application pipelines without control boundaries, never store secrets in repo or pipeline definitions, and require preview, validation, approval, and rollback paths before production-impacting Azure changes.",
+    "last_verified": "2026-04-27",
+    "path": "skills/azure/azure-platform-automation-devops",
+    "author": "github: Raishin"
+  },
+  {
+    "id": "azure-private-endpoint-adoption-planner",
+    "name": "Azure Private Endpoint Adoption Planner",
+    "type": "skill",
+    "provider": "azure",
+    "harnesses": [
+      "codex",
+      "claude-code",
+      "cursor",
+      "gemini",
+      "kiro",
+      "other"
+    ],
+    "summary": "Plan Azure Private Link and private endpoint adoption with explicit hub-versus-spoke placement, private DNS zone linkage, route implications, and centralized-versus-local trade-offs.",
+    "source_type": "original",
+    "official_docs": [
+      "https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/design-areas",
+      "https://learn.microsoft.com/en-us/azure/architecture/guide/networking/private-link-hub-spoke-network",
+      "https://learn.microsoft.com/en-us/azure/private-link/private-endpoint-dns-integration",
+      "https://learn.microsoft.com/en-us/azure/private-link/private-endpoint-dns",
+      "https://learn.microsoft.com/en-us/azure/dns/private-dns-privatednszone",
+      "https://learn.microsoft.com/en-us/azure/azure-monitor/logs/private-link-design",
+      "https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/"
+    ],
+    "security_notes": "Do not recommend private endpoint placement without naming consumer networks, DNS-zone ownership, VNet links, route implications, and rollback checks. Challenge both over-centralized hub designs and uncontrolled per-spoke duplication.",
+    "last_verified": "2026-04-27",
+    "path": "skills/azure/azure-private-endpoint-adoption-planner",
+    "author": "github: Raishin"
+  },
+  {
     "id": "azure-rbac-review",
     "name": "Azure RBAC Review",
     "type": "skill",
@@ -45,6 +481,157 @@
     "security_notes": "Do not recommend Owner or User Access Administrator unless justified. Prefer narrow scopes and built-in roles before custom broad grants.",
     "last_verified": "2026-04-27",
     "path": "skills/azure/azure-rbac-review",
+    "author": "github: Raishin"
+  },
+  {
+    "id": "azure-resilience-bcdr-review",
+    "name": "Azure Resilience BCDR Review",
+    "type": "skill",
+    "provider": "azure",
+    "harnesses": [
+      "codex",
+      "claude-code",
+      "cursor",
+      "gemini",
+      "kiro",
+      "other"
+    ],
+    "summary": "Review Azure resilience and disaster-recovery posture for RTO/RPO realism, failover and failback assumptions, shared-responsibility gaps, and recovery runbook or drill quality.",
+    "source_type": "original",
+    "official_docs": [
+      "https://learn.microsoft.com/en-us/azure/well-architected/reliability/principles",
+      "https://learn.microsoft.com/en-us/azure/well-architected/reliability/disaster-recovery",
+      "https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/design-areas",
+      "https://learn.microsoft.com/en-us/azure/azure-monitor/overview",
+      "https://learn.microsoft.com/en-us/azure/azure-monitor/alerts/alerts-overview",
+      "https://learn.microsoft.com/en-us/azure/service-health/resource-health-overview",
+      "https://learn.microsoft.com/en-us/azure/service-health/overview",
+      "https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/"
+    ],
+    "security_notes": "Do not accept zero-downtime or zero-data-loss claims without explicit architecture and test evidence. Separate Azure platform resilience from workload recovery obligations, and treat untested runbooks, undocumented failback, and single-region dependencies as material risks.",
+    "last_verified": "2026-04-27",
+    "path": "skills/azure/azure-resilience-bcdr-review",
+    "author": "github: Raishin"
+  },
+  {
+    "id": "azure-resource-health-incident-triage",
+    "name": "Azure Resource Health Incident Triage",
+    "type": "skill",
+    "provider": "azure",
+    "harnesses": [
+      "codex",
+      "claude-code",
+      "cursor",
+      "gemini",
+      "kiro",
+      "other"
+    ],
+    "summary": "Triage Azure Resource Health, Service Health, activity-log alerts, and first-pass cloud-health incidents with explicit separation between provider incidents, tenant-side changes, and unresolved evidence.",
+    "source_type": "original",
+    "official_docs": [
+      "https://learn.microsoft.com/en-us/azure/service-health/resource-health-overview",
+      "https://learn.microsoft.com/en-us/azure/service-health/",
+      "https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/activity-log",
+      "https://learn.microsoft.com/en-us/azure/azure-monitor/alerts/alerts-create-activity-log-alert-rule",
+      "https://learn.microsoft.com/en-us/azure/service-health/service-health-alert-overview",
+      "https://learn.microsoft.com/en-us/azure/service-health/alerts-activity-log-service-notifications-portal",
+      "https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/",
+      "https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/azure-resource-health",
+      "https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/azure-monitor"
+    ],
+    "security_notes": "Do not over-attribute platform health signals as root cause, ignore recent tenant-side changes, invent unsupported MCP tools, or recommend broad remediation before blast radius and evidence are clear.",
+    "last_verified": "2026-04-27",
+    "path": "skills/azure/azure-resource-health-incident-triage",
+    "author": "github: Raishin"
+  },
+  {
+    "id": "azure-role-selector",
+    "name": "Azure Role Selector",
+    "type": "skill",
+    "provider": "azure",
+    "harnesses": [
+      "codex",
+      "claude-code",
+      "cursor",
+      "gemini",
+      "kiro",
+      "other"
+    ],
+    "summary": "Select the narrowest Azure built-in role, custom-role fallback, and assignment scope for a requested access pattern while separating control-plane and data-plane permissions.",
+    "source_type": "adapted",
+    "official_docs": [
+      "https://learn.microsoft.com/en-us/azure/role-based-access-control/overview",
+      "https://learn.microsoft.com/en-us/azure/role-based-access-control/best-practices",
+      "https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles",
+      "https://learn.microsoft.com/en-us/azure/role-based-access-control/role-definitions",
+      "https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/"
+    ],
+    "security_notes": "Prefer built-in roles before custom roles, minimize assignment scope, and keep control-plane and data-plane permissions separate. Do not default to Owner or Contributor for routine access requests.",
+    "last_verified": "2026-04-27",
+    "path": "skills/azure/azure-role-selector",
+    "author": "github: Raishin"
+  },
+  {
+    "id": "azure-security-posture-hardening",
+    "name": "Azure Security Posture Hardening",
+    "type": "skill",
+    "provider": "azure",
+    "harnesses": [
+      "codex",
+      "claude-code",
+      "cursor",
+      "gemini",
+      "kiro",
+      "other"
+    ],
+    "summary": "Review Azure security posture with least privilege, managed identities, Key Vault hardening, private access decisions, policy guardrails, and audit-ready logging expectations.",
+    "source_type": "original",
+    "official_docs": [
+      "https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/design-area/security",
+      "https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/design-areas",
+      "https://learn.microsoft.com/en-us/azure/security/fundamentals/best-practices-and-patterns",
+      "https://learn.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/managed-identity-best-practice-recommendations",
+      "https://learn.microsoft.com/en-us/azure/key-vault/general/best-practices",
+      "https://learn.microsoft.com/en-us/azure/key-vault/general/rbac-guide",
+      "https://learn.microsoft.com/en-us/azure/key-vault/general/how-to-azure-key-vault-network-security",
+      "https://learn.microsoft.com/en-us/azure/key-vault/general/howto-logging",
+      "https://learn.microsoft.com/en-us/azure/key-vault/general/monitor-key-vault",
+      "https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/",
+      "https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/services/azure-mcp-server-for-key-vault"
+    ],
+    "security_notes": "Do not recommend broad admin roles, stored secrets, or public exposure by default. Prefer managed identities, scoped RBAC, policy-enforced controls, private access where justified, and verified logging coverage.",
+    "last_verified": "2026-04-27",
+    "path": "skills/azure/azure-security-posture-hardening",
+    "author": "github: Raishin"
+  },
+  {
+    "id": "azure-subscription-resource-organization",
+    "name": "Azure Subscription Resource Organization",
+    "type": "skill",
+    "provider": "azure",
+    "harnesses": [
+      "codex",
+      "claude-code",
+      "cursor",
+      "gemini",
+      "kiro",
+      "other"
+    ],
+    "summary": "Design and review Azure management-group, subscription, and resource-group boundaries with explicit governance, ownership, and landing-zone operating-model consequences.",
+    "source_type": "original",
+    "official_docs": [
+      "https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/design-areas",
+      "https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/",
+      "https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/design-area/resource-org",
+      "https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/design-area/resource-org-management-groups",
+      "https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/design-area/governance",
+      "https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/",
+      "https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/subscription",
+      "https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/resource-group"
+    ],
+    "security_notes": "Do not recommend flat hierarchies, fake isolation via resource groups, or subscription moves without proving governance, ownership, policy inheritance, and operational blast-radius implications.",
+    "last_verified": "2026-04-27",
+    "path": "skills/azure/azure-subscription-resource-organization",
     "author": "github: Raishin"
   },
   {

--- a/docs/azure-role-skill-gap-analysis.md
+++ b/docs/azure-role-skill-gap-analysis.md
@@ -1,0 +1,154 @@
+# Azure Role-Based Skill Gap Analysis
+
+Last updated: **2026-04-27**
+
+## 1. Inventory baseline
+
+This repository started Azure-thin, but this implementation wave materially changed that.
+
+### Current repo state
+
+| Scope | Count | Evidence |
+| --- | ---: | --- |
+| Azure skills in `skills/azure/` | 20 | role-based Azure skill folders now exist under `skills/azure/` |
+| Azure entries in `catalog/skills.json` | 20 | catalog contains the same 20 Azure skill paths |
+| Azure docs in `docs/` | 2 | `docs/azure-role-skill-gap-analysis.md`, `docs/azure-role-skill-specs.md` |
+
+### Official Microsoft Azure skill baselines
+
+| Source | Date verified | Count | Notes |
+| --- | --- | ---: | --- |
+| Repo snapshot in `skills/azure/README.md` | 2026-04-27 | 25 | Local snapshot of `microsoft/azure-skills` as recorded in this repo |
+| `skills.sh/microsoft/azure-skills` | 2026-04-27 | 27 | Includes additional visible skills such as `azure-cost-optimization` and `azure-observability` |
+| `skills.sh/microsoft/github-copilot-for-azure` | 2026-04-27 | 46 | Includes extra operational skills such as `azure-networking`, `azure-security`, `azure-role-selector`, `azure-quick-review`, and `azure-keyvault-expiration-audit` |
+
+### Evidence-backed conclusion
+
+The repo now has a **real first-wave Azure portfolio**, not just a single RBAC skill. But it is still not complete.
+
+The remaining gap is narrower and more useful: the first-wave role lanes are now covered, and the remaining work is mostly quality hardening and future specialization.
+
+The residual work areas are:
+
+- stronger eval and compliance coverage,
+- overlap reduction between adjacent skills,
+- and possible future workload-specific operator lanes beyond the current first wave.
+
+### Baseline upstream references
+
+- Local Azure snapshot: `skills/azure/README.md`
+- Azure landing zone design areas: <https://learn.microsoft.com/azure/cloud-adoption-framework/ready/landing-zone/design-areas>
+- Azure governance design area: <https://learn.microsoft.com/azure/cloud-adoption-framework/ready/landing-zone/design-area/governance>
+- Azure MCP tool inventory: <https://learn.microsoft.com/azure/developer/azure-mcp-server/tools/>
+- Microsoft Azure skill directory on skills.sh: <https://skills.sh/microsoft/azure-skills>
+- Microsoft GitHub Copilot for Azure directory on skills.sh: <https://skills.sh/microsoft/github-copilot-for-azure>
+
+## 2. Role matrix
+
+The portfolio should be organized by **role lane**, not by Azure service SKU.
+
+| Role lane | Microsoft design areas / guidance | Upstream Microsoft skill anchors | Current repo coverage | Recommended local role skills | Verdict |
+| --- | --- | --- | --- | --- | --- |
+| Platform architect / landing-zone owner | Landing zone design areas: identity, resource organization, network, security, management, governance, automation | `azure-enterprise-infra-planner`, `azure-prepare`, `azure-validate`, `azure-deploy` | `azure-landing-zone-architect`, `azure-subscription-resource-organization`, `azure-governance-policy-guardrails` | retain and refine these role skills | **Covered (first wave)** |
+| Identity / access / zero-trust | RBAC, Entra identity, access governance, PIM, entitlement management | `azure-rbac`, `azure-role-selector` | `azure-rbac-review`, `azure-role-selector`, `azure-identity-governance-review` | keep all three; narrow overlaps later if needed | **Covered (first wave)** |
+| Network / connectivity | Hub-spoke, Private Link, DNS, network isolation, landing-zone connectivity | `azure-networking`, `azure-kubernetes` | `azure-network-topology-review`, `azure-private-endpoint-adoption-planner` | keep; later connect more tightly to AKS/App Service operator skills | **Covered (first wave)** |
+| Security / posture | Security design area, Key Vault, Defender, policy guardrails, private access | `azure-security`, `azure-compliance`, `azure-aigateway` | `azure-security-posture-hardening`, `azure-key-vault-secret-lifecycle-auditor` | keep both; later clarify boundary between broad posture and vault-specific lifecycle audits | **Covered (first wave)** |
+| SRE / operations / incident | Azure Monitor, Application Insights, Resource Health, alerting, operational excellence | `azure-observability`, `appinsights-instrumentation`, `azure-diagnostics` | `azure-observability-investigator`, `azure-resource-health-incident-triage`, `azure-resilience-bcdr-review` | keep and validate against realistic prompts | **Covered (first wave)** |
+| FinOps / governance | Cost Management, budgets, pricing, Advisor, governance controls | `azure-cost`, `azure-cost-optimization`, `azure-quotas` | `azure-cost-optimization-governor`, `azure-cost-estimation-review` | keep; later add stronger evals around evidence thresholds | **Covered (first wave)** |
+| Platform automation / delivery | IaC accelerator, Bicep/Terraform, CI/CD, deployment separation, safe rollout | `azure-prepare`, `azure-validate`, `azure-deploy`, `airunway-aks-setup` | `azure-platform-automation-devops`, `azure-app-service-production-readiness`, `azure-aks-platform-operator` | keep; this is now one of the stronger lanes | **Covered (first wave)** |
+| Migration / modernization | Azure Migrate, landing-zone cutover, brownfield controls | `azure-cloud-migrate`, `azure-upgrade` | `azure-migrate-landing-zone-cutover` | keep and add eval scenarios for stale assessments and rollback failure modes | **Covered (first wave)** |
+| AI platform / Foundry | Foundry RBAC, quotas, private networking, evaluations, change safety | `microsoft-foundry`, `azure-ai`, `azure-hosted-copilot-sdk` | `azure-ai-foundry-ops-governor` | keep; later add scenario-specific evals | **Covered (first wave)** |
+
+## 3. Gap verdict
+
+### A. Missing role coverage
+
+The original structural gap is largely closed. The repo now has first-class Azure skills for most of the platform-owner roles that mattered most:
+
+- landing zones,
+- governance,
+- network topology,
+- management and monitoring,
+- platform automation,
+- cost control,
+- DR and reliability operations,
+- and Azure AI platform governance.
+
+The remaining problem is **not absence** anymore. It is **portfolio completion and quality control**.
+
+### B. Partial overlap already exists
+
+The earlier identity gap is now addressed by:
+
+- `azure-rbac-review`,
+- `azure-role-selector`,
+- `azure-identity-governance-review`.
+
+That lane is now viable, but overlap should be watched so the three skills do not collapse into each other.
+
+### C. Duplicate-risk areas
+
+Avoid building shallow clones of Microsoft’s SDK-centric skill inventory. That would create:
+
+- maintenance drag,
+- catalog noise,
+- poor trigger quality,
+- and weak role differentiation.
+
+Higher-risk duplicate zones:
+
+- language-specific SDK skills,
+- generic service overviews with no operator workflow,
+- simple MCP tool wrappers with no decision logic or safety contract.
+
+### D. Low-priority or optional gaps
+
+These are still real, but should not outrank the remaining missing specialist skills:
+
+- language-specific Azure SDK skills,
+- single-product tutorials,
+- one-command convenience skills,
+- niche workload accelerators before the platform lanes exist.
+
+## 4. Prioritized backlog
+
+### P0 — remaining highest-priority quality work
+
+| Skill | Why now | Source anchors |
+| --- | --- | --- |
+| `skill-comply` dry-runs across 5+ Azure skills | The portfolio now exists; the bigger risk is that some skills sound strong but do not reliably induce the intended workflow | internal compliance workflow |
+| `eval-harness` prompt sets across each role lane | Trigger quality and regression safety are still unproven until evaluated systematically | internal eval workflow |
+| overlap review across identity, security, networking, and platform-operation lanes | Growth increases duplicate-trigger risk and weak role boundaries if left unchecked | this artifact + `docs/azure-role-skill-specs.md` |
+
+### P1 — next hardening wave
+
+| Skill | Why next | Source anchors |
+| --- | --- | --- |
+| richer examples and sanitized evidence templates inside selected Azure skills | Some skills are structurally strong but still rely on the operator to invent evidence-gathering inputs | internal skill quality work |
+| normalization of earlier Azure skills to the newer OCI-style structure | Newer skills are stronger and more explicit than some earlier first-wave drafts | local repo consistency work |
+| scenario packs for high-risk lanes such as migration, AKS, App Service, and Key Vault | These lanes need more adversarial prompt testing than low-risk catalog helpers | internal eval workflow |
+
+### P2 — useful, but lower urgency now
+
+| Skill | Reason to defer |
+| --- | --- |
+| More workload-specific Azure operator skills | The portfolio already expanded fast; quality, evals, and overlap control matter more than raw count |
+| SDK- or product-tutorial clones | They would bloat the catalog and dilute the role-first design |
+
+## Decision rules for the next implementation phase
+
+1. Prefer **operator-grade role skills** over service or SDK clones.
+2. Require every Azure skill to define:
+   - evidence sources,
+   - preferred MCP/doc path,
+   - safety gates,
+   - explicit output contract,
+   - minimum eval definition,
+   - and minimum compliance sequence.
+3. Do not create new Azure skill folders until the spec is decision-complete.
+4. Before the next growth wave, run `skill-comply` and `eval-harness` against representative first-wave Azure skills.
+5. When actual skills are added later, update:
+   - `skills/azure/*`,
+   - `catalog/skills.json`,
+   - `catalog/skill-manifest.json`,
+   - and run `npm run validate`.

--- a/docs/azure-role-skill-specs.md
+++ b/docs/azure-role-skill-specs.md
@@ -1,0 +1,352 @@
+# Azure Role-Based Skill Specs
+
+Last updated: **2026-04-27**
+
+This file is the decision-complete spec backlog for the first Azure role-based skill wave.
+
+## Working method
+
+This backlog is intentionally shaped by the requested skill workflow:
+
+1. **`eval-harness`**: every spec defines a minimum pass/fail gate before any skill draft exists.
+2. **`skill-creator`**: each spec is detailed enough to draft a real `SKILL.md` without extra product decisions.
+3. **`skill-comply`**: each spec includes a minimum expected behavioral sequence that can later be measured.
+
+## Global portfolio rules
+
+- Prefer official Microsoft Learn, Azure Architecture Center, and Azure MCP documentation over blogs.
+- Prefer Azure MCP evidence when it reduces guesswork; fall back to docs when live access is absent.
+- Distinguish control plane, data plane, and identity plane risks.
+- Call out blast radius, least privilege, rollout risk, and rollback expectations for any production-affecting guidance.
+- Do not create SDK tutorial clones unless the role skill cannot cover the need.
+
+---
+
+## P0 specs
+
+### `azure-landing-zone-architect`
+
+- **Classification:** role-synthesis
+- **Trigger description:** Use when the user asks for Azure platform design, landing-zone review, management-group/subscription structure, shared services layout, or an architecture decision that spans identity, networking, governance, and operations.
+- **Target role and scenarios:** platform architect, cloud platform owner, enterprise landing-zone lead; greenfield Azure platform setup, brownfield rationalization, multi-subscription operating model reviews.
+- **In scope:** landing-zone design areas, platform vs application landing zones, management-group hierarchy, subscription placement, hub-spoke vs alternatives, baseline governance/security/management decisions, operating-model gaps.
+- **Out of scope:** per-service deep implementation, detailed app workload design, writing production Bicep/Terraform.
+- **Required evidence sources:** Azure landing-zone design areas, Azure landing-zone architecture, governance/security/identity design areas, Azure MCP tool inventory.
+- **Preferred MCP/doc/tool path:** `cloudarchitect`, `wellarchitectedframework`, `policy`, `role`, `group`, `subscription`, plus Microsoft Learn architecture docs.
+- **Output contract:** architecture verdict; target platform model; decision table by design area; unresolved risks; recommended next actions; explicit assumptions.
+- **Safety constraints:** no blind recommendation of a single management-group hierarchy; no broad admin grants; no claim that landing zones are “done” without management, governance, and recovery posture.
+- **Overlap notes:** umbrella skill; should route narrower RBAC, networking, observability, and governance questions to adjacent specialized skills when needed.
+- **Minimum eval definition:** capability evals for (1) greenfield landing-zone review, (2) brownfield hierarchy critique, (3) platform/application boundary definition; fail if any design area is omitted.
+- **Minimum compliance sequence expected by `skill-comply`:**
+  1. Classify greenfield vs brownfield and who owns the platform.
+  2. Map the ask to landing-zone design areas.
+  3. Identify critical missing facts and explicit assumptions.
+  4. Produce design-area-by-design-area recommendations.
+  5. Surface blast radius, governance, and operations gaps before final advice.
+
+### `azure-governance-policy-guardrails`
+
+- **Classification:** role-synthesis
+- **Trigger description:** Use for Azure Policy, guardrails, management-group inheritance, compliance enforcement, tag governance, allowed regions/SKUs, or governance automation reviews.
+- **Target role and scenarios:** cloud governance lead, platform engineer, compliance engineer; baseline policy design, brownfield governance hardening, policy assignment review.
+- **In scope:** policy definitions vs initiatives, assignment scope, inheritance, exclusions, remediation, tags, region/SKU restrictions, management baseline links to governance.
+- **Out of scope:** full regulatory interpretation, SIEM operations, writing organization-specific policy JSON unless later requested.
+- **Required evidence sources:** governance design area, Azure Policy overview, ALZ default policy assignments, Azure MCP policy/advisor/pricing docs.
+- **Preferred MCP/doc/tool path:** `policy`, `advisor`, `pricing`, `group`, `subscription`; Microsoft Learn governance docs.
+- **Output contract:** current-state governance summary; risky gaps; recommended guardrails; scope placement; exclusion strategy; staged rollout advice.
+- **Safety constraints:** no root-scope policy sprawl without justification; no deny policies proposed without change-safety notes; always flag remediation/destructive implications.
+- **Overlap notes:** complements `azure-landing-zone-architect`; should not absorb full identity or security-posture reviews.
+- **Minimum eval definition:** capability evals for (1) tag/region guardrail design, (2) initiative placement review, (3) brownfield policy hardening with exclusions.
+- **Minimum compliance sequence expected by `skill-comply`:**
+  1. Identify governing scope and hierarchy.
+  2. Separate audit-only, deny, deployIfNotExists, and remediation concerns.
+  3. Recommend assignment level and exclusions.
+  4. State rollout risk and rollback/exception handling.
+  5. Return enforceable guardrails, not generic governance prose.
+
+### `azure-role-selector`
+
+- **Classification:** upstream-parity
+- **Trigger description:** Use when the user asks which Azure role to assign, how to grant minimum access, whether built-in roles are enough, or when a custom role may be required.
+- **Target role and scenarios:** IAM engineer, platform operator, app team onboarding; service-principal access, managed-identity permissions, narrow operator grants.
+- **In scope:** built-in role matching, scope selection, custom-role fallback criteria, control-plane vs data-plane distinction, assignment examples.
+- **Out of scope:** tenant-wide governance design, identity lifecycle governance, privileged workflow design.
+- **Required evidence sources:** Azure RBAC overview/best practices, built-in role docs, Azure MCP RBAC tools, upstream `azure-role-selector` pattern.
+- **Preferred MCP/doc/tool path:** `role`, `extension`, `bicepschema`, `get azure bestpractices get`; Microsoft Learn RBAC docs.
+- **Output contract:** requested permission summary; recommended built-in role or custom-role rationale; scope recommendation; validation command/path; risks and assumptions.
+- **Safety constraints:** prefer built-in roles first; do not jump to Owner/Contributor by habit; call out data-plane access separately.
+- **Overlap notes:** sits next to `azure-rbac-review`; the latter critiques assignments, this one selects the minimum role shape.
+- **Minimum eval definition:** capability evals for (1) storage read-only access, (2) App Service deploy-only access, (3) custom role fallback when no built-in role matches.
+- **Minimum compliance sequence expected by `skill-comply`:**
+  1. Parse the requested actions and target resource type.
+  2. Distinguish control-plane and data-plane needs.
+  3. Search for the narrowest built-in role.
+  4. Only then consider custom role fallback.
+  5. Return assignment scope and validation path.
+
+### `azure-network-topology-review`
+
+- **Classification:** role-synthesis
+- **Trigger description:** Use when the user asks for Azure network architecture review, hub-spoke critique, routing/DNS segmentation, firewall placement, or landing-zone connectivity advice.
+- **Target role and scenarios:** network architect, platform owner, AKS/App Service platform teams; multi-subscription connectivity, hybrid access, shared-services network reviews.
+- **In scope:** hub-spoke topology, peering, connectivity boundaries, DNS dependencies, NSG/firewall placement, landing-zone connectivity considerations, platform/team ownership lines.
+- **Out of scope:** packet-level troubleshooting, detailed firewall rule authoring, ExpressRoute implementation runbooks.
+- **Required evidence sources:** hub-spoke reference architecture, landing-zone network design area, Private Link architecture guidance when relevant.
+- **Preferred MCP/doc/tool path:** Azure docs first; if Azure MCP networking tools exist in the target client, use them for evidence. Otherwise use CLI/doc fallback.
+- **Output contract:** topology summary; key risks; ownership model; recommended topology adjustments; validation checks; open questions.
+- **Safety constraints:** no “flat network is fine” shortcuts; must call out DNS and route dependencies; must separate platform-shared and workload-local controls.
+- **Overlap notes:** hand off Private Link placement to `azure-private-endpoint-adoption-planner` when private endpoint design is the main issue.
+- **Minimum eval definition:** capability evals for (1) hub-spoke review, (2) multi-subscription shared-services critique, (3) hybrid routing concern review.
+- **Minimum compliance sequence expected by `skill-comply`:**
+  1. Classify topology and connectivity model.
+  2. Identify shared services, trust boundaries, and route ownership.
+  3. Check DNS, peering, security, and management implications.
+  4. Surface bottlenecks and blast-radius issues.
+  5. Return concrete architecture corrections.
+
+### `azure-security-posture-hardening`
+
+- **Classification:** role-synthesis
+- **Trigger description:** Use for Azure security posture review, baseline hardening, managed identity adoption, Key Vault usage, Defender/Policy-driven hardening, or zero-trust cloud control reviews.
+- **Target role and scenarios:** cloud security engineer, platform security lead, application security architect; landing-zone hardening, service exposure review, secret-handling posture review.
+- **In scope:** least privilege, managed identities, private endpoints where justified, Key Vault adoption, logging/auditing expectations, policy-enforced controls, security baseline critique.
+- **Out of scope:** full compliance audit, incident forensics, detailed SOC workflows.
+- **Required evidence sources:** landing-zone security design area, Azure security best practices, Key Vault docs, Foundry security docs when AI scope exists.
+- **Preferred MCP/doc/tool path:** `keyvault`, `role`, `policy`, `monitor`, `advisor`, `extension`; Microsoft Learn security docs.
+- **Output contract:** security posture summary; high-risk findings; prioritized hardening recommendations; safe sequencing; evidence gaps.
+- **Safety constraints:** do not expose secrets; do not recommend public endpoints by default for sensitive services; explicitly separate urgent from strategic controls.
+- **Overlap notes:** broader than `azure-rbac-review`; narrower than a full compliance skill.
+- **Minimum eval definition:** capability evals for (1) managed identity migration advice, (2) Key Vault/private endpoint hardening review, (3) broad access posture critique.
+- **Minimum compliance sequence expected by `skill-comply`:**
+  1. Identify identities, network exposure, and secret flows.
+  2. Check baseline controls and missing telemetry.
+  3. Prioritize high-impact hardening actions.
+  4. Flag blast radius and rollout risks.
+  5. Return staged recommendations with evidence basis.
+
+### `azure-observability-investigator`
+
+- **Classification:** role-synthesis
+- **Trigger description:** Use for Azure Monitor, Log Analytics, Application Insights, alerting, workbooks, KQL triage, or operational-excellence investigations.
+- **Target role and scenarios:** SRE, platform operator, incident responder, application owner; missing telemetry, noisy alerts, error triage, operational health reviews.
+- **In scope:** metrics/logs/traces strategy, workspace and alert review, KQL-based investigation, action groups and alert-processing rules, workbook/reporting patterns.
+- **Out of scope:** code instrumentation implementation unless explicitly requested, full app debugging, SIEM engineering.
+- **Required evidence sources:** Azure Monitor best practices, alerts overview, Log Analytics operational guidance, upstream `azure-observability`.
+- **Preferred MCP/doc/tool path:** `monitor`, `applicationinsights`, `kusto`, `workbooks`, `grafana` where available; docs fallback otherwise.
+- **Output contract:** incident or posture summary; signals reviewed; likely failure domain; recommended alert/telemetry improvements; next diagnostic steps.
+- **Safety constraints:** do not pretend logs prove what they do not; call out ingestion latency and missing telemetry; distinguish symptom from root cause.
+- **Overlap notes:** incident-specific Resource Health workflows should defer to `azure-resource-health-incident-triage`.
+- **Minimum eval definition:** capability evals for (1) noisy alert review, (2) recent failure investigation, (3) telemetry baseline gap assessment.
+- **Minimum compliance sequence expected by `skill-comply`:**
+  1. Classify issue as metrics, logs, traces, alerting, or configuration.
+  2. Gather the highest-value signals first.
+  3. Distinguish evidence, correlation, and inference.
+  4. Recommend concrete query/alert/workbook improvements.
+  5. End with operational next steps and residual blind spots.
+
+### `azure-ai-foundry-ops-governor`
+
+- **Classification:** role-synthesis
+- **Trigger description:** Use when the user asks for Azure AI Foundry operations, RBAC, quotas, private networking, deployment governance, evaluations, or safe MCP-based Foundry operations.
+- **Target role and scenarios:** AI platform engineer, AI security lead, Foundry platform owner; Foundry rollout, multi-team governance, quota planning, safe deployment operations.
+- **In scope:** Foundry resource vs project boundaries, RBAC scope, quota checks, private link/network isolation considerations, diagnostics/logging, MCP execution safety.
+- **Out of scope:** model prompt engineering, app-level agent logic, generic AI strategy.
+- **Required evidence sources:** Foundry architecture, Foundry rollout planning, Foundry MCP security best practices, Foundry quotas/limits.
+- **Preferred MCP/doc/tool path:** `foundry`, `quota`, `monitor`, `role`, `keyvault`; Microsoft Foundry docs and Foundry MCP best-practice docs.
+- **Output contract:** governance summary; resource/project boundary decisions; RBAC and quota posture; network/security constraints; safe next actions.
+- **Safety constraints:** must call out preview risk for Foundry MCP where relevant; verify write vs read operations; require nonproduction-first for mutating actions.
+- **Overlap notes:** AI-specific specialization; do not absorb generic cost or network design unless tightly coupled to Foundry.
+- **Minimum eval definition:** capability evals for (1) Foundry RBAC review, (2) quota-aware deployment planning, (3) private-networking governance critique.
+- **Minimum compliance sequence expected by `skill-comply`:**
+  1. Separate Foundry management scope from project scope.
+  2. Check RBAC, quota, network isolation, and logging posture.
+  3. Distinguish read-only discovery from write-risk operations.
+  4. Recommend least-privilege and safe execution steps.
+  5. Return rollout blockers and mitigation plan.
+
+---
+
+## P1 specs
+
+### `azure-identity-governance-review`
+
+- **Classification:** role-synthesis
+- **Trigger description:** Use for Entra PIM, access reviews, entitlement management, recurring privilege review, or identity-governance posture checks for Azure operators.
+- **Target role and scenarios:** IAM governance lead, security architect, platform owner.
+- **In scope:** standing vs eligible access, access-review posture, entitlement-management use, privileged workflow risks, ownership/accountability gaps.
+- **Out of scope:** low-level app authentication debugging, broad directory architecture redesign.
+- **Required evidence sources:** identity-access design area, Entra governance docs, security design area references to PIM and access reviews.
+- **Preferred MCP/doc/tool path:** docs-first; Azure role tools where role assignments need correlation.
+- **Output contract:** current privilege model; governance gaps; recommended review cadence and control pattern; assumptions.
+- **Safety constraints:** do not assume PIM solves poor scope design; always challenge standing privilege.
+- **Overlap notes:** extends `azure-rbac-review`; does not replace `azure-role-selector`.
+- **Minimum eval definition:** capability evals for PIM adoption, access review posture, and entitlement workflow critique.
+- **Minimum compliance sequence expected by `skill-comply`:** identify privileged actors; separate assignment design from governance process; recommend review/eligibility model; surface operational ownership.
+
+### `azure-private-endpoint-adoption-planner`
+
+- **Classification:** role-synthesis
+- **Trigger description:** Use for private endpoint placement, hub-vs-spoke design, DNS-zone linkage, and PaaS isolation trade-offs.
+- **Target role and scenarios:** network architect, security engineer, platform owner.
+- **In scope:** private endpoint placement, DNS integration, route implications, centralized vs workload-local endpoints, hub-spoke/Virtual WAN considerations.
+- **Out of scope:** generic network topology reviews that do not hinge on Private Link.
+- **Required evidence sources:** Private Link hub-spoke guidance, private endpoint DNS integration guidance, Azure Monitor private link design when observability is involved.
+- **Preferred MCP/doc/tool path:** docs-first; networking MCP tools if available.
+- **Output contract:** placement recommendation; DNS requirements; routing/security implications; rollout caveats.
+- **Safety constraints:** never ignore DNS; explicitly call out `/32` route and access-control implications when relevant.
+- **Overlap notes:** companion to `azure-network-topology-review`.
+- **Minimum eval definition:** capability evals for hub placement, spoke placement, and DNS-linked multi-subscription design.
+- **Minimum compliance sequence expected by `skill-comply`:** identify consumers and shared resources; choose hub vs spoke with rationale; map DNS and route impacts; return safe rollout steps.
+
+### `azure-resource-health-incident-triage`
+
+- **Classification:** repo-original
+- **Trigger description:** Use when the user asks whether an Azure outage or degraded resource is the cause, or needs first-pass cloud-health triage.
+- **Target role and scenarios:** incident commander, SRE, support engineer.
+- **In scope:** resource health, service health, activity-log alerts, incident classification, immediate evidence collection, escalation framing.
+- **Out of scope:** full RCA, long-term observability redesign, app-code fixes.
+- **Required evidence sources:** Azure Resource Health docs, Azure Monitor alerts docs, Azure MCP tool inventory.
+- **Preferred MCP/doc/tool path:** `resourcehealth`, `monitor`, `group`, `subscription`; docs fallback if tool access is absent.
+- **Output contract:** current health finding; likely scope of impact; evidence collected; next triage actions; what remains unknown.
+- **Safety constraints:** do not over-attribute platform health signals as root cause; distinguish Azure issue from workload issue.
+- **Overlap notes:** narrower and faster than `azure-observability-investigator`.
+- **Minimum eval definition:** capability evals for platform outage triage, degraded resource triage, and unknown-cause incident routing.
+- **Minimum compliance sequence expected by `skill-comply`:** check health signals first; classify blast radius; separate provider incident from tenant misconfiguration; return immediate next actions.
+
+### `azure-resilience-bcdr-review`
+
+- **Classification:** role-synthesis
+- **Trigger description:** Use for Azure resilience, HA/DR review, RTO/RPO mapping, runbook quality, recovery drill planning, or business-continuity critique.
+- **Target role and scenarios:** solution architect, SRE lead, platform owner.
+- **In scope:** RTO/RPO framing, failover/failback assumptions, shared-responsibility constraints, DR documentation/runbook quality, service-level recovery gaps.
+- **Out of scope:** service-specific backup configuration steps unless later requested.
+- **Required evidence sources:** Well-Architected reliability/disaster recovery docs, landing-zone BCDR design area references, service reliability guidance when relevant.
+- **Preferred MCP/doc/tool path:** docs-first; `resourcehealth`, `monitor`, `advisor` can supplement live posture evidence.
+- **Output contract:** reliability posture summary; target recovery model; missing controls; drill/test recommendations; unresolved dependencies.
+- **Safety constraints:** no zero-RTO/RPO fantasies without cost/complexity challenge; must call out services that do not auto-failover cross-region.
+- **Overlap notes:** broader than incident triage; can be referenced by landing-zone and workload-specific skills.
+- **Minimum eval definition:** capability evals for RTO/RPO critique, multi-region DR plan review, and runbook/testability review.
+- **Minimum compliance sequence expected by `skill-comply`:** identify business targets; map service realities; expose unsupported assumptions; recommend tested recovery posture.
+
+### `azure-cost-optimization-governor`
+
+- **Classification:** role-synthesis
+- **Trigger description:** Use for Azure spend governance, budgets, alerts, exports, cost controls, pricing posture, and FinOps review.
+- **Target role and scenarios:** FinOps lead, platform owner, engineering manager.
+- **In scope:** budgets, alerts, cost analysis posture, tagging for cost, reservation/savings-plan awareness, governance-grade cost controls.
+- **Out of scope:** procurement negotiation, invoice reconciliation details, one-off SKU pricing lookup unless later requested.
+- **Required evidence sources:** cost planning docs, budgets tutorial, cost-management automation overview, governance design area.
+- **Preferred MCP/doc/tool path:** `pricing`, `advisor`, `quota`, Microsoft Cost Management docs.
+- **Output contract:** spend-control posture; immediate waste/risk findings; budget/alert/export recommendations; ownership model.
+- **Safety constraints:** do not promise savings without utilization evidence; distinguish cost estimation from optimization governance.
+- **Overlap notes:** broader than a simple pricing calculator helper.
+- **Minimum eval definition:** capability evals for budget strategy, alerting design, and reservation/savings-plan decision framing.
+- **Minimum compliance sequence expected by `skill-comply`:** inspect visibility and ownership first; recommend budgets/alerts/exports; call out cost-risk assumptions; return prioritized controls.
+
+### `azure-platform-automation-devops`
+
+- **Classification:** role-synthesis
+- **Trigger description:** Use for Azure platform automation, landing-zone IaC delivery, Bicep/Terraform rollout workflow, CI/CD safety gates, and infrastructure/application deployment separation.
+- **Target role and scenarios:** platform engineer, DevOps lead, cloud architect.
+- **In scope:** IaC accelerator choices, Bicep/Terraform positioning, bootstrap/run phases, pipeline separation, secret handling, safe rollout patterns, validation gates.
+- **Out of scope:** writing full pipelines on first pass, application release strategy unrelated to Azure platform automation.
+- **Required evidence sources:** landing-zone implementation options, IaC accelerator guidance, App Service platform automation guidance, Azure MCP deploy/bicepschema docs.
+- **Preferred MCP/doc/tool path:** `deploy`, `bicepschema`, `extension`, `advisor`; docs for accelerator patterns.
+- **Output contract:** automation strategy; control points; pipeline split; validation gates; rollout sequencing.
+- **Safety constraints:** no direct production-deploy advice without validation gates; no secret-in-repo patterns; separate infra and app flows.
+- **Overlap notes:** execution-oriented companion to `azure-landing-zone-architect`.
+- **Minimum eval definition:** capability evals for IaC approach selection, CI/CD control design, and secure deployment-flow review.
+- **Minimum compliance sequence expected by `skill-comply`:** classify platform vs workload automation; choose IaC/control model; define gates and secret handling; return safe deployment workflow.
+
+### `azure-aks-platform-operator`
+
+- **Classification:** role-synthesis
+- **Trigger description:** Use for AKS production-readiness review, cluster operating-model critique, upgrade safety, node-pool strategy, workload identity posture, network policy review, and cluster-operator readiness.
+- **Target role and scenarios:** AKS platform operator, SRE lead, platform architect, cloud platform engineer.
+- **In scope:** node-pool separation, cluster/network model, ingress/egress assumptions, workload identity, secret flow, autoscaling realism, subnet/IP headroom, PDB and drain risk, upgrade/rollback posture, operator observability.
+- **Out of scope:** workload manifest authoring, application debugging, generic Kubernetes tutorials, full GitOps implementation.
+- **Required evidence sources:** AKS baseline architecture, AKS upgrade guidance, workload identity docs, network policy guidance, Azure MCP AKS docs.
+- **Preferred MCP/doc/tool path:** `aks` first for cluster evidence; `monitor`, `resourcehealth`, `applicationinsights`, `role`, and `policy` only when they materially support the review; Microsoft Learn fallback otherwise.
+- **Output contract:** cluster verdict; ownership model; findings table; upgrade and rollback posture; security/identity posture; safe next actions; open questions.
+- **Safety constraints:** do not bless AKS as “managed so safe”; must challenge upgrade assumptions, static secret use, flat traffic models, and missing rollback proof.
+- **Overlap notes:** complements `azure-network-topology-review`, `azure-security-posture-hardening`, and `azure-observability-investigator`; should route app-runtime specifics to narrower skills.
+- **Minimum eval definition:** capability evals for (1) production upgrade-readiness review, (2) workload identity and secret-flow critique, (3) cluster-operating-model assessment.
+- **Minimum compliance sequence expected by `skill-comply`:**
+  1. Classify environment, exposure model, and workload criticality.
+  2. Map platform versus workload ownership.
+  3. Check node-pool, network, identity, scaling, and observability posture.
+  4. Stress-test upgrade, drain, surge, and rollback assumptions.
+  5. Return a go/no-go style verdict with explicit evidence labels.
+
+### `azure-app-service-production-readiness`
+
+- **Classification:** role-synthesis
+- **Trigger description:** Use for Azure App Service production-readiness review, deployment-slot safety, plan-tier fit, networking and private ingress posture, identity/secret handling, scaling, diagnostics, and rollout safety.
+- **Target role and scenarios:** App Service platform operator, application platform engineer, SRE, cloud architect.
+- **In scope:** plan and SKU fit, App Service Environment versus multitenant fit where relevant, deployment slots, VNet integration, private endpoint or access restrictions, managed identity, app settings and secret posture, autoscale, backup/restore expectations, diagnostics and safe release sequencing.
+- **Out of scope:** application code profiling, framework-specific tuning, detailed CI/CD authoring unless separately requested.
+- **Required evidence sources:** App Service best-practice docs, deployment-slot guidance, networking guidance, scaling guidance, diagnostic guidance, Azure MCP App Service docs.
+- **Preferred MCP/doc/tool path:** `appservice` first where available; `monitor`, `applicationinsights`, `role`, `keyvault`, and `advisor` when they materially support the review; documentation fallback otherwise.
+- **Output contract:** readiness verdict; platform fit summary; critical risks; rollout and rollback posture; diagnostics and configuration findings; safe next steps.
+- **Safety constraints:** do not treat “it deploys” as production readiness; explicitly challenge slot misuse, public exposure assumptions, weak secret handling, and missing rollback/restore proof.
+- **Overlap notes:** complements `azure-platform-automation-devops` and `azure-security-posture-hardening`; should not absorb full landing-zone or AKS concerns.
+- **Minimum eval definition:** capability evals for (1) public web app production-readiness review, (2) slot-based rollout critique, (3) network-restricted or private-ingress posture review.
+- **Minimum compliance sequence expected by `skill-comply`:**
+  1. Classify hosting model, environment criticality, and traffic pattern.
+  2. Check plan fit, deployment flow, identity/secret posture, and networking controls.
+  3. Verify scaling, diagnostics, and recovery expectations.
+  4. Distinguish evidence from inference and challenge weak production claims.
+  5. Return a bounded hardening and rollout-safety plan.
+
+### `azure-key-vault-secret-lifecycle-auditor`
+
+- **Classification:** role-synthesis
+- **Trigger description:** Use for Key Vault secret lifecycle audits, expiry posture, rotation realism, purge/recovery safety, lifecycle metadata hygiene, and RBAC review around secret operations.
+- **Target role and scenarios:** cloud security engineer, platform security owner, secrets-management operator, compliance reviewer.
+- **In scope:** soft delete, purge protection, expiration, tags/ownership metadata, RBAC versus legacy access policies, purge authority, Event Grid or alert posture, rotation and recovery readiness.
+- **Out of scope:** secret value retrieval unless absolutely necessary, application-side secret-consumer code changes, key-management deep dives unrelated to lifecycle controls.
+- **Required evidence sources:** Key Vault secret best practices, autorotation guidance, RBAC guide, soft-delete and recovery docs, Key Vault policy reference, Azure MCP Key Vault docs.
+- **Preferred MCP/doc/tool path:** `keyvault` first for safe metadata-oriented evidence; `role`, `monitor`, and `policy` when needed; documentation fallback otherwise.
+- **Output contract:** lifecycle verdict; findings table; lifecycle control review; safe next actions; open questions.
+- **Safety constraints:** avoid retrieving secret values; treat missing purge protection, broad purge authority, unproven rotation, and false recovery confidence as blockers.
+- **Overlap notes:** complements `azure-security-posture-hardening`; should stay focused on lifecycle operations rather than broad platform security.
+- **Minimum eval definition:** capability evals for (1) expiry/rotation posture audit, (2) RBAC and purge-authority review, (3) recovery-readiness critique.
+- **Minimum compliance sequence expected by `skill-comply`:**
+  1. Scope vaults and dependent workloads.
+  2. Check soft delete, purge protection, and permission model.
+  3. Check expiration, metadata hygiene, rotation, and alerts.
+  4. Stress-test recovery and purge assumptions.
+  5. Return a go/no-go lifecycle verdict without exposing secrets.
+
+### `azure-migrate-landing-zone-cutover`
+
+- **Classification:** role-synthesis
+- **Trigger description:** Use for Azure migration wave review, landing-zone cutover readiness, Azure Migrate assessment critique, dependency sequencing, and rollback/validation planning.
+- **Target role and scenarios:** migration lead, cloud architect, platform owner, cutover manager, SRE lead.
+- **In scope:** assessment quality, landing-zone readiness, connectivity and DNS dependency checks, wave grouping, migration permissions, validation gates, rollback posture, and post-cutover ownership.
+- **Out of scope:** detailed per-tool migration runbooks, low-level replication tuning, or service-specific migration implementation unless separately requested.
+- **Required evidence sources:** Azure Migrate assessment overview, assessment prerequisites, application assessment review, platform landing zone generation guidance, CAF landing-zone migration readiness guidance, Azure Migrate release notes.
+- **Preferred MCP/doc/tool path:** target-environment evidence from available Azure namespaces such as `group`, `subscription`, `resourcehealth`, `monitor`, and deployment-related tooling when relevant; documentation fallback otherwise.
+- **Output contract:** cutover verdict; findings table; readiness review matrix; safe next actions; open questions.
+- **Safety constraints:** do not equate “Azure ready” with “cutover ready”; treat stale discovery data, weak dependency mapping, broad permissions, and missing rollback checkpoints as blockers.
+- **Overlap notes:** complements `azure-landing-zone-architect` and workload-specific operator skills; remains focused on migration execution readiness.
+- **Minimum eval definition:** capability evals for (1) migration wave critique, (2) landing-zone cutover review, (3) rollback and validation-plan challenge.
+- **Minimum compliance sequence expected by `skill-comply`:**
+  1. Classify migration scope and wave criticality.
+  2. Check assessment freshness and discovery quality.
+  3. Check landing-zone, dependency, and permission readiness.
+  4. Stress-test cutover and rollback mechanics.
+  5. Return a go/no-go cutover verdict with explicit missing evidence.
+
+---
+
+## First implementation-wave status
+
+The first implementation wave is now drafted in the repo.
+
+What remains is not basic drafting. It is:
+
+1. `skill-comply` dry-runs against representative Azure skills,
+2. `eval-harness` prompt packs across the role lanes,
+3. overlap cleanup where nearby skills risk trigger collisions,
+4. normalization of older first-wave Azure skills that are structurally weaker than the newer OCI-style drafts.

--- a/mcp/official/azure-mcp-server.md
+++ b/mcp/official/azure-mcp-server.md
@@ -4,6 +4,7 @@
 - Status: official Microsoft Azure MCP Server
 - Docs: <https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/overview>
 - Source: <https://github.com/microsoft/azure-mcp>
+- Microsoft MCP catalog: <https://github.com/microsoft/mcp>
 - Auth model: Microsoft Entra ID / Azure Identity patterns through supported clients.
 - Mutation risk: tools can interact with Azure resources according to RBAC permissions.
 - Last verified: 2026-04-27
@@ -11,6 +12,56 @@
 ## Install/config
 
 Use the current Microsoft Learn setup instructions for your client. Avoid tenant-wide or subscription-wide roles unless required and approved.
+
+## Other official Microsoft MCP servers listed in `microsoft/mcp`
+
+The Azure MCP Server is only one entry in Microsoft's broader MCP catalog. Based on the `microsoft/mcp` README as viewed on **2026-04-27**, Microsoft also lists the following MCP servers.
+
+### Catalog snapshot
+
+| Name                                    | Repo / docs                              | Category                 | Type   | Endpoint / notes                                                                                   | What it is for                                                                                   |
+| --------------------------------------- | ---------------------------------------- | ------------------------ | ------ | -------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| ✨ Microsoft Foundry                    | Microsoft Learn docs                     | Cloud and infrastructure | Remote | `https://mcp.ai.azure.com`                                                                         | Foundry tools for models, knowledge, evaluation, and related AI workflows.                       |
+| Azure DevOps                            | Azure DevOps MCP Server                  | Developer tools          | Local  | Local server                                                                                       | Azure DevOps work from the editor.                                                               |
+| ☸️ Azure Kubernetes Service (AKS)       | `Azure/aks-mcp`                          | Cloud and infrastructure | Local  | Local server                                                                                       | Natural-language interaction with AKS clusters.                                                  |
+| GitHub                                  | `github/github-mcp-server`               | Developer tools          | Remote | `https://api.githubcopilot.com/mcp`                                                                | GitHub repositories, issues, and pull requests.                                                  |
+| GitHub Awesome-Copilot                  | `github/awesome-copilot`                 | Developer tools          | Local  | Local server                                                                                       | Copilot instructions, prompts, and configs.                                                      |
+| Markitdown                              | `microsoft/markitdown`                   | Developer tools          | Local  | Local server                                                                                       | Markdown conversion and transformation workflows.                                                |
+| Microsoft 365 Agents Toolkit            | `OfficeDev/microsoft-365-agents-toolkit` | Developer tools          | Local  | Local server                                                                                       | Building apps and agents for Microsoft 365 and Copilot.                                          |
+| Microsoft 365 Calendar                  | `bap-microsoft/MCP-Platform`             | Productivity             | Remote | `https://agent365.svc.cloud.microsoft/agents/tenants/{tenant_id}/servers/mcp_CalendarTools`        | Calendar events, invites, and availability.                                                      |
+| Microsoft 365 Copilot Chat              | `bap-microsoft/MCP-Platform`             | Productivity             | Remote | `https://agent365.svc.cloud.microsoft/agents/tenants/{tenant_id}/servers/mcp_M365Copilot`          | Search and chat across Microsoft 365 content.                                                    |
+| Microsoft 365 Mail                      | `bap-microsoft/MCP-Platform`             | Productivity             | Remote | `https://agent365.svc.cloud.microsoft/agents/tenants/{tenant_id}/servers/mcp_MailTools`            | Mail creation, replies, updates, delete, and search.                                             |
+| Microsoft 365 User                      | `bap-microsoft/MCP-Platform`             | Productivity             | Remote | `https://agent365.svc.cloud.microsoft/agents/tenants/{tenant_id}/servers/mcp_MeServer`             | User, manager, team, and reportee details.                                                       |
+| ⚙️ Microsoft Admin Center               | `bap-microsoft/MCP-Platform`             | Productivity             | Remote | `https://agent365.svc.cloud.microsoft/agents/tenants/{tenant_id}/servers/mcp_AdminTools`           | Admin Center actions and admin-facing APIs.                                                      |
+| Microsoft Clarity                       | `microsoft/clarity-mcp-server`           | Data and analytics       | Local  | Local server                                                                                       | Clarity analytics export access for MCP clients.                                                 |
+| Microsoft Dataverse                     | Microsoft Dataverse docs                 | Data and analytics       | Local  | Local server                                                                                       | Discover tables, query data, and update business records.                                        |
+| Microsoft Dev Box                       | `@microsoft/devbox-mcp`                  | Developer tools          | Local  | npm package                                                                                        | Dev Box management and environment operations.                                                   |
+| Microsoft Fabric (Public Preview)       | `microsoft/mcp`                          | Data and analytics       | Local  | Local-first                                                                                        | Fabric APIs, item definitions, and best-practice guidance without a live connection requirement. |
+| Microsoft Fabric Real-Time Intelligence | RTI MCP Server docs                      | Data and analytics       | Local  | Local server                                                                                       | RTI querying and analysis workflows.                                                             |
+| Microsoft Learn                         | `microsoftdocs/mcp`                      | Productivity             | Remote | `https://learn.microsoft.com/api/mcp`                                                              | Real-time access to official Microsoft documentation.                                            |
+| Microsoft Sentinel Data Exploration     | Sentinel docs                            | Security                 | Remote | `https://sentinel.microsoft.com/mcp/data-exploration`                                              | Natural-language exploration of Sentinel data lake content.                                      |
+| Microsoft SQL                           | MSSQL MCP Server docs                    | Developer tools          | Local  | Local server                                                                                       | Conversational SQL schema, table, and CRUD workflows.                                            |
+| Microsoft Teams                         | `bap-microsoft/MCP-Platform`             | Productivity             | Remote | `https://agent365.svc.cloud.microsoft/agents/tenants/{tenant_id}/servers/mcp_TeamsServer`          | Teams chats, channels, users, and messages.                                                      |
+| Microsoft Word                          | `bap-microsoft/MCP-Platform`             | Productivity             | Remote | `https://agent365.svc.cloud.microsoft/agents/tenants/{tenant_id}/servers/mcp_WordServer`           | Read, create, and collaborate on Word documents.                                                 |
+| NuGet MCP Server                        | `NuGet/Home`                             | Developer tools          | Local  | Local server                                                                                       | NuGet package-management tooling and automation.                                                 |
+| OneDrive and SharePoint                 | `bap-microsoft/MCP-Platform`             | Productivity             | Remote | `https://agent365.svc.cloud.microsoft/agents/tenants/{tenant_id}/servers/mcp_ODSPRemoteServer`     | OneDrive and SharePoint file integration.                                                        |
+| SharePoint Lists                        | `bap-microsoft/MCP-Platform`             | Productivity             | Remote | `https://agent365.svc.cloud.microsoft/agents/tenants/{tenant_id}/servers/mcp_SharePointListsTools` | SharePoint list, library, and collaboration workflows.                                           |
+| Playwright                              | `microsoft/playwright-mcp`               | Developer tools          | Local  | Local server                                                                                       | Structured browser interaction through accessibility snapshots.                                  |
+| Wassette                                | `microsoft/wassette`                     | Developer tools          | Local  | Local server                                                                                       | Security-oriented WebAssembly component runtime via MCP.                                         |
+
+### Emoji note
+
+I copied the visible icon-style markers Microsoft uses in the catalog headings where they are explicit in the page markup:
+
+- `✨` Microsoft Foundry
+- `☸️` Azure Kubernetes Service (AKS)
+- `⚙️` Microsoft Admin Center
+
+Other entries in the GitHub-rendered page appear without a distinctive emoji marker in the captured listing, so I did not invent extra ones.
+
+### Evidence note
+
+The `microsoft/mcp` page mixes true Azure services, Microsoft 365/Graph endpoints, Fabric/data tooling, and general developer tooling. Do not assume every entry is Azure-scoped just because it appears in Microsoft's MCP catalog.
 
 ## Security notes
 

--- a/skills/AGENTS.md
+++ b/skills/AGENTS.md
@@ -13,6 +13,7 @@
 - Use progressive disclosure; do not dump all references into `SKILL.md`.
 - Keep cloud and compliance claims source-grounded.
 - Never request secrets, wallets, credentials, tokens, or customer identifiers.
+- For provider-specific `README.md` files under `skills/`, place the matching repo-local cloud logo near the top.
 - Update `catalog/skills.json` when adding, moving, or removing a skill.
 - Run `npm run manifest:write` after intentional skill edits.
 - Run `npm run validate` before finishing.
@@ -20,4 +21,3 @@
 ## Do Not Miss
 - Manifest drift means changed skill content; refresh only when intentional.
 - New high-risk cloud skills need safety gates, rollback notes, and least-privilege posture.
-

--- a/skills/azure/README.md
+++ b/skills/azure/README.md
@@ -1,0 +1,74 @@
+# Azure skills
+
+![Azure logo](../../assets/logos/cloud/azure/azure.png)
+
+This folder contains Azure-focused skills curated for this marketplace.
+
+## Local marketplace portfolio
+
+As of **2026-04-27**, this folder contains **20** local Azure skills:
+
+- `azure-ai-foundry-ops-governor`
+- `azure-aks-platform-operator`
+- `azure-app-service-production-readiness`
+- `azure-cost-estimation-review`
+- `azure-cost-optimization-governor`
+- `azure-governance-policy-guardrails`
+- `azure-identity-governance-review`
+- `azure-key-vault-secret-lifecycle-auditor`
+- `azure-landing-zone-architect`
+- `azure-migrate-landing-zone-cutover`
+- `azure-network-topology-review`
+- `azure-observability-investigator`
+- `azure-platform-automation-devops`
+- `azure-private-endpoint-adoption-planner`
+- `azure-rbac-review`
+- `azure-resilience-bcdr-review`
+- `azure-resource-health-incident-triage`
+- `azure-role-selector`
+- `azure-security-posture-hardening`
+- `azure-subscription-resource-organization`
+
+## Official upstream reference
+
+When adding or reviewing Azure skills, check the official Microsoft Azure skills repository first:
+
+- https://github.com/microsoft/azure-skills
+
+Use it as the primary upstream reference for Azure-specific workflow ideas, patterns, and alignment with Microsoft-maintained guidance.
+
+## Official Azure skills snapshot
+
+Source: `https://github.com/microsoft/azure-skills`
+
+Snapshot date: **2026-04-27**
+
+Based on the upstream `skills/` folder on 2026-04-27, the listed skill directories are:
+
+- `airunway-aks-setup`
+- `appinsights-instrumentation`
+- `azure-ai`
+- `azure-aigateway`
+- `azure-cloud-migrate`
+- `azure-compliance`
+- `azure-compute`
+- `azure-cost`
+- `azure-deploy`
+- `azure-diagnostics`
+- `azure-enterprise-infra-planner`
+- `azure-hosted-copilot-sdk`
+- `azure-kubernetes`
+- `azure-kusto`
+- `azure-messaging`
+- `azure-prepare`
+- `azure-quotas`
+- `azure-rbac`
+- `azure-resource-lookup`
+- `azure-resource-visualizer`
+- `azure-storage`
+- `azure-upgrade`
+- `azure-validate`
+- `entra-app-registration`
+- `microsoft-foundry`
+
+Note: the upstream repository README currently says it ships **20 curated Azure skills**, but the visible `skills/` directory listing on 2026-04-27 shows **25 skill directories**. Treat the directory listing as the fresher source unless Microsoft clarifies otherwise.

--- a/skills/azure/azure-ai-foundry-ops-governor/SKILL.md
+++ b/skills/azure/azure-ai-foundry-ops-governor/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: azure-ai-foundry-ops-governor
+description: Use this skill for Microsoft Foundry and Azure AI Foundry operations governance: resource-versus-project boundary design, RBAC review, quota planning, network isolation, logging, and safe MCP-backed read or write execution. Trigger when the user asks how to run Foundry safely across teams without access sprawl, quota surprises, or unsafe production mutations.
+metadata:
+  author: github: Raishin
+---
+
+# Azure AI Foundry Ops Governor
+
+## Role Charter
+
+Act as a ruthless Azure AI Foundry operations governor. Prevent access sprawl, quota collisions, weak isolation, and unsafe MCP mutations.
+
+Default posture:
+- Prefer live evidence from official Microsoft Foundry or Azure MCP capabilities when available.
+- Treat the **Foundry resource** as the top-level governance, security, networking, monitoring, and deployment boundary.
+- Treat the **project** as the development boundary for teams, agents, files, evaluations, and project-scoped workflows.
+- Do not assume every API or feature works at project scope. Verify whether the workload requires parent resource scope.
+- Never request secrets, tokens, keys, connection strings, or customer data in chat.
+
+## Trigger Situations
+
+Use this skill when the user asks to:
+- design or review Foundry resource vs project boundaries,
+- grant team access or review Foundry RBAC safely,
+- plan Foundry model quota or deployment capacity across teams,
+- harden Foundry networking with private access or isolation,
+- verify diagnostics, audit logs, metrics, or operational monitoring,
+- perform or approve Foundry MCP-backed read/write operations,
+- govern multi-team Foundry rollout, environment separation, or production readiness.
+
+## Lean operating rules
+
+- Prefer live Azure or Microsoft evidence first when the active client exposes it; otherwise fall back to official documentation and sanitized user evidence.
+- Separate confirmed facts from inference. If state was not queried or shown, say so.
+- Challenge broad access, broad scope, destructive changes, and hand-wavy production claims.
+- Keep the answer scoped, reversible, least-privilege, and explicit about blockers or unknowns.
+
+## References
+
+Load these only when needed:
+
+- [MCP and evidence path](references/mcp-and-evidence.md) — use when choosing live Azure evidence, confirming Microsoft MCP capability, or switching to documentation mode.
+- [Workflow and output contract](references/workflow-and-output.md) — use when executing the full review, applying stress checks, or formatting the final answer.
+- [Official sources](references/official-sources.md) — use when you need the detailed Microsoft documentation list or source notes.
+
+## Response minimum
+
+Return, at minimum:
+
+- the scoped target and evidence level,
+- the main risks or control gaps,
+- the safest next actions,
+- the assumptions or blockers that prevent stronger conclusions.

--- a/skills/azure/azure-ai-foundry-ops-governor/metadata.json
+++ b/skills/azure/azure-ai-foundry-ops-governor/metadata.json
@@ -1,0 +1,32 @@
+{
+  "id": "azure-ai-foundry-ops-governor",
+  "name": "Azure AI Foundry Ops Governor",
+  "type": "skill",
+  "provider": "azure",
+  "harnesses": [
+    "codex",
+    "claude-code",
+    "cursor",
+    "gemini",
+    "kiro",
+    "other"
+  ],
+  "summary": "Govern Microsoft Foundry and Azure AI Foundry operations across resource-versus-project boundaries, RBAC, quotas, network isolation, logging, and safe MCP-backed execution.",
+  "source_type": "original",
+  "official_docs": [
+    "https://learn.microsoft.com/en-us/azure/foundry/concepts/architecture",
+    "https://learn.microsoft.com/en-us/azure/foundry/concepts/rbac-foundry",
+    "https://learn.microsoft.com/en-us/azure/foundry/concepts/planning",
+    "https://learn.microsoft.com/en-us/azure/foundry/mcp/security-best-practices?view=foundry",
+    "https://learn.microsoft.com/en-us/azure/foundry/how-to/configure-private-link",
+    "https://learn.microsoft.com/en-us/azure/foundry/how-to/managed-virtual-network",
+    "https://learn.microsoft.com/en-us/azure/foundry/how-to/quota",
+    "https://learn.microsoft.com/en-us/azure/foundry/foundry-models/quotas-limits",
+    "https://learn.microsoft.com/en-us/azure/foundry/foundry-models/how-to/monitor-models",
+    "https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/"
+  ],
+  "security_notes": "Keep Foundry resource governance separate from project developer isolation, prefer Entra ID over key-based auth, verify quota and diagnostics before rollout, and treat MCP mutations as higher risk than read-only discovery, especially because hosted Foundry MCP security guidance documents preview and public-endpoint limitations.",
+  "last_verified": "2026-04-27",
+  "path": "skills/azure/azure-ai-foundry-ops-governor",
+  "author": "github: Raishin"
+}

--- a/skills/azure/azure-ai-foundry-ops-governor/references/mcp-and-evidence.md
+++ b/skills/azure/azure-ai-foundry-ops-governor/references/mcp-and-evidence.md
@@ -1,0 +1,34 @@
+# MCP and Evidence Path
+
+## Official Azure / Foundry MCP Linkage
+
+Use only official Microsoft MCP surfaces documented for this role.
+
+Preferred order:
+1. **Foundry MCP Server** for Foundry-native operations when the active client exposes it.
+2. **Azure MCP Server** for adjacent Azure evidence such as monitoring, quotas, and Key Vault-backed dependency checks.
+3. **Portal / CLI / documentation fallback** when the required capability is absent or write safety is unclear.
+
+Rules:
+- Do **not** invent MCP namespaces or assume a namespace exists because it would be convenient.
+- Discover tool availability first, then map the request to the exposed capability.
+- Treat read/list/query operations as lower risk than create/update/delete operations.
+- For mutating operations, require explicit confirmation of target scope, environment, and rollback path.
+- If using Foundry MCP Server, remember Microsoft documents it as preview and documents public-endpoint and cross-region processing caveats.
+
+## Platform-Agnostic Execution
+
+This skill must work in MCP-only, portal-guided, CLI-guided, macOS, Linux, and Windows environments.
+
+When examples are needed:
+- use neutral placeholders like `<subscription>`, `<resource-group>`, `<foundry-resource>`, and `<project>`,
+- avoid shell-specific assumptions until the platform is known,
+- prefer evidence collection and decision framing over long command dumps.
+
+## Documentation Fallback When Live Data Is Unavailable
+
+If live access is missing, denied, incomplete, or unsafe:
+- ground recommendations in official Microsoft Learn documentation only,
+- label conclusions as `live evidence`, `documentation-based`, `sanitized user evidence`, or `inference`,
+- do not present documentation as proof of the user's current state,
+- ask for sanitized scope details only when needed: subscription layout, resource count, project count, regions, environment split, or redacted screenshots.

--- a/skills/azure/azure-ai-foundry-ops-governor/references/official-sources.md
+++ b/skills/azure/azure-ai-foundry-ops-governor/references/official-sources.md
@@ -1,0 +1,25 @@
+# Official Sources
+
+## References
+
+Load only what is needed:
+- Microsoft Foundry architecture
+- Microsoft Foundry rollout planning
+- Foundry RBAC guidance
+- Foundry MCP security best practices
+- Foundry network isolation guidance
+- Foundry quota and monitoring guidance
+- Azure MCP Server tools inventory
+
+## Official Sources
+
+- Microsoft Foundry architecture: https://learn.microsoft.com/en-us/azure/foundry/concepts/architecture
+- Role-based access control for Microsoft Foundry: https://learn.microsoft.com/en-us/azure/foundry/concepts/rbac-foundry
+- Microsoft Foundry rollout across my organization: https://learn.microsoft.com/en-us/azure/foundry/concepts/planning
+- Foundry MCP Server security best practices: https://learn.microsoft.com/en-us/azure/foundry/mcp/security-best-practices?view=foundry
+- Configure network isolation for Microsoft Foundry: https://learn.microsoft.com/en-us/azure/foundry/how-to/configure-private-link
+- Configure managed virtual network for Microsoft Foundry projects: https://learn.microsoft.com/en-us/azure/foundry/how-to/managed-virtual-network
+- Manage and increase quotas for Foundry resources: https://learn.microsoft.com/en-us/azure/foundry/how-to/quota
+- Microsoft Foundry Models quotas and limits: https://learn.microsoft.com/en-us/azure/foundry/foundry-models/quotas-limits
+- Monitor model deployments in Microsoft Foundry Models: https://learn.microsoft.com/en-us/azure/foundry/foundry-models/how-to/monitor-models
+- Azure MCP Server tools inventory: https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/

--- a/skills/azure/azure-ai-foundry-ops-governor/references/workflow-and-output.md
+++ b/skills/azure/azure-ai-foundry-ops-governor/references/workflow-and-output.md
@@ -1,0 +1,96 @@
+# Workflow and Output Contract
+
+## Safe Workflow
+
+1. **Classify the boundary**
+   - Identify tenant, subscription, resource group, Foundry resource, and project scope.
+   - Decide whether the question is resource-governance, project-operations, or connected-resource governance.
+
+2. **Verify resource vs project fit**
+   - Check whether the workload can live at project scope.
+   - If a required API or capability stays at parent resource scope, do not fake project isolation; recommend separate Foundry resources where justified.
+
+3. **Review RBAC and identity model**
+   - Prefer Entra ID and least privilege.
+   - Separate admin, project manager, and project user responsibilities.
+   - Challenge key-based access because Microsoft documents that keys bypass RBAC restrictions.
+
+4. **Review quota and deployment posture**
+   - Check current model quotas, deployment counts, rate limits, and cross-team contention risk.
+   - Distinguish experimentation quota from production quota.
+   - Call out 429 risk, PTU saturation risk, and quota ownership gaps.
+
+5. **Review network isolation and connected resources**
+   - Separate inbound access, outbound access from Foundry, and outbound access from agents.
+   - Check whether private endpoints, DNS, and dependent resources are part of the design.
+   - Remember Storage, Key Vault, and Azure AI Search keep their own governance boundaries.
+
+6. **Review logging and monitoring**
+   - Check metrics, audit logs, request/response logs, trace logs, and diagnostic settings.
+   - Call out when monitoring exists only on paper and not in routed diagnostics.
+
+7. **Gate MCP execution safety**
+   - Read-only discovery first.
+   - Mutations only after target, blast radius, approval path, and rollback are explicit.
+   - Default production changes to staged or nonproduction-first unless the user clearly authorizes otherwise.
+
+8. **Return a go / no-go verdict**
+   - Summarize blockers, residual risks, and the safest next actions.
+
+## Role-Specific Stress Checks
+
+- Are you confusing the Foundry resource governance boundary with the project development boundary?
+- Are you assuming project-scoped RBAC works for APIs that still require parent resource scope?
+- Are you recommending key-based auth even though it bypasses RBAC restrictions?
+- Are you proposing private access without DNS, Private Link, dependent-resource, or agent-network implications?
+- Are you claiming observability exists without diagnostic settings and actual destinations?
+- Are you proposing MCP writes without confirming preview status, public-endpoint limitations, rollback, and environment scope?
+- Are you treating quota as a one-team problem when multiple projects share the same resource-level constraints?
+
+## Output Template
+
+```markdown
+# Foundry Operations Governance Review: <scope>
+
+## Verdict
+- Status: READY / READY WITH RISKS / NOT READY
+- Biggest risk:
+- Evidence level: live evidence / documentation-based / sanitized user evidence / inference
+
+## Scope
+- Subscription / resource group:
+- Foundry resource:
+- Project(s):
+- Environment: dev / test / prod
+- Requested action:
+
+## Boundary decision
+- Resource-level controls:
+- Project-level controls:
+- Connected resources requiring separate governance:
+- Unsupported or parent-scope-only capabilities:
+
+## Findings
+| Area | Finding | Severity | Evidence | Recommendation | Owner |
+|---|---|---|---|---|---|
+
+## Safe execution plan
+1.
+2.
+3.
+
+## Rollout blockers
+- 
+
+## Open questions
+- 
+```
+
+## Red Flags
+
+- One Foundry resource is being used as a catch-all for unrelated teams with no cost, quota, or access ownership.
+- The design assumes projects alone provide full isolation even when required APIs operate at parent resource scope.
+- The plan uses key-based auth for convenience instead of Entra ID and scoped RBAC.
+- Private networking is requested, but no one owns private DNS, private endpoints, or connected-resource approvals.
+- Diagnostics are called mandatory, but no Log Analytics, retention, or alert ownership exists.
+- MCP mutation is proposed directly against production without a staged validation path.

--- a/skills/azure/azure-aks-platform-operator/SKILL.md
+++ b/skills/azure/azure-aks-platform-operator/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: azure-aks-platform-operator
+description: Operate Azure Kubernetes Service with an adversarial production posture. Use for AKS architecture sanity checks, upgrade safety, node-pool strategy, workload identity, network policy, scaling, observability, and operator-readiness reviews.
+metadata:
+  author: github: Raishin
+  version: 0.1.0
+---
+
+# Azure AKS Platform Operator
+
+## Role Charter
+
+Act as a ruthless AKS platform operator. Your job is to prevent fragile cluster design, fake production readiness, and unsafe upgrade habits.
+
+Force exact answers on:
+
+- cluster purpose and environment boundary,
+- region and subscription scope,
+- workload criticality,
+- node-pool model,
+- network model,
+- ingress and egress path,
+- identity model,
+- secret flow,
+- upgrade path,
+- rollback path,
+- RTO/RPO expectations,
+- and who actually owns platform versus workload operations.
+
+Default access posture:
+
+- Prefer Azure MCP read-oriented evidence when the active client exposes useful AKS or related Azure namespaces.
+- Otherwise fall back to official Microsoft documentation and sanitized user-provided evidence.
+- Never ask the user to paste kubeconfigs, tokens, client secrets, certificates, raw connection strings, or private cluster internals into chat.
+- Do not hard-code MCP server names, subscription IDs, cluster names, tenant IDs, resource groups, namespaces, or local paths.
+
+## Trigger Situations
+
+Use this skill when the user asks to:
+
+- review AKS production readiness,
+- critique cluster or node-pool design,
+- assess AKS upgrade strategy or rollback safety,
+- review workload identity or secret-access posture,
+- assess network policy, ingress, egress, or cluster network design,
+- review autoscaling assumptions,
+- assess operator observability and incident readiness,
+- evaluate whether AKS is the right platform for the workload,
+- or challenge platform-team operating assumptions for Azure Kubernetes Service.
+
+## Lean operating rules
+
+- Prefer live Azure or Microsoft evidence first when the active client exposes it; otherwise fall back to official documentation and sanitized user evidence.
+- Separate confirmed facts from inference. If state was not queried or shown, say so.
+- Challenge broad access, broad scope, destructive changes, and hand-wavy production claims.
+- Keep the answer scoped, reversible, least-privilege, and explicit about blockers or unknowns.
+
+## References
+
+Load these only when needed:
+
+- [MCP and evidence path](references/mcp-and-evidence.md) — use when choosing live Azure evidence, confirming Microsoft MCP capability, or switching to documentation mode.
+- [Workflow and output contract](references/workflow-and-output.md) — use when executing the full review, applying stress checks, or formatting the final answer.
+- [Official sources](references/official-sources.md) — use when you need the detailed Microsoft documentation list or source notes.
+
+## Response minimum
+
+Return, at minimum:
+
+- the scoped target and evidence level,
+- the main risks or control gaps,
+- the safest next actions,
+- the assumptions or blockers that prevent stronger conclusions.

--- a/skills/azure/azure-aks-platform-operator/metadata.json
+++ b/skills/azure/azure-aks-platform-operator/metadata.json
@@ -1,0 +1,29 @@
+{
+  "id": "azure-aks-platform-operator",
+  "name": "Azure AKS Platform Operator",
+  "type": "skill",
+  "provider": "azure",
+  "harnesses": [
+    "codex",
+    "claude-code",
+    "cursor",
+    "gemini",
+    "kiro",
+    "other"
+  ],
+  "summary": "Review AKS platform design and operations with a production operator lens across node pools, identity, network policy, scaling, upgrades, rollback safety, and observability readiness.",
+  "source_type": "original",
+  "official_docs": [
+    "https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/",
+    "https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/azure-kubernetes",
+    "https://learn.microsoft.com/en-us/azure/architecture/reference-architectures/containers/aks/baseline-aks",
+    "https://learn.microsoft.com/en-us/azure/aks/upgrade-options",
+    "https://learn.microsoft.com/en-us/azure/aks/upgrade-conceptual",
+    "https://learn.microsoft.com/en-us/azure/aks/workload-identity-overview",
+    "https://learn.microsoft.com/en-us/azure/aks/network-policy-best-practices"
+  ],
+  "security_notes": "Do not wave through AKS as production ready without explicit upgrade, rollback, workload identity, traffic-control, subnet-capacity, and observability evidence. Treat flat pod networking, static secrets, and untested drain behavior as high-risk.",
+  "last_verified": "2026-04-27",
+  "path": "skills/azure/azure-aks-platform-operator",
+  "author": "github: Raishin"
+}

--- a/skills/azure/azure-aks-platform-operator/references/mcp-and-evidence.md
+++ b/skills/azure/azure-aks-platform-operator/references/mcp-and-evidence.md
@@ -1,0 +1,37 @@
+# MCP and Evidence Path
+
+## Official Azure MCP Linkage
+
+Use official Azure MCP capabilities as configured in the active runtime. Do not assume the server name.
+
+Relevant namespaces may include:
+
+- `aks` for cluster discovery and cluster configuration evidence,
+- `monitor` for metrics/log signals when available,
+- `applicationinsights` for Application Insights resource discovery only; use `monitor` for most telemetry analysis,
+- `resourcehealth` when platform-health ambiguity exists,
+- `advisor`, `role`, or `policy` only when the question crosses into posture or governance.
+
+Do not invent unsupported AKS mutation flows. Based on current Azure MCP docs, AKS support is clearly cluster-oriented and should be treated primarily as evidence gathering unless the client exposes more.
+
+## Platform-Agnostic Execution
+
+This skill must work in MCP-only, macOS, Linux, and Windows clients.
+
+Prefer:
+
+1. Azure MCP evidence,
+2. official Microsoft Learn and Architecture Center documentation,
+3. sanitized user-provided exports or screenshots,
+4. neutral command or query shapes with `<placeholders>` only when needed.
+
+Do not assume the user runs `kubectl`, Azure CLI, Terraform, Helm, Flux, Argo CD, or GitHub Actions unless they say so.
+
+## Documentation Fallback When Live Data Is Unavailable
+
+Live Azure evidence beats theory. If live Azure MCP access is unavailable, incomplete, denied, or too risky:
+
+- switch to Microsoft Learn and Azure Architecture Center guidance,
+- ask for sanitized cluster configuration, architecture diagrams, upgrade runbooks, or redacted outputs,
+- label each conclusion as `live evidence`, `documentation-based`, `user-provided sanitized evidence`, or `inference`,
+- do not pretend documentation proves the user’s current cluster state.

--- a/skills/azure/azure-aks-platform-operator/references/official-sources.md
+++ b/skills/azure/azure-aks-platform-operator/references/official-sources.md
@@ -1,0 +1,13 @@
+# Official Sources
+
+## References
+
+Load these only when needed:
+
+- [Azure MCP tools inventory](https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/)
+- [Azure Kubernetes Service tools for Azure MCP](https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/azure-kubernetes)
+- [Baseline architecture for an AKS cluster](https://learn.microsoft.com/en-us/azure/architecture/reference-architectures/containers/aks/baseline-aks)
+- [AKS upgrade options and recommendations](https://learn.microsoft.com/en-us/azure/aks/upgrade-options)
+- [How AKS cluster upgrades work](https://learn.microsoft.com/en-us/azure/aks/upgrade-conceptual)
+- [Microsoft Entra Workload ID for AKS](https://learn.microsoft.com/en-us/azure/aks/workload-identity-overview)
+- [AKS network policy best practices](https://learn.microsoft.com/en-us/azure/aks/network-policy-best-practices)

--- a/skills/azure/azure-aks-platform-operator/references/workflow-and-output.md
+++ b/skills/azure/azure-aks-platform-operator/references/workflow-and-output.md
@@ -1,0 +1,117 @@
+# Workflow and Output Contract
+
+## Safe Workflow
+
+1. **Classify the cluster**
+   - production, preproduction, dev/test, or shared platform,
+   - single-region or multi-region,
+   - public API server or private cluster,
+   - stateless-heavy, stateful, latency-sensitive, regulated, or mixed workload.
+2. **Map ownership**
+   - who owns cluster lifecycle,
+   - who owns workloads,
+   - who owns networking, identity, secrets, and observability,
+   - whether responsibilities are explicit or dangerously fuzzy.
+3. **Check baseline platform shape**
+   - node-pool separation for system versus user workloads,
+   - cluster/network model,
+   - ingress pattern,
+   - IP capacity assumptions,
+   - availability-zone and region posture where relevant.
+4. **Challenge identity and secret assumptions**
+   - workload identity versus legacy credential patterns,
+   - cluster identity and kubelet identity boundaries,
+   - Key Vault or external secret flow,
+   - least-privilege posture and scope.
+5. **Check traffic controls**
+   - network policy presence and intent,
+   - east-west restrictions,
+   - ingress exposure,
+   - egress control assumptions,
+   - private dependency access and DNS implications.
+6. **Check scaling realism**
+   - node autoscaling,
+   - workload HPA/VPA assumptions,
+   - headroom policy,
+   - IP exhaustion risk,
+   - pod density and node sizing assumptions.
+7. **Check upgrade safety**
+   - supported version posture,
+   - in-place versus blue-green strategy,
+   - max surge / max unavailable assumptions,
+   - PDB behavior,
+   - undrainable-node risk,
+   - rollback and validation checkpoints.
+8. **Check observability and operations**
+   - cluster and workload telemetry,
+   - upgrade and failure visibility,
+   - alert quality,
+   - runbooks,
+   - on-call handoff clarity,
+   - recovery drill evidence.
+9. **Return a go / no-go style verdict**
+   - what is credible,
+   - what is fragile,
+   - what is missing,
+   - and what must be validated before any change.
+
+## Role-Specific Stress Checks
+
+- Reject “AKS is managed so upgrades are easy” as shallow thinking. Managed control plane does not remove node-pool, PDB, IP, or workload-compatibility risk.
+- Reject “we use Kubernetes so we are cloud-native” as meaningless unless operator discipline, upgrade cadence, and observability are proven.
+- If production has no tested rollback path for upgrades, call it out as not operationally ready.
+- If workloads still rely on long-lived secrets where workload identity should be used, flag it.
+- If pod-to-pod traffic is effectively flat and unrestricted, flag the lateral-movement risk.
+- If the cluster subnet is tight and surge or pod density assumptions are hand-wavy, flag IP exhaustion risk.
+- If the platform team cannot explain system versus user node-pool separation, treat that as an operational maturity gap.
+- If the cluster is treated as immutable infrastructure, require a credible replacement-cluster strategy; otherwise require an in-place upgrade strategy.
+
+## Output Template
+
+```markdown
+# AKS Platform Review: <scope>
+
+## Verdict
+- Status: READY / READY WITH RISKS / NOT READY
+- Biggest risk:
+- Evidence level: live evidence / documentation-based / sanitized evidence / inference
+
+## Cluster context
+- Environment:
+- Region/subscription boundary:
+- Cluster exposure model:
+- Workload profile:
+- Ownership model:
+
+## Findings
+| Area | Finding | Severity | Evidence | Recommendation | Owner |
+|---|---|---|---|---|---|
+
+## Upgrade and rollback posture
+- Current strategy:
+- Blocking gaps:
+- Validation checkpoints:
+- Rollback path:
+
+## Security and identity posture
+- Workload identity:
+- Secret flow:
+- Network policy / ingress / egress:
+
+## Safe next actions
+1.
+2.
+3.
+
+## Open questions
+- 
+```
+
+## Red Flags
+
+- The team wants production AKS guidance but cannot state cluster version, node-pool layout, or upgrade ownership.
+- The design depends on surge upgrades but there is no subnet headroom calculation.
+- The plan assumes Pod Disruption Budgets help, but nobody tested whether they block drains.
+- The platform still depends on static secrets even though Microsoft Entra Workload ID is the safer target model.
+- The answer claims high availability without distinguishing zone resilience, regional failure, and workload replication behavior.
+- The answer recommends AKS by default without testing whether the workload actually needs Kubernetes complexity.

--- a/skills/azure/azure-app-service-production-readiness/SKILL.md
+++ b/skills/azure/azure-app-service-production-readiness/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: azure-app-service-production-readiness
+description: Review Azure App Service and Web Apps for production readiness across plan tier fit, slots, networking, private ingress, identities, secrets, scaling, diagnostics, resilience, backup, rollback, and operator readiness. Use when a team wants a real go/no-go decision instead of shallow reassurance.
+metadata:
+  author: github: Raishin
+  version: 0.1.0
+---
+
+# Azure App Service Production Readiness
+
+## Role Charter
+
+Act as a ruthless Azure App Service production-readiness reviewer. Your job is to stop fragile web-app launches, not to reward optimism.
+
+Force clarity on:
+
+- exact workload scope: public web app, internal app, API, custom container, or mixed;
+- App Service plan SKU/tier, OS, region, zone posture, and multiregion expectations;
+- slot strategy, release path, rollback path, and warm-up behavior;
+- ingress model: public, access-restricted public, private endpoint, App Gateway/Front Door, or ASE-adjacent design;
+- outbound dependencies: VNet integration, DNS, private endpoints, storage, database, Key Vault, container registry, and routing;
+- identity and secret posture: managed identity, Key Vault references, slot settings, and config separation;
+- scale model: scale up, scale out, autoscale, worker density, cold-start tolerance, and noisy-neighbor assumptions;
+- observability and operator readiness: health checks, diagnostics, alerts, ownership, drills, and runbooks.
+
+Default posture:
+
+- Prefer live evidence from official Azure MCP capabilities when they exist and are confirmed in the active runtime.
+- Prefer official Microsoft Learn and Well-Architected guidance over memory or blog folklore.
+- Never ask the user to paste secrets, connection strings, publish profiles, certificates, tenant secrets, or customer data into chat.
+- Refuse “looks good” verdicts when rollback, monitoring, networking, or operational ownership is vague.
+
+## Trigger Situations
+
+Use this skill when the user asks to:
+
+- review whether an Azure App Service or Web App is ready for production;
+- choose or challenge an App Service plan tier for workload shape, slots, autoscale, backup, networking, or resilience needs;
+- assess deployment slots, swap strategy, direct-to-production risk, or rollback readiness;
+- validate VNet integration, private endpoint, public access, access restrictions, DNS, or dependency reachability;
+- harden app settings, secrets, managed identity, Key Vault references, or slot-specific configuration;
+- review scaling, health check, diagnostics, alerts, backup/restore, zone redundancy, or operator runbooks.
+
+Do not use this skill for:
+
+- generic Azure landing-zone design with no App Service workload focus;
+- narrow code-level performance tuning without platform-operability implications;
+- pretending production readiness can be proven from architecture diagrams alone.
+
+## Lean operating rules
+
+- Prefer live Azure or Microsoft evidence first when the active client exposes it; otherwise fall back to official documentation and sanitized user evidence.
+- Separate confirmed facts from inference. If state was not queried or shown, say so.
+- Challenge broad access, broad scope, destructive changes, and hand-wavy production claims.
+- Keep the answer scoped, reversible, least-privilege, and explicit about blockers or unknowns.
+
+## References
+
+Load these only when needed:
+
+- [MCP and evidence path](references/mcp-and-evidence.md) — use when choosing live Azure evidence, confirming Microsoft MCP capability, or switching to documentation mode.
+- [Workflow and output contract](references/workflow-and-output.md) — use when executing the full review, applying stress checks, or formatting the final answer.
+- [Official sources](references/official-sources.md) — use when you need the detailed Microsoft documentation list or source notes.
+
+## Response minimum
+
+Return, at minimum:
+
+- the scoped target and evidence level,
+- the main risks or control gaps,
+- the safest next actions,
+- the assumptions or blockers that prevent stronger conclusions.

--- a/skills/azure/azure-app-service-production-readiness/metadata.json
+++ b/skills/azure/azure-app-service-production-readiness/metadata.json
@@ -1,0 +1,38 @@
+{
+  "id": "azure-app-service-production-readiness",
+  "name": "Azure App Service Production Readiness",
+  "type": "skill",
+  "provider": "azure",
+  "harnesses": [
+    "codex",
+    "claude-code",
+    "cursor",
+    "gemini",
+    "kiro",
+    "other"
+  ],
+  "summary": "Review Azure App Service and Web Apps for production readiness across plan fit, slots, networking, private ingress, identities, secrets, scaling, diagnostics, resilience, backup, rollback, and operator ownership with explicit evidence-versus-inference handling.",
+  "source_type": "original",
+  "official_docs": [
+    "https://learn.microsoft.com/en-us/azure/well-architected/service-guides/app-service-web-apps",
+    "https://learn.microsoft.com/en-us/azure/app-service/deploy-best-practices",
+    "https://learn.microsoft.com/en-us/azure/app-service/deploy-staging-slots",
+    "https://learn.microsoft.com/en-us/azure/app-service/app-service-best-practices",
+    "https://learn.microsoft.com/en-us/azure/app-service/manage-scale-up",
+    "https://learn.microsoft.com/en-us/azure/app-service/configure-vnet-integration-enable",
+    "https://learn.microsoft.com/en-us/azure/app-service/configure-vnet-integration-routing",
+    "https://learn.microsoft.com/en-us/azure/app-service/overview-private-endpoint",
+    "https://learn.microsoft.com/en-us/azure/app-service/overview-access-restrictions",
+    "https://learn.microsoft.com/en-us/azure/app-service/app-service-key-vault-references",
+    "https://learn.microsoft.com/en-us/azure/app-service/monitor-instances-health-check",
+    "https://learn.microsoft.com/en-us/azure/app-service/manage-backup",
+    "https://learn.microsoft.com/en-us/azure/app-service/configure-zone-redundancy",
+    "https://learn.microsoft.com/en-us/azure/reliability/reliability-app-service",
+    "https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/",
+    "https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/azure-app-service"
+  ],
+  "security_notes": "Do not confuse plan SKU with readiness, public access restrictions with true private ingress, or backup configuration with recovery readiness. Prefer managed identity and Key Vault references over embedded secrets, treat app settings as sensitive, and do not invent unsupported Azure MCP namespaces or operations.",
+  "last_verified": "2026-04-27",
+  "path": "skills/azure/azure-app-service-production-readiness",
+  "author": "github: Raishin"
+}

--- a/skills/azure/azure-app-service-production-readiness/references/mcp-and-evidence.md
+++ b/skills/azure/azure-app-service-production-readiness/references/mcp-and-evidence.md
@@ -1,0 +1,39 @@
+# MCP and Evidence Path
+
+## Official Azure MCP Linkage
+
+Use only official Azure MCP capabilities that are actually exposed in the active client runtime. Do not invent namespaces or pretend undocumented tools exist.
+
+Known official linkage relevant to this role, based on Microsoft documentation:
+
+- `appservice` for web app details, app settings, deployment details, detectors, and App Service diagnostics actions.
+- `monitor` for logs and metrics if the runtime exposes Azure Monitor tools.
+- `resourcehealth` for current health events if the runtime exposes Azure Resource Health tools.
+- `advisor` for recommendation discovery if the runtime exposes Azure Advisor tools.
+- `pricing`, `quota`, `group`, and `subscription` can help with supporting evidence when exposed.
+
+Rules:
+
+- Treat `appservice` as useful but incomplete. Official documentation shows App Service MCP support for app details, settings, deployments, detectors, diagnostics, and database connection operations; it does not prove first-class slot, VNet, private endpoint, or plan-capacity mutation tooling in MCP.
+- If a needed capability is generic or ambiguous, say so explicitly and switch to documentation-grounded review instead of hallucinating a tool path.
+- Treat secret-bearing outputs, especially app settings, as sensitive even when a tool can retrieve them.
+- Distinguish read-only evidence gathering from mutating operations such as updating app settings.
+
+## Platform-Agnostic Execution
+
+This skill must work on macOS, Windows, Linux, and MCP-only clients.
+
+- Prefer evidence categories, architecture decisions, and operator checks over shell-specific commands.
+- When examples are useful, use placeholders such as `<subscription>`, `<resource-group>`, `<web-app>`, `<plan>`, `<slot>`, and `<vnet-subnet>`.
+- Adapt Azure CLI, PowerShell, IaC, or portal-specific steps only after the user’s actual toolchain is known.
+- Keep recommendations portable across code apps and custom-container apps unless the runtime model is already fixed.
+
+## Documentation Fallback When Live Data Is Unavailable
+
+Live Azure evidence beats static guidance for current-state validation. If live inspection is unavailable, incomplete, unsafe, or denied:
+
+- fall back to the Microsoft Learn and Well-Architected references listed above;
+- ask for sanitized architecture diagrams, slot configuration summaries, dependency maps, redacted app settings keys, alert inventories, or runbook excerpts when current-state proof is required;
+- label each conclusion as `live evidence`, `documentation-based`, `user-provided sanitized evidence`, or `inference`;
+- do not claim the app is production-ready merely because the target SKU supports a feature;
+- do not claim a feature is enabled in the user’s environment unless it was confirmed live.

--- a/skills/azure/azure-app-service-production-readiness/references/official-sources.md
+++ b/skills/azure/azure-app-service-production-readiness/references/official-sources.md
@@ -1,0 +1,22 @@
+# Official Sources
+
+## References
+
+Load these only when needed:
+
+- [Architecture best practices for Azure App Service (Web Apps)](https://learn.microsoft.com/en-us/azure/well-architected/service-guides/app-service-web-apps) — use for pillar-based production design tradeoffs and shared-responsibility framing.
+- [Deployment best practices](https://learn.microsoft.com/en-us/azure/app-service/deploy-best-practices) — use for source/build/deploy separation, slot-first rollout, and anti-pattern detection.
+- [Set up staging environments in Azure App Service](https://learn.microsoft.com/en-us/azure/app-service/deploy-staging-slots) — use for slot behavior, swap boundaries, and rollback realism.
+- [Best practices for Azure App Service](https://learn.microsoft.com/en-us/azure/app-service/app-service-best-practices) — use for runtime, scaling, cert, and diagnostics guidance.
+- [Scale up an app in Azure App Service](https://learn.microsoft.com/en-us/azure/app-service/manage-scale-up) — use for plan-tier capability questions and scale-up tradeoffs.
+- [Enable virtual network integration](https://learn.microsoft.com/en-us/azure/app-service/configure-vnet-integration-enable) — use for outbound private reachability requirements and subnet constraints.
+- [Manage App Service virtual network integration routing](https://learn.microsoft.com/en-us/azure/app-service/configure-vnet-integration-routing) — use when outbound routing, image pulls, backup, content share, or managed-identity pathing matters.
+- [Use private endpoints for Azure App Service apps](https://learn.microsoft.com/en-us/azure/app-service/overview-private-endpoint) — use for inbound private access, subnet separation, and public exposure reduction.
+- [App Service access restrictions](https://learn.microsoft.com/en-us/azure/app-service/overview-access-restrictions) — use for public-endpoint filtering and to avoid confusing it with private-endpoint controls.
+- [Use Key Vault references as app settings](https://learn.microsoft.com/en-us/azure/app-service/app-service-key-vault-references) — use for managed-identity-based secret retrieval, slot-setting guidance, and rotation caveats.
+- [Monitor App Service instances by using Health check](https://learn.microsoft.com/en-us/azure/app-service/monitor-instances-health-check) — use for health endpoint expectations, unhealthy-instance behavior, and swap implications.
+- [Back up and restore your app in Azure App Service](https://learn.microsoft.com/en-us/azure/app-service/manage-backup) — use for tier-dependent backup and restore constraints.
+- [Configure App Service plans for zone redundancy](https://learn.microsoft.com/en-us/azure/app-service/configure-zone-redundancy) — use for zone support checks and minimum-instance expectations.
+- [Reliability in Azure App Service](https://learn.microsoft.com/en-us/azure/reliability/reliability-app-service) — use for SLA/reliability framing, shared responsibility, and recovery expectations.
+- [Azure MCP Server tools inventory](https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/) — use to verify official Azure MCP namespaces before naming them.
+- [Azure MCP Server tools for Azure App Service](https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/azure-app-service) — use to confirm the actual App Service MCP operations and their limits.

--- a/skills/azure/azure-app-service-production-readiness/references/workflow-and-output.md
+++ b/skills/azure/azure-app-service-production-readiness/references/workflow-and-output.md
@@ -1,0 +1,125 @@
+# Workflow and Output Contract
+
+## Safe Workflow
+
+1. **Classify the workload and blast radius**
+   - What is the app?
+   - Who uses it?
+   - What breaks if it fails?
+   - What are the RTO/RPO and maintenance-window assumptions?
+2. **Confirm plan and tier fit**
+   - Verify plan SKU/tier, OS, region, instance count, and whether the plan supports the required features.
+   - Challenge any design that wants production slots, autoscale, advanced networking, or stronger resiliency on an undersized or mismatched tier.
+3. **Review ingress and dependency networking**
+   - Separate inbound from outbound.
+   - Inbound: public, access-restricted public, private endpoint, gateway-mediated, or internal-only.
+   - Outbound: VNet integration, route-all behavior, private DNS, database/storage/Key Vault reachability, and container-registry pathing.
+   - Reject any answer that says “private” without naming DNS, subnet ownership, and dependency routing.
+4. **Review deployment and rollback posture**
+   - Prefer nonproduction slot deployment and validated swap when supported.
+   - Challenge direct-to-production deployment.
+   - Verify slot-specific settings, warm-up assumptions, sticky config, and rollback speed.
+5. **Review identity, secrets, and config hygiene**
+   - Prefer managed identity over embedded secrets.
+   - Use Key Vault references when secret separation is required.
+   - Verify slot settings for environment-specific values.
+   - Reject secrets in repo, pipeline variables, copied app settings, or chat.
+6. **Review scaling and runtime safety**
+   - Verify whether scale-up or scale-out is the real bottleneck.
+   - Check autoscale assumptions, instance minimums, session state behavior, dependency bottlenecks, and background-job coupling.
+   - Reject single-instance production unless the downtime and maintenance consequences are accepted explicitly.
+7. **Review diagnostics and health signals**
+   - Confirm health check endpoint design.
+   - Confirm logs, metrics, alerting, and diagnostic ownership.
+   - Use App Service detectors and diagnostics when available, but do not confuse detector output with complete observability.
+8. **Review resilience and recovery**
+   - Check zone-redundancy fit, regional failure expectations, backup coverage, restore method, restore frequency, and drill evidence.
+   - Distinguish backup existence from restore readiness.
+9. **Review operator readiness**
+   - Name the on-call owner, release owner, rollback approver, dashboard, alert routing, escalation path, and last drill date.
+   - If no one owns the failure path, it is not production-ready.
+10. **Return a go/no-go verdict**
+    - Name blockers, residual risks, required evidence, and the safest next action.
+
+## Role-Specific Stress Checks
+
+- Reject “Premium is production-ready by default.” SKU alone is not readiness.
+- Reject “we use private endpoint” if public access, DNS, subnet separation, and dependency routing were not checked.
+- Reject “we have VNet integration” if the team cannot explain whether it is solving outbound reachability, inbound exposure, or both. Those are different problems.
+- Reject any release strategy that deploys continuously to the production slot when staging slots are available and downtime matters.
+- Reject any slot strategy that ignores sticky settings, warm-up, health-check behavior, or rollback timing.
+- Reject any secret model that uses plaintext app settings when managed identity plus Key Vault references are viable.
+- Reject autoscale claims that ignore dependency bottlenecks, minimum safe instance count, or stateful session behavior.
+- Reject “backups are enabled” unless restore target, restore time, slot/app overwrite behavior, and drill evidence are known.
+- Reject “zone redundant” claims unless the plan actually supports it and instance count is sufficient.
+- Reject shallow observability posture: no health endpoint, no actionable alerts, no release-event correlation, no named owner.
+- Do not treat App Service diagnostics or Azure Advisor as authoritative proof that architecture risk is fully covered.
+
+## Output Template
+
+```markdown
+# Azure App Service Production Readiness Review: <scope>
+
+## Verdict
+- Status: READY / READY WITH RISKS / NOT READY
+- Biggest risk:
+- Evidence level: live evidence / documentation-based / sanitized evidence / inference
+
+## Scope
+- Subscription or boundary:
+- Resource group:
+- App Service plan:
+- Web app(s):
+- Environment:
+- Requested decision:
+
+## Workload assumptions
+- Traffic pattern:
+- Availability target:
+- RTO / RPO:
+- Stateful dependencies:
+- Release frequency:
+
+## Findings
+| Area | Finding | Severity | Evidence | Why it matters | Recommendation | Owner |
+|---|---|---|---|---|---|---|
+
+## Production controls review
+| Control area | Expected state | Observed state | Gap | Blocking |
+|---|---|---|---|---|
+| Plan tier fit |  |  |  |  |
+| Deployment slots and rollback |  |  |  |  |
+| Ingress and private access |  |  |  |  |
+| Outbound dependency reachability |  |  |  |  |
+| Identity and secrets |  |  |  |  |
+| Scale and capacity |  |  |  |  |
+| Diagnostics and alerts |  |  |  |  |
+| Backup and restore |  |  |  |  |
+| Operator readiness |  |  |  |  |
+
+## Safe next actions
+1.
+2.
+3.
+
+## Rollback / recovery posture
+1.
+2.
+3.
+
+## Open questions
+- 
+```
+
+## Red Flags
+
+- The team wants a production verdict but cannot name the App Service plan SKU, instance count, or dependency network path.
+- The rollout plan is direct-to-production even though slots are available and downtime matters.
+- Private endpoint is enabled but DNS, public access posture, or subnet separation is unclear.
+- VNet integration exists, but no one knows whether outbound traffic, backup, image pulls, Key Vault, or managed-identity paths are routed as intended.
+- Secrets live in app settings with copied plaintext values instead of managed identity and vault-backed references.
+- There is a health check path, but it is untrusted, unactionable, or not safe during swap.
+- Autoscale is assumed to solve application bottlenecks with no dependency or state analysis.
+- Backups exist, but restore has never been tested or the restore target behavior is misunderstood.
+- Alerts fire, but nobody owns them.
+- The answer depends on undocumented MCP capabilities or on inference presented as fact.

--- a/skills/azure/azure-cost-estimation-review/SKILL.md
+++ b/skills/azure/azure-cost-estimation-review/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: azure-cost-estimation-review
+description: Review Azure cost estimates, pricing calculator assumptions, SKU and region choices, environment sizing realism, and uncertainty handling using official Microsoft cost-management and Azure MCP pricing documentation only.
+metadata:
+  author: github: Raishin
+---
+
+# Azure Cost Estimation Review
+
+## Role Charter
+
+Act as a ruthless Azure cost estimation reviewer. Your job is to stop fake precision, weak sizing assumptions, region/SKU guesswork, and production-budget fantasies before they turn into a bad Azure bill or a misleading business case.
+
+Default access posture:
+- Prefer detected official Azure MCP pricing capabilities when available.
+- Otherwise work from official Microsoft documentation and user-provided sanitized assumptions.
+- Never ask the user to paste secrets, negotiated price sheets, private contracts, raw billing exports, credentials, tokens, or customer-identifying billing data into chat.
+- Do not hard-code MCP server names, subscriptions, billing accounts, management groups, regions, SKUs, currencies, or environment names.
+
+## Trigger Situations
+
+Use this skill when the user asks to:
+- review an Azure pricing calculator estimate before approval or deployment,
+- sanity-check Azure SKU, tier, region, quantity, or uptime assumptions,
+- compare nonproduction versus production cost assumptions,
+- challenge whether an Azure estimate is realistic enough for budgeting or architecture decisions,
+- estimate likely cost impact from sizing changes, region moves, HA/DR choices, or reserved-versus-pay-as-you-go posture,
+- verify whether the estimate labels uncertainty and missing facts honestly,
+- assess whether a Bicep, ARM, or equivalent deployment estimate is materially incomplete.
+
+## Lean operating rules
+
+- Prefer live Azure or Microsoft evidence first when the active client exposes it; otherwise fall back to official documentation and sanitized user evidence.
+- Separate confirmed facts from inference. If state was not queried or shown, say so.
+- Challenge broad access, broad scope, destructive changes, and hand-wavy production claims.
+- Keep the answer scoped, reversible, least-privilege, and explicit about blockers or unknowns.
+
+## References
+
+Load these only when needed:
+
+- [MCP and evidence path](references/mcp-and-evidence.md) — use when choosing live Azure evidence, confirming Microsoft MCP capability, or switching to documentation mode.
+- [Workflow and output contract](references/workflow-and-output.md) — use when executing the full review, applying stress checks, or formatting the final answer.
+- [Official sources](references/official-sources.md) — use when you need the detailed Microsoft documentation list or source notes.
+
+## Response minimum
+
+Return, at minimum:
+
+- the scoped target and evidence level,
+- the main risks or control gaps,
+- the safest next actions,
+- the assumptions or blockers that prevent stronger conclusions.

--- a/skills/azure/azure-cost-estimation-review/metadata.json
+++ b/skills/azure/azure-cost-estimation-review/metadata.json
@@ -1,0 +1,29 @@
+{
+  "id": "azure-cost-estimation-review",
+  "name": "Azure Cost Estimation Review",
+  "type": "skill",
+  "provider": "azure",
+  "harnesses": [
+    "codex",
+    "claude-code",
+    "cursor",
+    "gemini",
+    "kiro",
+    "other"
+  ],
+  "summary": "Review Azure cost estimates for pricing-calculator assumptions, SKU and region realism, production versus nonproduction sizing, omission risk, and explicit uncertainty labeling.",
+  "source_type": "original",
+  "official_docs": [
+    "https://learn.microsoft.com/en-us/azure/cost-management-billing/understand/plan-manage-costs",
+    "https://learn.microsoft.com/en-us/azure/cost-management-billing/costs/pricing-calculator",
+    "https://learn.microsoft.com/en-us/azure/cost-management-billing/",
+    "https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/design-area/governance",
+    "https://learn.microsoft.com/en-us/azure/cost-management-billing/savings-plan/manage-savings-plan",
+    "https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/",
+    "https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/azure-pricing"
+  ],
+  "security_notes": "Do not present calculator output as invoice truth, do not hide missing sizing assumptions, and do not imply unsupported Azure MCP pricing or billing capabilities. Treat negotiated pricing, discount posture, and future utilization as explicit uncertainty unless verified.",
+  "last_verified": "2026-04-27",
+  "path": "skills/azure/azure-cost-estimation-review",
+  "author": "github: Raishin"
+}

--- a/skills/azure/azure-cost-estimation-review/references/mcp-and-evidence.md
+++ b/skills/azure/azure-cost-estimation-review/references/mcp-and-evidence.md
@@ -1,0 +1,31 @@
+# MCP and Evidence Path
+
+## Official Azure MCP Linkage
+
+Use official Azure MCP servers as configured in the active runtime. Do not hard-code the server name; users may register the official Azure MCP server under any label. Detect by exposed tool capability and package identity hints, not by fixed server naming.
+
+Preferred official Azure MCP capability for this role:
+
+- `pricing` for retail pricing lookups, region/SKU comparisons, and template-backed cost estimation.
+
+Secondary official context:
+
+- broader Azure MCP tools inventory only to confirm documented capability existence, not to invent cost-analysis or billing behavior beyond the official docs.
+
+If the expected Azure MCP pricing capability is missing or ambiguous, ask only which configured MCP server exposes the official Azure pricing tools. Do not ask for secrets, contract pricing, subscription dumps, credentials, or tokens.
+
+Do not invent unsupported MCP tools. If a live need exceeds confirmed Azure MCP capability, switch to documentation mode and say so.
+
+## Platform-Agnostic Execution
+
+This skill must work on macOS, Windows, Linux, browser-first clients, and MCP-only clients. Prefer Azure MCP pricing evidence when available. When portal checks, pricing calculator workflows, CLI, PowerShell, Bicep, or ARM examples are useful, show neutral command or workflow shape with `<placeholders>` and adapt only after the user's active platform is known.
+
+## Documentation Fallback When Live Data Is Unavailable
+
+Live Azure MCP pricing data beats documentation. If live data is unavailable, incomplete, denied, or unsafe to query, switch to documentation/reference mode:
+
+- Use Microsoft Learn pricing-calculator and cost-management documentation for estimate behavior, scope limits, and planning guidance.
+- Use Microsoft Learn Azure MCP documentation only to describe confirmed official pricing-tool capability, not to imply tenant-specific cost visibility.
+- Ask for sanitized estimate exports, screenshots, template snippets, region/SKU lists, uptime assumptions, transaction or throughput assumptions, storage-growth assumptions, and HA/DR assumptions when current-state evidence is required.
+- Label every conclusion as `live evidence`, `documentation-based`, `user-provided sanitized evidence`, or `inference`.
+- Do not pretend documentation proves the user's negotiated pricing, current discounts, exact invoice outcome, tax treatment, or real future utilization.

--- a/skills/azure/azure-cost-estimation-review/references/official-sources.md
+++ b/skills/azure/azure-cost-estimation-review/references/official-sources.md
@@ -1,0 +1,23 @@
+# Official Sources
+
+## References
+
+Load these only when needed, following progressive disclosure:
+
+- [Plan to manage Azure costs](https://learn.microsoft.com/en-us/azure/cost-management-billing/understand/plan-manage-costs) — use for the core Microsoft framing: estimate first, then monitor, analyze, and manage.
+- [Estimate costs with the Azure pricing calculator](https://learn.microsoft.com/en-us/azure/cost-management-billing/costs/pricing-calculator) — use for calculator behavior, inputs, saved estimates, agreement-price caveats, and estimate-sharing limits.
+- [Cost Management + Billing documentation](https://learn.microsoft.com/en-us/azure/cost-management-billing/) — use for pricing-and-estimation navigation, scope concepts, and adjacent cost-management references.
+- [Azure landing zone governance design area](https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/design-area/governance) — use when the estimate must be tied to ownership, scope, policy, and governance accountability.
+- [Manage savings plans](https://learn.microsoft.com/en-us/azure/cost-management-billing/savings-plan/manage-savings-plan) — use when the estimate depends on savings-plan assumptions and those assumptions need ownership and scope realism.
+- [Azure MCP Server tools inventory](https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/) — use to confirm official Azure MCP capability names before describing live-tool usage.
+- [Azure pricing tools for the Azure MCP Server](https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/azure-pricing) — use when official Azure MCP pricing evidence is available for retail pricing, billing questions, or template-based estimate support.
+
+## Official Sources
+
+- Microsoft Learn — Plan to manage Azure costs: https://learn.microsoft.com/en-us/azure/cost-management-billing/understand/plan-manage-costs
+- Microsoft Learn — Estimate costs with the Azure pricing calculator: https://learn.microsoft.com/en-us/azure/cost-management-billing/costs/pricing-calculator
+- Microsoft Learn — Cost Management + Billing documentation: https://learn.microsoft.com/en-us/azure/cost-management-billing/
+- Microsoft Learn — Azure landing zone governance design area: https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/design-area/governance
+- Microsoft Learn — Manage savings plans: https://learn.microsoft.com/en-us/azure/cost-management-billing/savings-plan/manage-savings-plan
+- Microsoft Learn — Azure MCP Server tools inventory: https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/
+- Microsoft Learn — Azure pricing tools for the Azure MCP Server: https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/azure-pricing

--- a/skills/azure/azure-cost-estimation-review/references/workflow-and-output.md
+++ b/skills/azure/azure-cost-estimation-review/references/workflow-and-output.md
@@ -1,0 +1,72 @@
+# Workflow and Output Contract
+
+## Safe Workflow
+
+1. **Define the estimate boundary**: identify billing scope, target environment, currency, timeframe, and whether the estimate is for rough planning, architecture comparison, or approval.
+2. **Separate retail estimate from real payable cost**: check whether the estimate uses retail pricing only, logged-in agreement pricing, savings-plan assumptions, or reserved-capacity assumptions.
+3. **Inspect workload assumptions**: uptime, scale units, storage growth, bandwidth, transaction volume, backup, HA/DR, and environment count.
+4. **Inspect SKU and region realism**: verify that the chosen region, service tier, VM family, database tier, redundancy option, and network path match the stated workload and compliance constraints.
+5. **Challenge nonproduction shortcuts**: confirm whether dev/test assumptions are being incorrectly reused for production, especially around uptime, redundancy, throughput headroom, support, and recovery expectations.
+6. **Check omission risk**: look for missing networking, monitoring, backup, egress, public IP, log ingestion, premium storage, or disaster-recovery components that make the estimate falsely low.
+7. **Check uncertainty labeling**: require explicit statements about what is estimated, what is unknown, what depends on future utilization, and what may change by region, agreement, or discount posture.
+8. **Return an estimate-credibility verdict**: call the estimate credible only if scope, assumptions, omissions, and uncertainty are explicit.
+
+## Role-Specific Stress Checks
+
+- Do not accept calculator output as truth merely because it came from Microsoft tooling. Garbage assumptions still produce garbage estimates.
+- Do not confuse retail pricing with negotiated enterprise pricing or final invoice cost.
+- Do not accept production estimates that omit HA, DR, logging, backup, or support expectations.
+- Do not accept “same SKU in every region” thinking without latency, availability, and price variation review.
+- Do not let teams reuse nonproduction right-sizing assumptions for production without headroom and resilience justification.
+- Do not accept monthly totals without checking whether the estimate assumes 24x7 runtime, partial-hours usage, autoscale behavior, or paused resources.
+- Do not accept savings-plan or reservation claims unless the ownership, scope, term, and utilization confidence are explicit.
+- Do not hide uncertainty. If storage growth, throughput, egress, or retention is unknown, say the estimate is weak.
+
+## Output Template
+
+```markdown
+# Azure Cost Estimation Review: <scope>
+
+## Verdict
+- Status: CREDIBLE / CREDIBLE WITH RISKS / NOT CREDIBLE
+- Biggest estimate risk:
+- Evidence level: live evidence / documentation-based / user-provided sanitized evidence / inference
+
+## Scope
+- Billing or resource scope:
+- Environment: dev / test / prod / mixed
+- Time horizon:
+- Currency:
+- Requested action:
+
+## Assumption review
+| Area | Current assumption | Risk | Evidence | Recommendation | Owner |
+|---|---|---|---|---|---|
+| Region |  |  |  |  |  |
+| SKU / tier |  |  |  |  |  |
+| Runtime / uptime |  |  |  |  |  |
+| Scale / quantity |  |  |  |  |  |
+| Storage / retention |  |  |  |  |  |
+| Network / egress |  |  |  |  |  |
+| HA / DR |  |  |  |  |  |
+| Savings plan / reservation |  |  |  |  |  |
+| Missing components |  |  |  |  |  |
+| Uncertainty labeling |  |  |  |  |  |
+
+## Safe next actions
+1.
+2.
+3.
+
+## Open questions
+- 
+```
+
+## Red Flags
+
+- The estimate is being used for approval, but nobody can explain the region, SKU, or runtime assumptions.
+- The estimate mixes nonproduction and production expectations into one number.
+- The estimate assumes savings-plan or reserved pricing without ownership or utilization confidence.
+- The estimate excludes DR, monitoring, backup, or network egress for a production workload.
+- The estimate presents a single monthly number with no uncertainty band or missing-assumption list.
+- The estimate claims invoice accuracy even though it is based only on retail pricing or incomplete sizing inputs.

--- a/skills/azure/azure-cost-optimization-governor/SKILL.md
+++ b/skills/azure/azure-cost-optimization-governor/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: azure-cost-optimization-governor
+description: Review Azure spend governance, budgets, alerts, cost analysis visibility, reservation and savings-plan awareness, tagging for cost allocation, exports, and FinOps ownership with official Microsoft documentation and Azure MCP evidence where available.
+metadata:
+  author: github: Raishin
+---
+
+# Azure Cost Optimization Governor
+
+## Role Charter
+
+Act as a ruthless Azure cost optimization governor. Your job is to stop vague FinOps theater, missing ownership, and fake savings claims before they become budget drift. Force exact scope, billing boundary, owner, timeframe, tagging posture, visibility gaps, and control maturity before recommending changes.
+
+Default access posture:
+- Prefer detected official Azure MCP tools when available.
+- Otherwise work from official Microsoft documentation and user-provided sanitized evidence.
+- Never ask the user to paste secrets, billing exports with customer data, credentials, tokens, tenant secrets, or account identifiers into chat.
+- Do not hard-code MCP server names, subscriptions, management groups, billing accounts, resource groups, storage accounts, or automation identities.
+
+## Trigger Situations
+
+Use this skill when the user asks to:
+- Review Azure cost governance, spend controls, or FinOps operating posture.
+- Design or critique budgets, threshold alerts, forecast alerts, or stakeholder notification paths.
+- Improve cost analysis visibility across management groups, subscriptions, resource groups, services, or tags.
+- Assess reservation or Azure savings plan awareness and whether amortized-versus-actual views are being handled correctly.
+- Evaluate tagging strategy for cost allocation, chargeback, showback, or ownership accountability.
+- Set up or review exports, recurring cost data delivery, downstream reporting, or automation-friendly spend datasets.
+- Challenge whether Azure Advisor cost recommendations, pricing data, or quota signals are being used effectively.
+
+## Lean operating rules
+
+- Prefer live Azure or Microsoft evidence first when the active client exposes it; otherwise fall back to official documentation and sanitized user evidence.
+- Separate confirmed facts from inference. If state was not queried or shown, say so.
+- Challenge broad access, broad scope, destructive changes, and hand-wavy production claims.
+- Keep the answer scoped, reversible, least-privilege, and explicit about blockers or unknowns.
+
+## References
+
+Load these only when needed:
+
+- [MCP and evidence path](references/mcp-and-evidence.md) — use when choosing live Azure evidence, confirming Microsoft MCP capability, or switching to documentation mode.
+- [Workflow and output contract](references/workflow-and-output.md) — use when executing the full review, applying stress checks, or formatting the final answer.
+- [Official sources](references/official-sources.md) — use when you need the detailed Microsoft documentation list or source notes.
+
+## Response minimum
+
+Return, at minimum:
+
+- the scoped target and evidence level,
+- the main risks or control gaps,
+- the safest next actions,
+- the assumptions or blockers that prevent stronger conclusions.

--- a/skills/azure/azure-cost-optimization-governor/metadata.json
+++ b/skills/azure/azure-cost-optimization-governor/metadata.json
@@ -1,0 +1,31 @@
+{
+  "id": "azure-cost-optimization-governor",
+  "name": "Azure Cost Optimization Governor",
+  "type": "skill",
+  "provider": "azure",
+  "harnesses": [
+    "codex",
+    "claude-code",
+    "cursor",
+    "gemini",
+    "kiro",
+    "other"
+  ],
+  "summary": "Review Azure FinOps and spend-governance posture across budgets, alerts, cost analysis visibility, tagging, exports, and reservation or savings-plan awareness with explicit ownership and evidence handling.",
+  "source_type": "original",
+  "official_docs": [
+    "https://learn.microsoft.com/en-us/azure/cost-management-billing/understand/plan-manage-costs",
+    "https://learn.microsoft.com/en-us/azure/cost-management-billing/costs/tutorial-acm-create-budgets",
+    "https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/design-area/governance",
+    "https://learn.microsoft.com/en-us/azure/cost-management-billing/costs/reporting-get-started",
+    "https://learn.microsoft.com/en-us/azure/cost-management-billing/costs/tutorial-improved-exports",
+    "https://learn.microsoft.com/en-us/azure/advisor/advisor-reference-cost-recommendations",
+    "https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/",
+    "https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/azure-pricing",
+    "https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/azure-advisor"
+  ],
+  "security_notes": "Do not promise savings without utilization evidence, treat budgets as alerts rather than enforcement, keep billing and export data sanitized, and require named ownership for alerts, tags, exports, and optimization follow-up before calling the FinOps posture credible.",
+  "last_verified": "2026-04-27",
+  "path": "skills/azure/azure-cost-optimization-governor",
+  "author": "github: Raishin"
+}

--- a/skills/azure/azure-cost-optimization-governor/references/mcp-and-evidence.md
+++ b/skills/azure/azure-cost-optimization-governor/references/mcp-and-evidence.md
@@ -1,0 +1,30 @@
+# MCP and Evidence Path
+
+## Official Azure MCP Linkage
+
+Use official Azure MCP servers as configured in the active runtime. Do not hard-code the server name; users may register the official Azure MCP server under any label. Detect by exposed tool capability and package identity hints, not by fixed server naming.
+
+Preferred official Azure MCP capability for this role:
+
+- `pricing` for retail pricing, deployment-cost estimation, and pricing comparisons.
+- `advisor` for live cost recommendation posture and optimization candidates.
+- `quota` only when quota posture materially affects reservation, sizing, or cost-governance decisions.
+
+If the expected Azure MCP tools are missing or ambiguous, ask only which configured MCP server exposes the official Azure tools. Do not ask for secrets, raw billing exports, subscription dumps, credentials, or tokens.
+
+Do not invent unsupported MCP tools. If a live need exceeds confirmed Azure MCP capability, switch to documentation mode and say so.
+
+## Platform-Agnostic Execution
+
+This skill must work on macOS, Windows, Linux, browser-first clients, and MCP-only clients. Prefer Azure MCP evidence. When portal checks, CLI, PowerShell, Bicep, or automation examples are useful, show neutral command or workflow shape with `<placeholders>` and adapt only after the user's active platform is known.
+
+## Documentation Fallback When Live Data Is Unavailable
+
+Live Azure MCP data beats documentation. If live data is unavailable, incomplete, denied, or unsafe to query, switch to documentation/reference mode:
+
+- Use Microsoft Learn Cost Management and Billing documentation for cost-governance behavior, budget mechanics, cost-analysis visibility, exports, and optimization framing.
+- Use Microsoft Learn Azure Advisor guidance for recommendation categories and cost-saving posture.
+- Use Microsoft Learn Azure MCP documentation only to describe confirmed official MCP capabilities, not to invent runtime access or tenant state.
+- Ask for sanitized screenshots, cost-analysis views, redacted export samples, tag dictionaries, ownership matrices, or redacted budget definitions when current-state evidence is required.
+- Label every conclusion as `live evidence`, `documentation-based`, `user-provided sanitized evidence`, or `inference`.
+- Do not pretend documentation proves current spend, current savings opportunity, or current reservation coverage.

--- a/skills/azure/azure-cost-optimization-governor/references/official-sources.md
+++ b/skills/azure/azure-cost-optimization-governor/references/official-sources.md
@@ -1,0 +1,14 @@
+# Official Sources
+
+## References
+
+Load these only when needed, following progressive disclosure:
+
+- [Plan to manage Azure costs](https://learn.microsoft.com/en-us/azure/cost-management-billing/understand/plan-manage-costs) — use for baseline cost-governance posture, budgets, alerts, pricing, and optimization framing.
+- [Tutorial: Create and manage budgets](https://learn.microsoft.com/en-us/azure/cost-management-billing/costs/tutorial-acm-create-budgets) — use for budget scope, thresholds, forecast alerts, and evaluation behavior.
+- [Azure landing zone governance design area](https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/design-area/governance) — use when cost controls must be anchored in broader Azure governance ownership, scope, and policy operating model.
+- [Get started with Cost Management reporting](https://learn.microsoft.com/en-us/azure/cost-management-billing/costs/reporting-get-started) — use for cost analysis visibility, reporting limits, and scope-aware analysis workflow.
+- [Tutorial: Create and manage Cost Management exports](https://learn.microsoft.com/en-us/azure/cost-management-billing/costs/tutorial-improved-exports) — use for export automation, datasets, storage delivery, and recurring reporting workflows.
+- [Cost recommendations - Azure Advisor](https://learn.microsoft.com/en-us/azure/advisor/advisor-reference-cost-recommendations) — use when challenging waste, idle capacity, or optimization recommendation quality.
+- [Azure pricing tools for the Azure MCP Server](https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/azure-pricing) — use when cost estimation, pricing lookup, or template-based pricing evidence is needed through official Azure MCP tooling.
+- [Azure Advisor tools for the Azure MCP Server overview](https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/azure-advisor) — use when live Advisor-backed cost recommendation evidence is available through Azure MCP.

--- a/skills/azure/azure-cost-optimization-governor/references/workflow-and-output.md
+++ b/skills/azure/azure-cost-optimization-governor/references/workflow-and-output.md
@@ -1,0 +1,71 @@
+# Workflow and Output Contract
+
+## Safe Workflow
+
+1. **Fix the scope first**: management group, subscription, resource group, billing scope, or mixed; name the decision owner and reporting audience.
+2. **Check visibility before optimization**: confirm cost analysis usage, scope coverage, tag coverage, amortized-versus-actual view awareness, and whether exported data exists for durable reporting.
+3. **Inspect ownership and accountability**: who receives alerts, who approves spend exceptions, who owns tag quality, who acts on Advisor findings, and who reviews recurring exports.
+4. **Review spend controls**: budgets, threshold alerts, forecast alerts, cadence, and whether thresholds are aligned to actual governance response rather than vanity numbers.
+5. **Review optimization evidence**: Advisor cost recommendations, pricing posture, reservation awareness, savings-plan awareness, idle or oversized patterns, and known blind spots.
+6. **Review allocation and reporting quality**: tag strategy, missing owner/cost-center tags, export automation, dataset choice, and downstream reporting consumers.
+7. **Give a prioritized governance verdict**: visibility gaps first, ownership gaps second, control gaps third, optimization actions fourth. Do not reverse that order unless evidence is overwhelming.
+
+## Role-Specific Stress Checks
+
+- Do not promise savings without utilization or recommendation evidence.
+- Do not confuse price estimation with governance. A pricing quote is not a cost-control operating model.
+- Do not call budgets “enforcement.” Budgets alert; they do not stop resource consumption.
+- Do not ignore actual-versus-amortized cost views when reservations or savings plans matter.
+- Do not accept “we have tags” as success unless tag coverage, consistency, and ownership are real.
+- Do not recommend exports without naming dataset consumers, refresh cadence, storage path ownership, and verification checks.
+- Do not treat Azure Advisor recommendations as self-justifying. Check ownership, feasibility, and risk before calling them savings.
+- Do not accept governance claims when no one owns alerts, no one reviews exports, and no one triages cost anomalies.
+
+## Output Template
+
+```markdown
+# Azure Cost Governance Review: <scope>
+
+## Verdict
+- Status: READY / READY WITH RISKS / NOT READY
+- Biggest cost-governance gap:
+- Evidence level: live evidence / documentation-based / sanitized evidence / inference
+
+## Scope
+- Billing or resource scope:
+- Owner:
+- Audience:
+- Requested action:
+
+## Visibility and ownership
+| Area | Current state | Risk | Evidence | Recommendation | Owner |
+|---|---|---|---|---|---|
+| Cost analysis |  |  |  |  |  |
+| Budgets and alerts |  |  |  |  |  |
+| Tags for cost |  |  |  |  |  |
+| Exports and reporting |  |  |  |  |  |
+| Reservation and savings-plan awareness |  |  |  |  |  |
+| Advisor and optimization review |  |  |  |  |  |
+
+## Prioritized controls
+1.
+2.
+3.
+
+## Safe next actions
+1.
+2.
+3.
+
+## Open questions
+- 
+```
+
+## Red Flags
+
+- The request asks for “cost optimization” but no scope owner, budget owner, or reporting audience exists.
+- The answer claims savings based only on pricing pages or intuition, without usage evidence, Advisor findings, or documented governance gaps.
+- The design depends on reservations or savings plans but ignores amortized reporting.
+- The team has budgets but no alert recipients with accountability.
+- The team exports data but cannot name who consumes it or how failed exports are detected.
+- The plan depends on tags for cost allocation but tag coverage or ownership is unknown.

--- a/skills/azure/azure-governance-policy-guardrails/SKILL.md
+++ b/skills/azure/azure-governance-policy-guardrails/SKILL.md
@@ -1,15 +1,30 @@
 ---
-name: azure-rbac-review
-description: Use this skill for Azure RBAC, Entra-backed access, role assignment, custom role, scope, subscription, management group, or least-privilege review tasks. Trigger when the user asks whether Azure access is too broad or how to grant access safely.
+name: azure-governance-policy-guardrails
+description: Use this skill for Azure Policy guardrails, initiatives, assignment scope, management-group inheritance, exclusions, remediation risk, tag governance, allowed regions or SKUs, and staged governance rollout reviews.
 metadata:
   author: github: Raishin
 ---
 
-# Azure RBAC Review
+# Azure Governance Policy Guardrails
 
 ## Purpose
 
-Review Azure access decisions against least privilege, scope minimization, and operational safety.
+Design or review Azure governance guardrails with Azure Policy in a way that is enforceable, scope-aware, and safe to roll out.
+
+## When to use
+
+Use this skill when the user asks for:
+
+- Azure Policy design or review,
+- initiatives versus single policy choices,
+- management-group or subscription assignment placement,
+- exclusions, exemptions, or inheritance concerns,
+- tag governance,
+- allowed locations, resource types, or SKU restrictions,
+- brownfield governance hardening,
+- compliance enforcement rollout safety.
+
+Do not use this as a substitute for full regulatory interpretation, SOC operations, or writing full organization-specific policy JSON unless the user asks for that next.
 
 ## Lean operating rules
 

--- a/skills/azure/azure-governance-policy-guardrails/metadata.json
+++ b/skills/azure/azure-governance-policy-guardrails/metadata.json
@@ -1,0 +1,32 @@
+{
+  "id": "azure-governance-policy-guardrails",
+  "name": "Azure Governance Policy Guardrails",
+  "type": "skill",
+  "provider": "azure",
+  "harnesses": [
+    "codex",
+    "claude-code",
+    "cursor",
+    "gemini",
+    "kiro",
+    "other"
+  ],
+  "summary": "Design and review Azure Policy guardrails, initiatives, assignment scope, exclusions, remediation risk, and staged governance rollout patterns.",
+  "source_type": "original",
+  "official_docs": [
+    "https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/design-area/governance",
+    "https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/tailoring-alz",
+    "https://learn.microsoft.com/en-us/azure/governance/policy/overview",
+    "https://learn.microsoft.com/en-us/azure/governance/policy/concepts/initiative-definition-structure",
+    "https://learn.microsoft.com/en-us/azure/governance/policy/assign-policy-portal",
+    "https://learn.microsoft.com/en-us/azure/governance/policy/how-to/remediate-resources",
+    "https://learn.microsoft.com/en-us/azure/governance/policy/concepts/exemption-structure",
+    "https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/design-area/migrate-azure-landing-zone-policies",
+    "https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/",
+    "https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/azure-policy"
+  ],
+  "security_notes": "Do not recommend broad-scope deny or remediation-first rollout without blast-radius review, inheritance analysis, exception handling, and rollback notes.",
+  "last_verified": "2026-04-27",
+  "path": "skills/azure/azure-governance-policy-guardrails",
+  "author": "github: Raishin"
+}

--- a/skills/azure/azure-governance-policy-guardrails/references/mcp-and-evidence.md
+++ b/skills/azure/azure-governance-policy-guardrails/references/mcp-and-evidence.md
@@ -1,0 +1,22 @@
+# MCP and Evidence Path
+
+## Evidence path
+
+Prefer evidence in this order:
+
+1. Azure governance design guidance:
+   - https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/design-area/governance
+   - https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/tailoring-alz
+2. Azure Policy core behavior:
+   - https://learn.microsoft.com/en-us/azure/governance/policy/overview
+   - https://learn.microsoft.com/en-us/azure/governance/policy/concepts/initiative-definition-structure
+   - https://learn.microsoft.com/en-us/azure/governance/policy/assign-policy-portal
+   - https://learn.microsoft.com/en-us/azure/governance/policy/how-to/remediate-resources
+   - https://learn.microsoft.com/en-us/azure/governance/policy/concepts/exemption-structure
+3. Azure landing zone policy lifecycle guidance:
+   - https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/design-area/migrate-azure-landing-zone-policies
+4. Azure MCP discovery path when available in the client:
+   - https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/
+   - https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/azure-policy
+
+If Azure MCP tools are available, use `policy` first for assignments, definitions, and initiatives. Use `group` and `subscription` to confirm hierarchy and inheritance boundaries. Use `advisor` or `pricing` only when they materially help with governance tradeoffs such as SKU restriction or cost-control guardrails.

--- a/skills/azure/azure-governance-policy-guardrails/references/official-sources.md
+++ b/skills/azure/azure-governance-policy-guardrails/references/official-sources.md
@@ -1,0 +1,18 @@
+# Official Sources
+
+Load these only when needed:
+
+- [What is Azure Policy?](https://learn.microsoft.com/azure/governance/policy/overview) — use for policy object model, assignment scope behavior, evaluation timing, Azure RBAC interaction, and core rollout cautions.
+- [Azure Policy definitions effect basics](https://learn.microsoft.com/azure/governance/policy/concepts/effect-basics) — use when comparing `audit`, `auditIfNotExists`, `deny`, `modify`, and `deployIfNotExists`.
+- [Remediate non-compliant resources with Azure Policy](https://learn.microsoft.com/azure/governance/policy/how-to/remediate-resources) — use for managed identity, RBAC, and remediation-task implications.
+- [Azure Policy built-in policy definitions](https://learn.microsoft.com/azure/governance/policy/samples/built-in-policies) — use when checking whether built-ins already cover tags, locations, SKUs, or baseline controls.
+- [Adopt policy-driven guardrails](https://learn.microsoft.com/azure/cloud-adoption-framework/ready/enterprise-scale/dine-guidance) — use for canary rollout, enforcement mode, and phased `audit` to `deny` or remediation sequencing.
+- [Azure landing zone design principles](https://learn.microsoft.com/azure/cloud-adoption-framework/ready/landing-zone/design-principles) — use when guardrails are part of the broader landing-zone operating model.
+- [Azure MCP Server tools inventory](https://learn.microsoft.com/azure/developer/azure-mcp-server/tools/) — use to verify whether `policy`, `group`, `subscription`, `advisor`, or other namespaces are actually documented before naming them.
+
+## Grounded insights worth carrying into the skill
+
+- A policy can be assigned at management-group scope, but Azure Policy evaluates resources at subscription or resource-group level; do not imply it governs arbitrary tenant objects.
+- `modify` and `deployIfNotExists` are not “free automation”; their assignment identities need the right Azure RBAC permissions to create or update target resources.
+- Microsoft guidance explicitly recommends starting with `audit` or `auditIfNotExists` when rollout risk is unclear, rather than jumping straight to production `deny` or remediation.
+- Broad exclusions are usually governance debt. Prefer narrow exclusions or time-bounded exemptions with named ownership.

--- a/skills/azure/azure-governance-policy-guardrails/references/workflow-and-output.md
+++ b/skills/azure/azure-governance-policy-guardrails/references/workflow-and-output.md
@@ -1,0 +1,86 @@
+# Workflow and Output Contract
+
+## Workflow
+
+1. Identify the governing hierarchy first:
+   - tenant root management group,
+   - intermediate management groups,
+   - subscriptions,
+   - resource groups,
+   - exceptional resources that may need carve-outs.
+2. Classify the requested control:
+   - audit-only visibility,
+   - `deny` prevention,
+   - `modify` mutation,
+   - `deployIfNotExists` deployment/remediation,
+   - initiative bundling for repeated baseline controls.
+3. Decide whether the control belongs in:
+   - a single policy definition,
+   - an initiative for baseline packaging,
+   - an existing landing-zone baseline,
+   - or not in policy at all because the ask is process-only or too brittle.
+4. Choose assignment scope deliberately:
+   - prefer the highest scope that matches the real control boundary,
+   - do not assign at broad scope by habit,
+   - verify inheritance impact on child subscriptions and resource groups,
+   - call out when management-group placement is justified versus excessive.
+5. Design exclusions and exemptions separately:
+   - exclusions for scope carve-outs,
+   - exemptions for approved exception handling,
+   - narrow both by resource type, location, or defined exception boundary where possible.
+6. Evaluate guardrail content explicitly for common governance cases:
+   - required tags and tag value standards,
+   - allowed locations,
+   - allowed resource types,
+   - allowed or denied SKUs where built-in policy coverage exists,
+   - baseline initiatives that bundle related controls.
+7. Challenge remediation and mutation risk before recommending enforcement:
+   - `modify` and `deployIfNotExists` need managed identity, permissions, and rollback thought,
+   - remediation can change existing resources,
+   - deny can block live deployment paths if staged badly.
+   - remember that assignment at management-group scope still evaluates subscription/resource-group resources; do not imply magical tenant-object coverage.
+8. Recommend rollout sequencing:
+   - observe with audit first when facts are incomplete,
+   - pilot on a lower, representative scope,
+   - measure non-compliance and exception volume,
+   - then tighten to enforce where justified.
+9. State the rollback and exception path:
+   - remove or disable the assignment,
+   - narrow scope,
+   - replace deny with audit temporarily,
+   - use time-bounded exemptions instead of permanent policy erosion.
+
+## Output contract
+
+Return:
+
+- current governance summary,
+- target control objective,
+- recommended policy versus initiative shape,
+- assignment scope recommendation and inheritance impact,
+- exclusion and exemption strategy,
+- remediation or mutation risk,
+- staged rollout plan,
+- rollback or exception path,
+- assumptions, missing facts, and evidence used.
+
+## Eval gate
+
+Treat the answer as incomplete unless it does all of the following:
+
+- identifies the actual governing scope,
+- separates audit, deny, modify, and remediation concerns,
+- recommends assignment placement instead of hand-waving “use policy,”
+- addresses exclusions or exemptions for brownfield reality,
+- flags rollout risk for deny or remediation effects,
+- gives enforceable guardrails for tags, regions, SKUs, or baseline initiatives when those are in scope.
+
+Fail the response if it recommends root-scope sprawl, ignores inheritance, or proposes enforcement without change-safety notes.
+
+## Safety notes
+
+- Do not recommend tenant-root or broad management-group assignments without explicit blast-radius justification.
+- Do not recommend `deny`, `modify`, or `deployIfNotExists` as a default first move in production.
+- Do not hide remediation side effects; existing resources may be changed or left non-compliant depending on policy effect.
+- Do not treat exclusions as a dumping ground for weak design; prefer narrow, accountable exceptions.
+- Do not claim governance is solved by policy alone; ownership, operating process, and lifecycle updates still matter.

--- a/skills/azure/azure-identity-governance-review/SKILL.md
+++ b/skills/azure/azure-identity-governance-review/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: azure-identity-governance-review
+description: Review Microsoft Entra identity governance posture for Azure operators, with focus on standing versus eligible access, Privileged Identity Management, access reviews, entitlement management, ownership gaps, and least-privilege control patterns.
+metadata:
+  author: github: Raishin
+  version: 0.1.0
+---
+
+# Azure Identity Governance Review
+
+## Role Charter
+
+Act as a ruthless Azure identity-governance reviewer. Your job is to expose where privileged access is permanent, weakly reviewed, poorly owned, or bundled without accountability. Do not confuse “PIM enabled” with “governed.” Force exact scope, actor type, privileged role set, review owner, approval path, expiration model, and evidence source before calling the design acceptable.
+
+Default posture:
+- Prefer official Microsoft documentation and live Azure evidence when available.
+- Use Azure role/assignment evidence only to reduce guesswork; do not invent unsupported Entra governance tooling.
+- Never ask the user to paste secrets, tokens, tenant secrets, passwords, private keys, or customer data into chat.
+- Treat standing privileged access, unclear approvers, and unowned access packages as governance failures until proven otherwise.
+
+## Trigger Situations
+
+Use this skill when the user asks to:
+- review Microsoft Entra Privileged Identity Management adoption or role-activation design,
+- assess standing versus eligible access for Azure or Entra administrators,
+- critique access-review coverage for privileged roles, groups, or application access,
+- evaluate entitlement-management design for operator onboarding, project access, or external-user access,
+- identify ownership and accountability gaps in privileged access workflows,
+- tighten least-privilege governance for Azure platform teams without redesigning the whole directory.
+
+Do not use this skill for low-level authentication debugging, app sign-in break/fix, or broad tenant identity architecture redesign.
+
+## Lean operating rules
+
+- Prefer live Azure or Microsoft evidence first when the active client exposes it; otherwise fall back to official documentation and sanitized user evidence.
+- Separate confirmed facts from inference. If state was not queried or shown, say so.
+- Challenge broad access, broad scope, destructive changes, and hand-wavy production claims.
+- Keep the answer scoped, reversible, least-privilege, and explicit about blockers or unknowns.
+
+## References
+
+Load these only when needed:
+
+- [MCP and evidence path](references/mcp-and-evidence.md) — use when choosing live Azure evidence, confirming Microsoft MCP capability, or switching to documentation mode.
+- [Workflow and output contract](references/workflow-and-output.md) — use when executing the full review, applying stress checks, or formatting the final answer.
+- [Official sources](references/official-sources.md) — use when you need the detailed Microsoft documentation list or source notes.
+
+## Response minimum
+
+Return, at minimum:
+
+- the scoped target and evidence level,
+- the main risks or control gaps,
+- the safest next actions,
+- the assumptions or blockers that prevent stronger conclusions.

--- a/skills/azure/azure-identity-governance-review/metadata.json
+++ b/skills/azure/azure-identity-governance-review/metadata.json
@@ -1,0 +1,33 @@
+{
+  "id": "azure-identity-governance-review",
+  "name": "Azure Identity Governance Review",
+  "type": "skill",
+  "provider": "azure",
+  "harnesses": [
+    "codex",
+    "claude-code",
+    "cursor",
+    "gemini",
+    "kiro",
+    "other"
+  ],
+  "summary": "Review Microsoft Entra identity governance posture for Azure operators, focusing on PIM, access reviews, entitlement management, standing access, and ownership gaps.",
+  "source_type": "original",
+  "official_docs": [
+    "https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/design-area/identity-access",
+    "https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/design-area/identity-access-landing-zones",
+    "https://learn.microsoft.com/en-us/azure/active-directory/roles/best-practices",
+    "https://learn.microsoft.com/en-us/entra/id-governance/privileged-identity-management/",
+    "https://learn.microsoft.com/en-us/entra/id-governance/privileged-identity-management/pim-resource-roles-assign-roles",
+    "https://learn.microsoft.com/en-us/entra/id-governance/access-reviews-overview",
+    "https://learn.microsoft.com/en-us/entra/id-governance/manage-access-review",
+    "https://learn.microsoft.com/en-us/entra/id-governance/privileged-identity-management/pim-perform-roles-and-resource-roles-review",
+    "https://learn.microsoft.com/en-us/entra/id-governance/entitlement-management-overview",
+    "https://learn.microsoft.com/en-us/entra/id-governance/entitlement-management-access-reviews-create",
+    "https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/"
+  ],
+  "security_notes": "Challenge standing privileged access by default. Do not treat PIM, access reviews, or entitlement management as sufficient unless scope, ownership, cadence, and removal behavior are explicit.",
+  "last_verified": "2026-04-27",
+  "path": "skills/azure/azure-identity-governance-review",
+  "author": "github: Raishin"
+}

--- a/skills/azure/azure-identity-governance-review/references/mcp-and-evidence.md
+++ b/skills/azure/azure-identity-governance-review/references/mcp-and-evidence.md
@@ -1,0 +1,49 @@
+# MCP and Evidence Path
+
+## Official Azure / Entra Linkage
+
+Ground this skill in official Microsoft Learn content only.
+
+Preferred linkage:
+- Use the Cloud Adoption Framework identity-access design area to frame identity-plane responsibilities, separation of duties, and privileged-access expectations.
+- Use Microsoft Entra ID Governance documentation for PIM, access reviews, and entitlement management behavior.
+- Use Azure RBAC or role-assignment evidence only when correlating governance findings to actual Azure scopes or role sprawl.
+
+If live Azure tooling is available in the client, use Azure role-related evidence carefully for:
+- which principals hold privileged Azure resource roles,
+- whether assignment scope is broader than claimed,
+- whether standing assignments remain where eligibility should exist.
+
+Do not claim that Azure MCP exposes full Entra governance state unless the active client actually does. If governance evidence is missing, say so.
+
+## Platform-Agnostic Execution
+
+This skill must work in MCP-only, browser-only, and documentation-only environments. Prefer neutral evidence language:
+- `<tenant>`
+- `<management-group | subscription | resource-group | resource>`
+- `<principal>`
+- `<privileged role>`
+- `<access package>`
+
+If commands or portal paths are useful, keep them platform-neutral and adapt only after the user’s actual environment is known.
+
+## Documentation Fallback When Live Data Is Unavailable
+
+Live tenant evidence beats documentation. If live evidence is unavailable, denied, incomplete, or unsafe to collect:
+
+- switch to documentation-grounded review mode,
+- ask for sanitized exports or screenshots of assignments, PIM settings, review schedules, access packages, or ownership mappings,
+- label each conclusion as `live evidence`, `documentation-based`, `sanitized evidence`, or `inference`,
+- refuse to present documentation as proof of current tenant posture.
+
+Documentation fallback is acceptable for:
+- control-pattern recommendations,
+- review-cadence design,
+- eligibility-versus-standing critiques,
+- entitlement-management workflow design.
+
+It is not enough for:
+- proving PIM is enabled,
+- proving reviews actually run,
+- proving expired access is removed,
+- proving ownership is assigned and operational.

--- a/skills/azure/azure-identity-governance-review/references/official-sources.md
+++ b/skills/azure/azure-identity-governance-review/references/official-sources.md
@@ -1,0 +1,28 @@
+# Official Sources
+
+## References
+
+Load only what is needed:
+
+- Azure identity and access management design area  
+  https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/design-area/identity-access
+- Landing zone identity and access management  
+  https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/design-area/identity-access-landing-zones
+- Microsoft Entra roles best practices  
+  https://learn.microsoft.com/en-us/azure/active-directory/roles/best-practices
+- Privileged Identity Management documentation  
+  https://learn.microsoft.com/en-us/entra/id-governance/privileged-identity-management/
+- Assign Azure resource roles in Privileged Identity Management  
+  https://learn.microsoft.com/en-us/entra/id-governance/privileged-identity-management/pim-resource-roles-assign-roles
+- Access reviews overview  
+  https://learn.microsoft.com/en-us/entra/id-governance/access-reviews-overview
+- Manage access with access reviews  
+  https://learn.microsoft.com/en-us/entra/id-governance/manage-access-review
+- Perform access reviews for Azure resource and Microsoft Entra roles in PIM  
+  https://learn.microsoft.com/en-us/entra/id-governance/privileged-identity-management/pim-perform-roles-and-resource-roles-review
+- Entitlement management overview  
+  https://learn.microsoft.com/en-us/entra/id-governance/entitlement-management-overview
+- Create an access review of an access package in entitlement management  
+  https://learn.microsoft.com/en-us/entra/id-governance/entitlement-management-access-reviews-create
+- Azure MCP tool inventory  
+  https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/

--- a/skills/azure/azure-identity-governance-review/references/workflow-and-output.md
+++ b/skills/azure/azure-identity-governance-review/references/workflow-and-output.md
@@ -1,0 +1,76 @@
+# Workflow and Output Contract
+
+## Safe Workflow
+
+1. **Identify privileged population**: Azure resource roles, Microsoft Entra roles, privileged groups, app-access groups, external users, and service principals/workload identities when relevant.
+2. **Separate assignment design from governance process**: who has access, whether it is active or eligible, how it is activated, who approves it, how long it lasts, and who reviews it.
+3. **Challenge standing privilege first**: any always-active privileged role needs explicit justification, bounded scope, and an owner.
+4. **Review PIM posture**: activation requirements, approval path, time limits, notifications, and whether eligibility is actually used for human admin access.
+5. **Review access-review posture**: target resources, reviewer accountability, cadence, completion/application of results, and stale-access handling.
+6. **Review entitlement-management use**: whether access packages are used where recurring project/team access exists, whether package owners exist, and whether assignments expire and get reviewed.
+7. **Map ownership/accountability gaps**: role owner, group owner, package owner, approver, review owner, and exception approver.
+8. **Return a go/no-go governance verdict** with explicit evidence labels, least-privilege recommendations, and missing facts.
+
+## Role-Specific Stress Checks
+
+- PIM does not fix bad scope design. Eligible `Owner` at subscription scope can still be reckless.
+- Access reviews that never apply removals are theater, not governance.
+- Entitlement management without package owners, approval rules, expiration, and reviews is packaging, not control.
+- Standing access for human administrators is a red flag unless there is a documented break-glass or operational justification.
+- Privileged groups can hide excessive access just as easily as direct role assignments; do not stop at direct assignments.
+- “We review quarterly” means nothing unless the review target, reviewer, completion path, and removal action are defined.
+- Service principals and workload identities need governance too, but do not force human PIM patterns onto unsupported cases.
+
+## Output Template
+
+```markdown
+# Azure Identity Governance Review: <scope>
+
+## Verdict
+- Status: READY / READY WITH RISKS / NOT READY
+- Biggest governance gap:
+- Evidence level: live evidence / documentation-based / sanitized evidence / inference
+
+## Scope
+- Tenant or hierarchy boundary:
+- Privileged population reviewed:
+- Requested outcome:
+- Review owner:
+
+## Current privilege model
+| Area | Current state | Risk |
+|---|---|---|
+| Standing vs eligible access |  |  |
+| PIM posture |  |  |
+| Access reviews |  |  |
+| Entitlement management |  |  |
+| Ownership/accountability |  |  |
+
+## Findings
+| Finding | Severity | Evidence | Why it matters | Recommendation | Owner |
+|---|---|---|---|---|---|
+
+## Least-privilege governance pattern
+- Human privileged access:
+- Workload or service access:
+- Review cadence:
+- Approval model:
+- Expiration model:
+
+## Safe next actions
+1.
+2.
+3.
+
+## Open questions
+- 
+```
+
+## Red Flags
+
+- Permanent `Owner`, `Contributor`, `User Access Administrator`, or high-privilege Entra role assignments for normal operator work.
+- PIM enabled only for a subset of admins while broad standing access remains elsewhere.
+- Access reviews exist but have no clear reviewer, no recurrence, or no evidence that denied access is removed.
+- Entitlement management is absent where recurring team/project access could replace manual privileged group handling.
+- No named owner for privileged groups, access packages, or approval workflows.
+- Governance claims rely only on documentation or intent, not tenant evidence.

--- a/skills/azure/azure-key-vault-secret-lifecycle-auditor/SKILL.md
+++ b/skills/azure/azure-key-vault-secret-lifecycle-auditor/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: azure-key-vault-secret-lifecycle-auditor
+description: Audit Azure Key Vault secret lifecycle posture across RBAC, soft delete, purge protection, rotation, expiration, metadata hygiene, Event Grid notifications, and recovery readiness. Use when the question is whether secret management is actually safe, not just present.
+metadata:
+  author: github: Raishin
+  version: 0.1.0
+---
+
+# Azure Key Vault Secret Lifecycle Auditor
+
+## Role Charter
+
+Act as a ruthless Key Vault secret lifecycle auditor. Your job is to catch fake secret hygiene before it becomes an outage or breach.
+
+Force clarity on:
+
+- which vaults matter,
+- which apps or operators depend on them,
+- which assets are secrets versus keys versus certificates,
+- whether the vault uses Azure RBAC or legacy access policies,
+- who can read, write, delete, recover, or purge,
+- whether soft delete and purge protection are enabled,
+- whether expiration and rotation are defined,
+- how near-expiry or failed-rotation events are monitored,
+- and whether restore and dependency fallout have ever been tested.
+
+Default access posture:
+
+- Prefer Azure MCP read-oriented evidence when Key Vault tooling is available.
+- Treat secret contents as sensitive and unnecessary for most audits.
+- Never ask the user to paste secret values, certificate private keys, tokens, connection strings, or customer data into chat.
+- Prefer metadata, policy, ownership, and rotation posture over retrieving secret values.
+
+## Trigger Situations
+
+Use this skill when the user asks to:
+
+- review Azure Key Vault secret hygiene,
+- audit expiration, rotation, or near-expiry posture,
+- assess soft delete, purge protection, or recovery safety,
+- review secret ownership, tags, metadata, or lifecycle operations,
+- assess Key Vault RBAC and who can purge or recover,
+- review Event Grid or alert coverage for secret lifecycle events,
+- or decide whether a Key Vault setup is operationally safe for production.
+
+## Lean operating rules
+
+- Prefer live Azure or Microsoft evidence first when the active client exposes it; otherwise fall back to official documentation and sanitized user evidence.
+- Separate confirmed facts from inference. If state was not queried or shown, say so.
+- Challenge broad access, broad scope, destructive changes, and hand-wavy production claims.
+- Keep the answer scoped, reversible, least-privilege, and explicit about blockers or unknowns.
+
+## References
+
+Load these only when needed:
+
+- [MCP and evidence path](references/mcp-and-evidence.md) — use when choosing live Azure evidence, confirming Microsoft MCP capability, or switching to documentation mode.
+- [Workflow and output contract](references/workflow-and-output.md) — use when executing the full review, applying stress checks, or formatting the final answer.
+- [Official sources](references/official-sources.md) — use when you need the detailed Microsoft documentation list or source notes.
+
+## Response minimum
+
+Return, at minimum:
+
+- the scoped target and evidence level,
+- the main risks or control gaps,
+- the safest next actions,
+- the assumptions or blockers that prevent stronger conclusions.

--- a/skills/azure/azure-key-vault-secret-lifecycle-auditor/metadata.json
+++ b/skills/azure/azure-key-vault-secret-lifecycle-auditor/metadata.json
@@ -1,0 +1,31 @@
+{
+  "id": "azure-key-vault-secret-lifecycle-auditor",
+  "name": "Azure Key Vault Secret Lifecycle Auditor",
+  "type": "skill",
+  "provider": "azure",
+  "harnesses": [
+    "codex",
+    "claude-code",
+    "cursor",
+    "gemini",
+    "kiro",
+    "other"
+  ],
+  "summary": "Audit Azure Key Vault secret lifecycle posture across RBAC, soft delete, purge protection, expiration, rotation, metadata hygiene, eventing, and recovery readiness without exposing secret values.",
+  "source_type": "original",
+  "official_docs": [
+    "https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/",
+    "https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/azure-key-vault",
+    "https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/services/azure-mcp-server-for-key-vault",
+    "https://learn.microsoft.com/en-us/azure/key-vault/secrets/secure-secrets",
+    "https://learn.microsoft.com/en-us/azure/key-vault/general/autorotation",
+    "https://learn.microsoft.com/en-us/azure/key-vault/general/rbac-guide",
+    "https://learn.microsoft.com/en-us/azure/key-vault/general/soft-delete-overview",
+    "https://learn.microsoft.com/en-us/azure/key-vault/general/key-vault-recovery",
+    "https://learn.microsoft.com/en-us/azure/key-vault/policy-reference"
+  ],
+  "security_notes": "Avoid retrieving secret values unless absolutely necessary. Treat purge authority, missing soft delete, missing purge protection, and unproven rotation or recovery paths as high-risk. Prefer RBAC least privilege and metadata-based audits over content access.",
+  "last_verified": "2026-04-27",
+  "path": "skills/azure/azure-key-vault-secret-lifecycle-auditor",
+  "author": "github: Raishin"
+}

--- a/skills/azure/azure-key-vault-secret-lifecycle-auditor/references/mcp-and-evidence.md
+++ b/skills/azure/azure-key-vault-secret-lifecycle-auditor/references/mcp-and-evidence.md
@@ -1,0 +1,40 @@
+# MCP and Evidence Path
+
+## Official Azure MCP Linkage
+
+Use only official Azure MCP capabilities actually exposed in the active runtime.
+
+Relevant namespaces may include:
+
+- `keyvault` for vault, key, secret, certificate, and Managed HSM evidence,
+- `role` when RBAC assignment correlation is required,
+- `monitor` if alerting or event visibility is part of the audit,
+- `policy` when policy-enforced protections matter.
+
+Do not confuse tool availability with audit sufficiency:
+
+- Azure MCP can help inspect assets and settings.
+- It does not automatically prove rotation logic, downstream dependency handling, or restore readiness.
+- Secret-reading tools may require user confirmation because they can expose sensitive data. Avoid them unless absolutely necessary.
+
+## Platform-Agnostic Execution
+
+This skill must work in MCP-only, macOS, Linux, and Windows clients.
+
+Prefer:
+
+1. Azure MCP metadata and configuration evidence,
+2. official Microsoft Learn and policy references,
+3. sanitized inventories, screenshots, or exports from the user,
+4. neutral placeholder commands only when needed.
+
+Do not assume the user operates through Azure CLI, PowerShell, Terraform, Bicep, or portal-only workflows unless they say so.
+
+## Documentation Fallback When Live Data Is Unavailable
+
+Live vault posture beats theory. If live access is unavailable, incomplete, denied, or unsafe:
+
+- fall back to official Microsoft documentation,
+- ask for sanitized inventories such as vault settings, secret lists without values, expiration metadata, role assignments, and alert definitions,
+- label each conclusion as `live evidence`, `documentation-based`, `user-provided sanitized evidence`, or `inference`,
+- do not claim a vault is safe merely because the platform supports the right features.

--- a/skills/azure/azure-key-vault-secret-lifecycle-auditor/references/official-sources.md
+++ b/skills/azure/azure-key-vault-secret-lifecycle-auditor/references/official-sources.md
@@ -1,0 +1,15 @@
+# Official Sources
+
+## References
+
+Load these only when needed:
+
+- [Azure MCP Server tools inventory](https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/)
+- [Azure Key Vault tools for Azure MCP Server](https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/azure-key-vault)
+- [Manage Azure Key Vault with Azure MCP Server](https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/services/azure-mcp-server-for-key-vault)
+- [Secure your Azure Key Vault secrets](https://learn.microsoft.com/en-us/azure/key-vault/secrets/secure-secrets)
+- [Understanding autorotation in Azure Key Vault](https://learn.microsoft.com/en-us/azure/key-vault/general/autorotation)
+- [Grant permission to applications to access an Azure key vault using Azure RBAC](https://learn.microsoft.com/en-us/azure/key-vault/general/rbac-guide)
+- [Azure Key Vault soft-delete overview](https://learn.microsoft.com/en-us/azure/key-vault/general/soft-delete-overview)
+- [Azure Key Vault recovery management with soft delete and purge protection](https://learn.microsoft.com/en-us/azure/key-vault/general/key-vault-recovery)
+- [Built-in policy definitions for Key Vault](https://learn.microsoft.com/en-us/azure/key-vault/policy-reference)

--- a/skills/azure/azure-key-vault-secret-lifecycle-auditor/references/workflow-and-output.md
+++ b/skills/azure/azure-key-vault-secret-lifecycle-auditor/references/workflow-and-output.md
@@ -1,0 +1,101 @@
+# Workflow and Output Contract
+
+## Safe Workflow
+
+1. **Scope the vault estate**
+   - Which vaults matter?
+   - Which workloads or teams depend on them?
+   - Which assets are secrets, keys, or certificates?
+2. **Check the protection floor**
+   - Is soft delete enabled?
+   - Is purge protection enabled?
+   - What is the retention period?
+   - Are policy controls enforcing the floor?
+3. **Check the permission model**
+   - Azure RBAC or legacy access policies?
+   - Who can read, write, delete, recover, or purge?
+   - Are roles assigned at the right scope?
+   - Is purge authority too broad?
+4. **Check secret lifecycle hygiene**
+   - Expiration set or missing?
+   - Owner and rotation metadata present?
+   - Tags used for lifecycle metadata rather than stuffing metadata into secret values?
+   - General configuration data incorrectly stored as secrets?
+5. **Check rotation realism**
+   - Is rotation manual, reminder-based, or automated?
+   - Is dual-credential or zero-downtime rotation needed?
+   - Are dependent services updated correctly?
+   - Are failed rotations visible?
+6. **Check monitoring and events**
+   - Near-expiry notifications configured?
+   - Event Grid or other alerting present?
+   - Are alert owners named?
+7. **Check recovery posture**
+   - Can deleted secrets be recovered?
+   - Does the team understand purge consequences?
+   - Do they know that some integrated services or subscriptions may need recreation after vault recovery?
+8. **Return a go / no-go style secret-lifecycle verdict**
+   - What is safe,
+   - what is brittle,
+   - what is missing,
+   - and what must change first.
+
+## Role-Specific Stress Checks
+
+- Reject “it’s in Key Vault, so it’s secure.” Storage location is not lifecycle discipline.
+- Reject any design where humans can purge critical vault assets casually.
+- Reject rotation claims that do not explain how dependent systems receive the new secret.
+- Reject “we monitor expiry” if the team cannot name the alert path, owner, and escalation.
+- Reject vault designs storing feature flags or generic configuration as secrets.
+- Reject recovery confidence if soft delete or purge protection is missing or misunderstood.
+- Reject audits that inspect secret values when metadata would answer the question safely.
+- Reject broad `Key Vault Administrator` usage as a default operational model.
+
+## Output Template
+
+```markdown
+# Azure Key Vault Secret Lifecycle Audit: <scope>
+
+## Verdict
+- Status: READY / READY WITH RISKS / NOT READY
+- Biggest risk:
+- Evidence level: live evidence / documentation-based / sanitized evidence / inference
+
+## Scope
+- Vault(s):
+- Environment:
+- Dependent workloads:
+- Permission model:
+
+## Findings
+| Area | Finding | Severity | Evidence | Recommendation | Owner |
+|---|---|---|---|---|---|
+
+## Lifecycle control review
+| Control area | Expected state | Observed state | Gap | Blocking |
+|---|---|---|---|---|
+| Soft delete |  |  |  |  |
+| Purge protection |  |  |  |  |
+| RBAC / purge authority |  |  |  |  |
+| Expiration metadata |  |  |  |  |
+| Rotation process |  |  |  |  |
+| Eventing / alerts |  |  |  |  |
+| Recovery readiness |  |  |  |  |
+
+## Safe next actions
+1.
+2.
+3.
+
+## Open questions
+- 
+```
+
+## Red Flags
+
+- The team wants an audit but refuses to separate secrets, keys, and certificates.
+- Secret rotation is claimed, but nobody can explain how consumers adopt new values.
+- Purge protection is absent for critical vaults or encryption dependencies.
+- Broad administrator roles exist where narrower secrets roles would suffice.
+- The audit relies on secret contents instead of safer metadata.
+- The team assumes vault recovery restores every dependent integration automatically.

--- a/skills/azure/azure-landing-zone-architect/SKILL.md
+++ b/skills/azure/azure-landing-zone-architect/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: azure-landing-zone-architect
+description: Use this skill for Azure landing-zone design, management-group and subscription hierarchy reviews, platform-versus-application boundary decisions, or multi-subscription Azure platform architecture critiques that span governance, identity, networking, security, and operations.
+metadata:
+  author: github: Raishin
+---
+
+# Azure Landing Zone Architect
+
+## Purpose
+
+Design or review Azure landing zones with an operator-grade focus on structure, dependencies, and blast radius.
+
+This skill is for platform decisions that cut across:
+
+- management groups,
+- subscriptions,
+- platform versus application landing zones,
+- identity and access boundaries,
+- network topology and shared services,
+- governance and policy inheritance,
+- security baselines,
+- management, monitoring, backup, and recovery posture.
+
+## When to use
+
+Use this skill when the user asks for:
+
+- a greenfield Azure landing-zone design,
+- a brownfield hierarchy or subscription-placement critique,
+- shared-services or platform-subscription layout advice,
+- a hub-spoke or alternative connectivity decision in landing-zone context,
+- a review of whether governance, security, and operations dependencies were missed,
+- clarification of platform-team versus application-team ownership boundaries.
+
+Do not use this skill for:
+
+- narrow RBAC assignment questions with no platform-design component,
+- single-service implementation tutorials,
+- writing production Bicep or Terraform on first pass,
+- workload-only design questions that do not affect the platform operating model.
+
+## Lean operating rules
+
+- Prefer live Azure or Microsoft evidence first when the active client exposes it; otherwise fall back to official documentation and sanitized user evidence.
+- Separate confirmed facts from inference. If state was not queried or shown, say so.
+- Challenge broad access, broad scope, destructive changes, and hand-wavy production claims.
+- Keep the answer scoped, reversible, least-privilege, and explicit about blockers or unknowns.
+
+## References
+
+Load these only when needed:
+
+- [MCP and evidence path](references/mcp-and-evidence.md) — use when choosing live Azure evidence, confirming Microsoft MCP capability, or switching to documentation mode.
+- [Workflow and output contract](references/workflow-and-output.md) — use when executing the full review, applying stress checks, or formatting the final answer.
+- [Official sources](references/official-sources.md) — use when you need the detailed Microsoft documentation list or source notes.
+
+## Response minimum
+
+Return, at minimum:
+
+- the scoped target and evidence level,
+- the main risks or control gaps,
+- the safest next actions,
+- the assumptions or blockers that prevent stronger conclusions.

--- a/skills/azure/azure-landing-zone-architect/metadata.json
+++ b/skills/azure/azure-landing-zone-architect/metadata.json
@@ -1,0 +1,29 @@
+{
+  "id": "azure-landing-zone-architect",
+  "name": "Azure Landing Zone Architect",
+  "type": "skill",
+  "provider": "azure",
+  "harnesses": [
+    "codex",
+    "claude-code",
+    "cursor",
+    "gemini",
+    "kiro",
+    "other"
+  ],
+  "summary": "Design or review Azure landing-zone architecture across management groups, subscriptions, governance, security, networking, and operations dependencies.",
+  "source_type": "original",
+  "official_docs": [
+    "https://learn.microsoft.com/azure/cloud-adoption-framework/ready/landing-zone/design-areas",
+    "https://learn.microsoft.com/azure/cloud-adoption-framework/ready/landing-zone/design-area/identity-access",
+    "https://learn.microsoft.com/azure/cloud-adoption-framework/ready/landing-zone/design-area/governance",
+    "https://learn.microsoft.com/azure/cloud-adoption-framework/ready/landing-zone/design-area/security",
+    "https://learn.microsoft.com/azure/cloud-adoption-framework/ready/landing-zone/implementation-options",
+    "https://learn.microsoft.com/azure/architecture/networking/architecture/hub-spoke",
+    "https://learn.microsoft.com/azure/developer/azure-mcp-server/tools/"
+  ],
+  "security_notes": "Do not prescribe a one-size-fits-all hierarchy, broad admin grants, or a production-ready verdict without governance, management, and recovery dependencies being addressed.",
+  "last_verified": "2026-04-27",
+  "path": "skills/azure/azure-landing-zone-architect",
+  "author": "github: Raishin"
+}

--- a/skills/azure/azure-landing-zone-architect/references/mcp-and-evidence.md
+++ b/skills/azure/azure-landing-zone-architect/references/mcp-and-evidence.md
@@ -1,0 +1,25 @@
+# MCP and Evidence Path
+
+## Evidence path
+
+Prefer evidence in this order:
+
+1. Microsoft Learn Azure landing-zone guidance:
+   - landing-zone design areas,
+   - identity and access design area,
+   - governance design area,
+   - security design area,
+   - implementation options when delivery model matters.
+2. Microsoft Learn Azure architecture guidance when network topology is part of the decision.
+3. Azure MCP evidence, if the client exposes the relevant namespaces and live tenant inspection reduces guesswork.
+
+Useful Azure MCP namespaces from repo-backed specs:
+
+- `cloudarchitect`
+- `wellarchitectedframework`
+- `policy`
+- `role`
+- `group`
+- `subscription`
+
+Use MCP evidence to confirm current hierarchy, scope, or governance reality. Do not use it as an excuse to skip design-area reasoning.

--- a/skills/azure/azure-landing-zone-architect/references/official-sources.md
+++ b/skills/azure/azure-landing-zone-architect/references/official-sources.md
@@ -1,0 +1,19 @@
+# Official Sources
+
+Load these only when needed:
+
+- [What is an Azure landing zone?](https://learn.microsoft.com/azure/cloud-adoption-framework/ready/landing-zone/) — use for platform versus application landing zones and the reference-architecture baseline.
+- [Azure landing zone design areas and conceptual architecture](https://learn.microsoft.com/azure/cloud-adoption-framework/ready/landing-zone/design-areas) — use for the design-area map and the dependency between resource organization, networking, governance, management, and automation.
+- [Azure landing zone design principles](https://learn.microsoft.com/azure/cloud-adoption-framework/ready/landing-zone/design-principles) — use for policy-driven governance, Azure-native alignment, and avoiding application-agnostic hierarchy mistakes.
+- [Deploy Azure landing zones](https://learn.microsoft.com/azure/architecture/landing-zones/landing-zone-deploy) — use for platform landing zone deployment approaches and application landing zone patterns.
+- [Platform landing zone vs. application landing zones](https://learn.microsoft.com/azure/cloud-adoption-framework/ready/landing-zone/#platform-landing-zone-vs-application-landing-zones) — use when teams are blurring shared platform services with workload-local ownership.
+- [Tailor the Azure landing zone architecture to meet requirements](https://learn.microsoft.com/azure/cloud-adoption-framework/ready/landing-zone/tailoring-alz) — use when the user wants to deviate from the reference architecture without pretending there is one canonical hierarchy.
+- [Ready your Azure environment for workloads](https://learn.microsoft.com/azure/cloud-adoption-framework/ready/) — use for the baseline expectation that management, governance, security, and monitoring apply across subscriptions.
+- [Azure MCP Server tools inventory](https://learn.microsoft.com/azure/developer/azure-mcp-server/tools/) — use to verify `cloudarchitect`, `policy`, `group`, `subscription`, `role`, or `wellarchitectedframework` before naming them.
+
+## Grounded insights worth carrying into the skill
+
+- Microsoft’s landing-zone guidance is explicitly modular and should be tailored; a single canned hierarchy is usually a sign of lazy thinking.
+- Platform landing zones and application landing zones are different operating boundaries; mixing them casually creates ownership and governance confusion.
+- Azure AI workloads do not require a separate “AI landing zone” by default; Microsoft says they should usually fit inside normal application landing zones governed by the same design areas.
+- A landing zone is not complete if management, governance, monitoring, and recovery posture are still deferred.

--- a/skills/azure/azure-landing-zone-architect/references/workflow-and-output.md
+++ b/skills/azure/azure-landing-zone-architect/references/workflow-and-output.md
@@ -1,0 +1,86 @@
+# Workflow and Output Contract
+
+## Workflow
+
+1. Classify the operating context.
+   - greenfield or brownfield,
+   - single-subscription or multi-subscription,
+   - enterprise platform or team-local setup,
+   - who owns the platform: central platform team, security/governance team, app teams, or mixed.
+2. State missing facts before pretending certainty.
+   - regulated or not,
+   - connectivity model,
+   - identity source and privileged access model,
+   - regional footprint,
+   - shared-services expectations,
+   - management/monitoring/SOC ownership,
+   - recovery objectives.
+3. Map the problem to landing-zone design areas.
+   - identity and access,
+   - resource organization,
+   - network topology and connectivity,
+   - security,
+   - management,
+   - governance,
+   - platform automation.
+4. Define the target platform model.
+   - management-group hierarchy shape and why,
+   - subscription segmentation and placement,
+   - platform landing zones versus application landing zones,
+   - shared services placement,
+   - connectivity pattern and tradeoffs,
+   - baseline governance and policy inheritance points.
+5. Stress-test dependencies that are often skipped.
+   - logging and monitoring foundation,
+   - backup and disaster recovery assumptions,
+   - identity administration and privileged access,
+   - policy rollout sequencing and exceptions,
+   - DNS, routing, and private-access consequences,
+   - cost and operational ownership boundaries.
+6. Challenge unsafe defaults.
+   - one giant subscription,
+   - flat management-group hierarchy by habit,
+   - hub-spoke assumed without requirements,
+   - broad admin access for convenience,
+   - “we will add governance later”,
+   - calling a landing zone complete without management and recovery posture.
+   - inventing a separate AI landing zone by default when normal application landing zones already satisfy the governance boundary.
+7. Route narrower follow-up work when needed.
+   - RBAC specifics -> `azure-rbac-review` or a role-selection skill,
+   - policy-detail design -> governance/policy skill,
+   - network-depth review -> network topology skill,
+   - automation delivery model -> platform automation skill.
+
+## Output contract
+
+Return all of the following:
+
+- **Architecture verdict**: whether the current or proposed landing-zone model is sound, risky, or incomplete.
+- **Target platform model**: recommended hierarchy, subscription model, and platform/application boundary.
+- **Design-area decision table**: for each relevant design area, give current state, risk, recommendation, and dependency.
+- **Unresolved risks**: explicit gaps, assumptions, and blocked decisions.
+- **Next actions**: prioritized steps, sequenced so governance and operational dependencies are not deferred into fantasy.
+- **Evidence used**: Microsoft Learn pages and any Azure MCP namespaces actually used.
+
+## Eval gate
+
+The skill output is not acceptable unless it:
+
+1. distinguishes greenfield versus brownfield context,
+2. identifies platform ownership assumptions,
+3. covers every relevant landing-zone design area,
+4. separates platform landing zones from application landing zones,
+5. addresses management-group and subscription placement,
+6. surfaces governance, security, management, and recovery dependencies,
+7. states assumptions and unknowns explicitly,
+8. avoids broad-admin or one-size-fits-all hierarchy advice.
+
+Fail the response if any major design area is skipped or if the answer collapses into generic Azure architecture prose.
+
+## Safety notes
+
+- Do not recommend a single canonical management-group hierarchy without business and governance context.
+- Do not recommend tenant-wide, management-group-wide, or subscription-wide admin access unless the user has justified the blast radius.
+- Do not treat platform, connectivity, identity, and governance as separable afterthoughts; in landing-zone work they are coupled.
+- Do not claim the landing zone is production-ready without management, monitoring, backup, and disaster-recovery posture.
+- Be explicit when guidance is inference from incomplete tenant facts rather than confirmed current-state evidence.

--- a/skills/azure/azure-migrate-landing-zone-cutover/SKILL.md
+++ b/skills/azure/azure-migrate-landing-zone-cutover/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: azure-migrate-landing-zone-cutover
+description: Plan and stress-test Azure migration cutovers across landing-zone readiness, Azure Migrate assessments, dependency sequencing, permissions, rollback, and operational ownership. Use when a migration plan needs a go/no-go verdict instead of vague optimism.
+metadata:
+  author: github: Raishin
+  version: 0.1.0
+---
+
+# Azure Migrate Landing Zone Cutover
+
+## Role Charter
+
+Act as a ruthless migration cutover reviewer. Your job is to stop half-prepared Azure migrations from turning into expensive outages.
+
+Force clarity on:
+
+- what is being migrated,
+- which migration wave it belongs to,
+- what the target Azure landing zone actually looks like,
+- whether readiness data is current,
+- whether dependencies were discovered or guessed,
+- whether permissions are least-privilege and sufficient,
+- what the cutover trigger is,
+- what rollback looks like,
+- and who owns validation before, during, and after cutover.
+
+Default posture:
+
+- Prefer Azure Migrate assessments, landing-zone evidence, and official Microsoft guidance over broad migration slogans.
+- Never accept “Azure ready” as equivalent to “cutover ready.”
+- Never ask the user to paste secrets, credentials, appliance details, customer data, or full inventories into chat.
+
+## Trigger Situations
+
+Use this skill when the user asks to:
+
+- review an Azure migration wave or cutover plan,
+- assess whether the landing zone is ready for migration,
+- stress-test Azure Migrate assessment results,
+- critique dependency sequencing or migration grouping,
+- review permissions and tooling boundaries for migration execution,
+- challenge rollback and validation plans,
+- or decide whether a migration is actually ready to proceed.
+
+## Lean operating rules
+
+- Prefer live Azure or Microsoft evidence first when the active client exposes it; otherwise fall back to official documentation and sanitized user evidence.
+- Separate confirmed facts from inference. If state was not queried or shown, say so.
+- Challenge broad access, broad scope, destructive changes, and hand-wavy production claims.
+- Keep the answer scoped, reversible, least-privilege, and explicit about blockers or unknowns.
+
+## References
+
+Load these only when needed:
+
+- [MCP and evidence path](references/mcp-and-evidence.md) — use when choosing live Azure evidence, confirming Microsoft MCP capability, or switching to documentation mode.
+- [Workflow and output contract](references/workflow-and-output.md) — use when executing the full review, applying stress checks, or formatting the final answer.
+- [Official sources](references/official-sources.md) — use when you need the detailed Microsoft documentation list or source notes.
+
+## Response minimum
+
+Return, at minimum:
+
+- the scoped target and evidence level,
+- the main risks or control gaps,
+- the safest next actions,
+- the assumptions or blockers that prevent stronger conclusions.

--- a/skills/azure/azure-migrate-landing-zone-cutover/metadata.json
+++ b/skills/azure/azure-migrate-landing-zone-cutover/metadata.json
@@ -1,0 +1,28 @@
+{
+  "id": "azure-migrate-landing-zone-cutover",
+  "name": "Azure Migrate Landing Zone Cutover",
+  "type": "skill",
+  "provider": "azure",
+  "harnesses": [
+    "codex",
+    "claude-code",
+    "cursor",
+    "gemini",
+    "kiro",
+    "other"
+  ],
+  "summary": "Stress-test Azure migration cutovers across assessment quality, landing-zone readiness, dependency sequencing, permissions, rollback, and post-cutover operating ownership.",
+  "source_type": "original",
+  "official_docs": [
+    "https://learn.microsoft.com/en-us/azure/migrate/concepts-overview?view=migrate",
+    "https://learn.microsoft.com/en-us/azure/migrate/assessment-prerequisites?view=migrate",
+    "https://learn.microsoft.com/en-us/azure/migrate/review-application-assessment?view=migrate",
+    "https://learn.microsoft.com/en-us/azure/migrate/platform-landing-zone?view=migrate",
+    "https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/ready-azure-landing-zone",
+    "https://learn.microsoft.com/en-us/azure/migrate/whats-new?view=migrate"
+  ],
+  "security_notes": "Do not equate Azure readiness with cutover readiness. Treat stale assessments, weak dependency mapping, broad migration permissions, missing rollback checkpoints, and incomplete landing-zone connectivity or monitoring as high-risk blockers.",
+  "last_verified": "2026-04-27",
+  "path": "skills/azure/azure-migrate-landing-zone-cutover",
+  "author": "github: Raishin"
+}

--- a/skills/azure/azure-migrate-landing-zone-cutover/references/mcp-and-evidence.md
+++ b/skills/azure/azure-migrate-landing-zone-cutover/references/mcp-and-evidence.md
@@ -1,0 +1,37 @@
+# MCP and Evidence Path
+
+## Official Azure MCP Linkage
+
+Use official Azure MCP capabilities only when they are actually exposed in the active runtime.
+
+Relevant namespaces may include:
+
+- `group`, `subscription`, and `resourcehealth` for target-scope evidence,
+- `azuremigrate` when the client exposes the official Azure Migrate tooling,
+- `monitor` for validation or incident signal posture,
+- `deploy` or `bicepschema` if landing-zone deployment evidence is relevant,
+- generic Azure discovery namespaces when they materially help confirm the target environment.
+
+Do not assume the Azure Migrate namespace exists in the current runtime just because Microsoft documents it. If migration-specific live tooling is missing, switch to documentation-grounded and sanitized-evidence review.
+
+## Platform-Agnostic Execution
+
+This skill must work in MCP-only, macOS, Linux, and Windows clients.
+
+Prefer:
+
+1. assessment evidence,
+2. landing-zone readiness evidence,
+3. sanitized dependency maps and migration wave plans,
+4. neutral placeholder commands or artifacts only when needed.
+
+Do not assume Azure CLI, PowerShell, Terraform, GitHub Actions, or Azure DevOps unless the user confirms the toolchain.
+
+## Documentation Fallback When Live Data Is Unavailable
+
+Live target-state evidence beats theory. If live access is unavailable, incomplete, denied, or too risky:
+
+- fall back to official Azure Migrate and Cloud Adoption Framework guidance,
+- ask for sanitized assessment exports, wave plans, dependency diagrams, landing-zone summaries, and rollback checklists,
+- label each conclusion as `live evidence`, `documentation-based`, `user-provided sanitized evidence`, or `inference`,
+- do not present a migration as safe merely because Azure Migrate produced a recommendation.

--- a/skills/azure/azure-migrate-landing-zone-cutover/references/official-sources.md
+++ b/skills/azure/azure-migrate-landing-zone-cutover/references/official-sources.md
@@ -1,0 +1,12 @@
+# Official Sources
+
+## References
+
+Load these only when needed:
+
+- [Azure Migrate assessment overview](https://learn.microsoft.com/en-us/azure/migrate/concepts-overview?view=migrate)
+- [Prerequisites for assessments](https://learn.microsoft.com/en-us/azure/migrate/assessment-prerequisites?view=migrate)
+- [Review an application assessment](https://learn.microsoft.com/en-us/azure/migrate/review-application-assessment?view=migrate)
+- [Generate and deploy Platform Landing Zone with Azure Migrate](https://learn.microsoft.com/en-us/azure/migrate/platform-landing-zone?view=migrate)
+- [Prepare your landing zone for migration](https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/ready-azure-landing-zone)
+- [What’s new in Azure Migrate](https://learn.microsoft.com/en-us/azure/migrate/whats-new?view=migrate)

--- a/skills/azure/azure-migrate-landing-zone-cutover/references/workflow-and-output.md
+++ b/skills/azure/azure-migrate-landing-zone-cutover/references/workflow-and-output.md
@@ -1,0 +1,117 @@
+# Workflow and Output Contract
+
+## Safe Workflow
+
+1. **Classify migration scope**
+   - application, server, database, web app, or mixed wave,
+   - pilot, low-risk wave, or business-critical cutover,
+   - same-region, cross-region, or hybrid coexistence phase.
+2. **Check discovery and assessment quality**
+   - Was the workload actually discovered?
+   - Is performance data sufficient and current?
+   - Were workloads tagged and grouped correctly?
+   - Are recommendations point-in-time snapshots that may already be stale?
+3. **Check landing-zone readiness**
+   - connectivity,
+   - identity,
+   - policy and governance,
+   - target subscriptions and resource groups,
+   - DNS,
+   - monitoring,
+   - and operator ownership.
+4. **Check dependency realism**
+   - upstream/downstream systems,
+   - database coupling,
+   - authentication dependencies,
+   - certificate or secret paths,
+   - network path and private access requirements.
+5. **Check permissions and tooling**
+   - who can assess,
+   - who can deploy,
+   - who can execute migration,
+   - whether least-privilege roles are used,
+   - whether temporary elevated access is bounded.
+6. **Check cutover mechanics**
+   - cutover trigger,
+   - freeze window,
+   - validation gates,
+   - fallback time limit,
+   - data consistency checks,
+   - DNS or traffic switch behavior.
+7. **Check rollback credibility**
+   - can the source stay authoritative,
+   - how long rollback remains viable,
+   - what changes become irreversible,
+   - who approves rollback.
+8. **Check post-cutover operations**
+   - alerting,
+   - dashboards,
+   - ownership,
+   - incident path,
+   - cost visibility,
+   - decommission sequencing.
+9. **Return a cutover go / no-go verdict**
+   - what is ready,
+   - what is not,
+   - what evidence is missing,
+   - and what must be proven before execution.
+
+## Role-Specific Stress Checks
+
+- Reject “assessment says ready” if dependency and landing-zone evidence are weak.
+- Reject migration waves built from stale or low-quality discovery data.
+- Reject landing-zone claims that skip hybrid connectivity, DNS, RBAC, or monitoring readiness.
+- Reject cutover plans with no explicit freeze window, validation owner, or rollback decision point.
+- Reject permission models that require permanent broad admin rights for routine migration steps.
+- Reject plans that treat migration tooling recommendations as architecture truth.
+- Reject rollback claims that ignore replicated data divergence, DNS TTLs, or irreversible writes.
+
+## Output Template
+
+```markdown
+# Azure Migration Cutover Review: <scope>
+
+## Verdict
+- Status: READY / READY WITH RISKS / NOT READY
+- Biggest risk:
+- Evidence level: live evidence / documentation-based / sanitized evidence / inference
+
+## Scope
+- Migration wave:
+- Workload type:
+- Source environment:
+- Target landing zone:
+- Requested cutover date or window:
+
+## Findings
+| Area | Finding | Severity | Evidence | Recommendation | Owner |
+|---|---|---|---|---|---|
+
+## Cutover readiness review
+| Control area | Expected state | Observed state | Gap | Blocking |
+|---|---|---|---|---|
+| Discovery and assessment quality |  |  |  |  |
+| Landing-zone readiness |  |  |  |  |
+| Dependency mapping |  |  |  |  |
+| Permissions and tooling |  |  |  |  |
+| Cutover validation gates |  |  |  |  |
+| Rollback posture |  |  |  |  |
+| Post-cutover operations |  |  |  |  |
+
+## Safe next actions
+1.
+2.
+3.
+
+## Open questions
+- 
+```
+
+## Red Flags
+
+- The team has no current assessment data or cannot explain how old the data is.
+- The landing zone exists on paper but connectivity, DNS, or monitoring is still incomplete.
+- A migration wave groups systems by convenience instead of dependency reality.
+- The plan has no defined rollback cut-off or authority.
+- Target ownership after cutover is ambiguous.
+- The cutover depends on undocumented MCP or automation behavior.

--- a/skills/azure/azure-network-topology-review/SKILL.md
+++ b/skills/azure/azure-network-topology-review/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: azure-network-topology-review
+description: Use this skill for Azure network architecture review, hub-spoke critique, routing and DNS dependency analysis, shared-services boundary decisions, firewall placement review, and landing-zone connectivity guidance.
+metadata:
+  author: github: Raishin
+---
+
+# Azure Network Topology Review
+
+## Purpose
+
+Review Azure network topology with an operator-grade focus on connectivity boundaries, shared-services design, routing and DNS dependencies, and the separation between platform-owned and workload-owned controls.
+
+This skill is for architecture and review work across:
+
+- hub-spoke versus alternative connectivity models,
+- shared hub services and spoke isolation,
+- peering and subscription boundary decisions,
+- route ownership and forced-tunneling implications,
+- DNS and private name-resolution dependencies,
+- centralized versus workload-local firewall, NVA, and private-endpoint patterns,
+- platform-team versus workload-team control boundaries.
+
+## When to use
+
+Use this skill when the user asks for:
+
+- an Azure hub-spoke review or critique,
+- network topology advice for a landing zone or multi-subscription platform,
+- shared-services placement guidance for DNS, egress, ingress, Bastion, or hybrid connectivity,
+- routing, peering, UDR, gateway-transit, or forced-tunneling concerns,
+- private connectivity architecture review when the main issue is topology and boundary design,
+- clarification of who should own which network controls across platform and workload teams.
+
+Do not use this skill for:
+
+- packet-level troubleshooting,
+- detailed firewall rule authoring,
+- step-by-step ExpressRoute implementation runbooks,
+- a Private Link placement question where private-endpoint design is the primary issue rather than the overall topology.
+
+Route private-endpoint-first questions toward `azure-private-endpoint-adoption-planner` if that skill exists in the repo state the user is working with.
+
+## Lean operating rules
+
+- Prefer live Azure or Microsoft evidence first when the active client exposes it; otherwise fall back to official documentation and sanitized user evidence.
+- Separate confirmed facts from inference. If state was not queried or shown, say so.
+- Challenge broad access, broad scope, destructive changes, and hand-wavy production claims.
+- Keep the answer scoped, reversible, least-privilege, and explicit about blockers or unknowns.
+
+## References
+
+Load these only when needed:
+
+- [MCP and evidence path](references/mcp-and-evidence.md) — use when choosing live Azure evidence, confirming Microsoft MCP capability, or switching to documentation mode.
+- [Workflow and output contract](references/workflow-and-output.md) — use when executing the full review, applying stress checks, or formatting the final answer.
+- [Official sources](references/official-sources.md) — use when you need the detailed Microsoft documentation list or source notes.
+
+## Response minimum
+
+Return, at minimum:
+
+- the scoped target and evidence level,
+- the main risks or control gaps,
+- the safest next actions,
+- the assumptions or blockers that prevent stronger conclusions.

--- a/skills/azure/azure-network-topology-review/metadata.json
+++ b/skills/azure/azure-network-topology-review/metadata.json
@@ -1,0 +1,26 @@
+{
+  "id": "azure-network-topology-review",
+  "name": "Azure Network Topology Review",
+  "type": "skill",
+  "provider": "azure",
+  "harnesses": [
+    "codex",
+    "claude-code",
+    "cursor",
+    "gemini",
+    "kiro",
+    "other"
+  ],
+  "summary": "Review Azure hub-spoke and related network topologies for routing, DNS, shared-services boundaries, security implications, and platform-versus-workload control ownership.",
+  "source_type": "original",
+  "official_docs": [
+    "https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/design-areas",
+    "https://learn.microsoft.com/en-us/azure/architecture/networking/architecture/hub-spoke",
+    "https://learn.microsoft.com/en-us/azure/architecture/networking/guide/private-link-hub-spoke-network",
+    "https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/"
+  ],
+  "security_notes": "Do not recommend flat or over-centralized network patterns by default. Always address routing, DNS, shared-service blast radius, and platform-versus-workload control boundaries before calling a topology safe.",
+  "last_verified": "2026-04-27",
+  "path": "skills/azure/azure-network-topology-review",
+  "author": "github: Raishin"
+}

--- a/skills/azure/azure-network-topology-review/references/mcp-and-evidence.md
+++ b/skills/azure/azure-network-topology-review/references/mcp-and-evidence.md
@@ -1,0 +1,16 @@
+# MCP and Evidence Path
+
+## Evidence path
+
+Prefer evidence in this order:
+
+1. Azure landing-zone design areas for the platform context and design-area coupling:
+   - https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/design-areas
+2. Azure Architecture Center hub-spoke guidance for topology behavior and ownership implications:
+   - https://learn.microsoft.com/en-us/azure/architecture/networking/architecture/hub-spoke
+3. Azure Architecture Center Private Link hub-and-spoke guidance when private networking, DNS, or `/32` route behavior is materially relevant:
+   - https://learn.microsoft.com/en-us/azure/architecture/networking/guide/private-link-hub-spoke-network
+4. Azure MCP discovery guidance, only when the current client actually exposes useful Azure tools:
+   - https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/
+
+If Azure MCP is available, use it for read-focused evidence gathering, not to skip architecture reasoning. Repo-backed docs only support generic Azure MCP tooling plus `group` and `subscription` as clearly named namespaces for scope confirmation, so do not invent unsupported network namespace claims.

--- a/skills/azure/azure-network-topology-review/references/official-sources.md
+++ b/skills/azure/azure-network-topology-review/references/official-sources.md
@@ -1,0 +1,18 @@
+# Official Sources
+
+Load these only when needed:
+
+- [Network topology and connectivity](https://learn.microsoft.com/azure/cloud-adoption-framework/ready/landing-zone/design-area/network-topology-and-connectivity) — use for the landing-zone design-area framing and connectivity-management-group intent.
+- [Hub-spoke network topology in Azure](https://learn.microsoft.com/azure/architecture/networking/architecture/hub-spoke) — use for hub-spoke recommendations, non-transitive peering, spoke-to-spoke patterns, and gateway transit.
+- [Azure Private Link in a hub-and-spoke network](https://learn.microsoft.com/azure/architecture/networking/guide/private-link-hub-spoke-network) — use for hub-versus-spoke private endpoint placement, `/32` route propagation, DNS requirements, and on-premises implications.
+- [Private Link and DNS integration at scale](https://learn.microsoft.com/azure/cloud-adoption-framework/ready/azure-best-practices/private-link-and-dns-integration-at-scale) — use when DNS and private endpoint resolution are the real bottleneck.
+- [Integrate Azure services with virtual networks for network isolation](https://learn.microsoft.com/azure/virtual-network/vnet-integration-for-azure-services) — use when the user is confusing Private Link with other integration patterns.
+- [Azure landing zone design areas and conceptual architecture](https://learn.microsoft.com/azure/cloud-adoption-framework/ready/landing-zone/design-areas) — use when topology choices are coupled to broader landing-zone organization.
+- [Azure MCP Server tools inventory](https://learn.microsoft.com/azure/developer/azure-mcp-server/tools/) — use to verify `group`, `subscription`, `monitor`, or other documented namespaces before naming them.
+
+## Grounded insights worth carrying into the skill
+
+- Virtual network peering is non-transitive. Any answer that assumes transitivity is broken.
+- Private endpoints in spokes inject `/32` routes that propagate across peerings and VPN or ExpressRoute paths; if you ignore that, your topology advice is shallow.
+- Private endpoint success depends on deliberate DNS zone linkage and resolution path, not just resource placement.
+- In Virtual WAN, private endpoints belong in connected spoke virtual networks, not in the hub itself.

--- a/skills/azure/azure-network-topology-review/references/workflow-and-output.md
+++ b/skills/azure/azure-network-topology-review/references/workflow-and-output.md
@@ -1,0 +1,129 @@
+# Workflow and Output Contract
+
+## Workflow
+
+1. Classify the topology before recommending anything.
+   - hub-spoke, flat peering mesh, Virtual WAN-adjacent, or unclear,
+   - single region or multi-region,
+   - single subscription or multi-subscription,
+   - Azure-only or hybrid with on-premises connectivity.
+2. Identify ownership and trust boundaries.
+   - which controls are platform-owned,
+   - which controls are workload-owned,
+   - which services are shared: DNS, firewall, Bastion, gateways, inspection, private endpoints, or monitoring,
+   - whether the current design accidentally centralizes too much or delegates too much.
+3. Map the current shared-services pattern.
+   - hub resources and their role,
+   - spoke purpose by environment or workload,
+   - whether spokes are isolated by subscription, resource group, environment, or team,
+   - whether cross-spoke communication is required, forbidden, or poorly defined.
+4. Challenge the connectivity model.
+   - hub-and-spoke is not automatically correct,
+   - flat peering becomes operational debt at scale,
+   - direct spoke-to-spoke connectivity changes blast radius,
+   - a central hub can become an outage choke point if routing, DNS, or firewall decisions are brittle.
+5. Review routing dependencies explicitly.
+   - peering is non-transitive,
+   - gateway-transit expectations must be deliberate,
+   - UDR ownership must be clear,
+   - forced tunneling through Azure Firewall or an NVA changes east-west and egress behavior,
+   - hybrid paths need route and failure-domain thinking, not just connectivity diagrams.
+6. Review DNS dependencies explicitly.
+   - shared DNS is often a hidden platform dependency,
+   - private endpoint resolution requires deliberate private DNS zone linkage,
+   - custom DNS and on-premises resolution paths can become the real failure point,
+   - if name resolution is undefined, the topology is incomplete even if peering exists.
+7. Review security and inspection boundaries.
+   - what the hub inspects,
+   - what stays workload-local,
+   - whether central egress or ingress policy is justified,
+   - whether NSGs, firewalls, NVAs, and private endpoints are being mixed without a clear control model,
+   - whether the design reduces or expands lateral-movement risk.
+8. Review shared versus workload-local private networking decisions.
+   - if many workloads need the same PaaS resource, central hub placement may simplify routing and control,
+   - if only specific workloads need access, workload-local placement may better preserve least privilege,
+   - call out `/32` route implications and DNS dependencies when private endpoints are involved.
+   - if Virtual WAN is in play, remember private endpoints belong in connected spokes, not in the hub itself.
+9. Surface bottlenecks and failure domains.
+   - single hub per region assumptions,
+   - shared firewall throughput or rule-management bottlenecks,
+   - DNS forwarder fragility,
+   - operational coupling between unrelated workloads,
+   - unclear rollback path for route-table or peering changes.
+10. Return concrete topology corrections.
+   - what should stay centralized,
+   - what should move to workload boundaries,
+   - what routing or DNS assumptions must be fixed first,
+   - what should be validated before any production change.
+
+## Output contract
+
+Return all of the following:
+
+- **Topology summary**: current or proposed model, regions, subscriptions, and connectivity pattern.
+- **Ownership model**: platform-owned controls versus workload-owned controls.
+- **Key risks**: routing, DNS, blast radius, operational bottlenecks, and security boundary weaknesses.
+- **Recommended topology adjustments**: specific changes to hub, spokes, peering, shared services, or private-network placement.
+- **Validation checks**: bounded checks for routes, DNS resolution, peering intent, and access paths.
+- **Open questions and assumptions**: what is still unknown and why it matters.
+- **Evidence used**: Microsoft Learn pages and any Azure MCP namespaces actually used.
+
+Use this response shape:
+
+```text
+Topology summary
+- Model: ...
+- Regions/subscriptions: ...
+- Shared services: ...
+
+Ownership model
+- Platform-owned: ...
+- Workload-owned: ...
+
+Key risks
+- Routing: ...
+- DNS: ...
+- Security / blast radius: ...
+- Operations: ...
+
+Recommended topology adjustments
+- ...
+
+Validation checks
+- Confirm peering and gateway-transit intent
+- Confirm effective routes or UDR ownership
+- Confirm DNS resolution path
+- Confirm security-control boundary
+
+Open questions and assumptions
+- ...
+```
+
+## Eval gate
+
+The skill output fails if it does not do all of the following:
+
+1. classify the actual topology and connectivity model,
+2. identify shared services and trust boundaries,
+3. separate platform-owned controls from workload-owned controls,
+4. call out routing dependencies, including peering non-transitivity where relevant,
+5. call out DNS dependencies instead of treating them as an implementation detail,
+6. address security and blast-radius implications,
+7. return concrete topology corrections rather than generic “use hub-spoke” advice,
+8. state assumptions and missing facts explicitly.
+
+Minimum scenarios this skill should handle:
+
+1. hub-spoke review for a multi-subscription landing zone,
+2. shared-services boundary critique across platform and workload teams,
+3. hybrid-routing or private-networking concern review where DNS and route dependencies matter.
+
+## Safety notes
+
+- Do not say a flat network is acceptable by default just because it is simpler.
+- Do not recommend centralizing every control in the hub; that often creates a high-blast-radius bottleneck.
+- Do not recommend workload-local exceptions without explaining the operational and security tradeoff.
+- Do not ignore DNS. A topology that “works on paper” but has no credible name-resolution path is not production-ready.
+- Do not treat route tables, gateway transit, or forced tunneling as minor implementation details; they are architecture decisions.
+- Do not blur platform-shared controls and workload-local controls. Ambiguous ownership becomes outage fuel.
+- Be explicit when advice is inference from incomplete topology evidence rather than confirmed current-state facts.

--- a/skills/azure/azure-observability-investigator/SKILL.md
+++ b/skills/azure/azure-observability-investigator/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: azure-observability-investigator
+description: Use this skill for Azure Monitor, Log Analytics, Application Insights, alerting, KQL triage, telemetry-gap analysis, workbooks, or operator-grade incident and posture investigations.
+metadata:
+  author: github: Raishin
+---
+
+# Azure Observability Investigator
+
+## Purpose
+
+Investigate Azure operational health using evidence from metrics, logs, traces, alerts, and observability configuration before jumping to root-cause claims.
+
+This skill is for operator-grade Azure monitoring work across:
+
+- Azure Monitor metrics and logs,
+- Log Analytics workspace design and query posture,
+- Application Insights telemetry and dependency signals,
+- alert rules, action groups, and alert processing rules,
+- workbook or Grafana-backed operational visibility,
+- KQL-based triage,
+- telemetry blind spots, noisy alerts, and missing-signal investigations.
+
+## When to use
+
+Use this skill when the user asks for:
+
+- Azure Monitor or Application Insights incident investigation,
+- noisy, duplicate, stale, or low-value alert review,
+- Log Analytics or KQL triage help,
+- missing telemetry or observability-gap analysis,
+- workspace or signal-placement review,
+- dashboard, workbook, or operational reporting critique,
+- recommended next diagnostic steps for a recent failure.
+
+Do not use this skill as a substitute for:
+
+- full application debugging with code changes,
+- SIEM engineering or Microsoft Sentinel content design,
+- resource-health-first outage triage when the main question is whether Azure itself is degraded,
+- instrumentation implementation details unless the user asks for that next.
+
+## Lean operating rules
+
+- Prefer live Azure or Microsoft evidence first when the active client exposes it; otherwise fall back to official documentation and sanitized user evidence.
+- Separate confirmed facts from inference. If state was not queried or shown, say so.
+- Challenge broad access, broad scope, destructive changes, and hand-wavy production claims.
+- Keep the answer scoped, reversible, least-privilege, and explicit about blockers or unknowns.
+
+## References
+
+Load these only when needed:
+
+- [MCP and evidence path](references/mcp-and-evidence.md) — use when choosing live Azure evidence, confirming Microsoft MCP capability, or switching to documentation mode.
+- [Workflow and output contract](references/workflow-and-output.md) — use when executing the full review, applying stress checks, or formatting the final answer.
+- [Official sources](references/official-sources.md) — use when you need the detailed Microsoft documentation list or source notes.
+
+## Response minimum
+
+Return, at minimum:
+
+- the scoped target and evidence level,
+- the main risks or control gaps,
+- the safest next actions,
+- the assumptions or blockers that prevent stronger conclusions.

--- a/skills/azure/azure-observability-investigator/metadata.json
+++ b/skills/azure/azure-observability-investigator/metadata.json
@@ -1,0 +1,37 @@
+{
+  "id": "azure-observability-investigator",
+  "name": "Azure Observability Investigator",
+  "type": "skill",
+  "provider": "azure",
+  "harnesses": [
+    "codex",
+    "claude-code",
+    "cursor",
+    "gemini",
+    "kiro",
+    "other"
+  ],
+  "summary": "Investigate Azure Monitor, Log Analytics, Application Insights, alerting, KQL triage, telemetry gaps, and observability workflows with explicit evidence-versus-inference handling.",
+  "source_type": "original",
+  "official_docs": [
+    "https://learn.microsoft.com/en-us/azure/azure-monitor/overview",
+    "https://learn.microsoft.com/en-us/azure/azure-monitor/best-practices-analysis",
+    "https://learn.microsoft.com/en-us/azure/azure-monitor/alerts/alerts-overview",
+    "https://learn.microsoft.com/en-us/azure/azure-monitor/alerts/action-groups",
+    "https://learn.microsoft.com/en-us/azure/azure-monitor/alerts/alerts-processing-rules",
+    "https://learn.microsoft.com/en-us/azure/azure-monitor/logs/log-analytics-workspace-overview",
+    "https://learn.microsoft.com/en-us/azure/azure-monitor/logs/workspace-design",
+    "https://learn.microsoft.com/en-us/azure/azure-monitor/logs/get-started-queries",
+    "https://learn.microsoft.com/en-us/azure/azure-monitor/app/app-insights-overview",
+    "https://learn.microsoft.com/en-us/azure/well-architected/service-guides/application-insights",
+    "https://learn.microsoft.com/en-us/azure/azure-monitor/visualize/workbooks-overview",
+    "https://learn.microsoft.com/en-us/azure/azure-monitor/visualize/visualize-grafana-overview",
+    "https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/",
+    "https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/monitor",
+    "https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/azure-monitor"
+  ],
+  "security_notes": "Do not over-attribute symptoms as root cause, ignore missing telemetry, or recommend broad alerting changes without signal-quality review, routing checks, and bounded verification steps.",
+  "last_verified": "2026-04-27",
+  "path": "skills/azure/azure-observability-investigator",
+  "author": "github: Raishin"
+}

--- a/skills/azure/azure-observability-investigator/references/mcp-and-evidence.md
+++ b/skills/azure/azure-observability-investigator/references/mcp-and-evidence.md
@@ -1,0 +1,37 @@
+# MCP and Evidence Path
+
+## Evidence path
+
+Prefer evidence in this order:
+
+1. Azure Monitor fundamentals and analysis guidance:
+   - https://learn.microsoft.com/en-us/azure/azure-monitor/overview
+   - https://learn.microsoft.com/en-us/azure/azure-monitor/best-practices-analysis
+2. Alerts and notification flow:
+   - https://learn.microsoft.com/en-us/azure/azure-monitor/alerts/alerts-overview
+   - https://learn.microsoft.com/en-us/azure/azure-monitor/alerts/action-groups
+   - https://learn.microsoft.com/en-us/azure/azure-monitor/alerts/alerts-processing-rules
+3. Log Analytics and query posture:
+   - https://learn.microsoft.com/en-us/azure/azure-monitor/logs/log-analytics-workspace-overview
+   - https://learn.microsoft.com/en-us/azure/azure-monitor/logs/workspace-design
+   - https://learn.microsoft.com/en-us/azure/azure-monitor/logs/get-started-queries
+4. Application Insights and application telemetry:
+   - https://learn.microsoft.com/en-us/azure/azure-monitor/app/app-insights-overview
+   - https://learn.microsoft.com/en-us/azure/well-architected/service-guides/application-insights
+5. Visualization and reporting:
+   - https://learn.microsoft.com/en-us/azure/azure-monitor/visualize/workbooks-overview
+   - https://learn.microsoft.com/en-us/azure/azure-monitor/visualize/visualize-grafana-overview
+6. Azure MCP discovery and monitor tools, when supported in the client:
+   - https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/
+   - https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/azure-monitor
+   - https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/application-insights
+
+Only mention Azure MCP namespaces when they are actually useful to the task. Based on the repo spec, relevant namespaces can include:
+
+- `monitor` for logs and metrics
+- `applicationinsights` for Application Insights resource discovery, not as a substitute for full Azure Monitor analysis
+- `kusto` only if Azure Data Explorer is actually part of the observability stack
+- `workbooks`
+- `grafana`
+
+Use live MCP evidence to reduce guesswork. Do not pretend a namespace is available if the client does not expose it.

--- a/skills/azure/azure-observability-investigator/references/official-sources.md
+++ b/skills/azure/azure-observability-investigator/references/official-sources.md
@@ -1,0 +1,18 @@
+# Official Sources
+
+Load these only when needed:
+
+- [Monitor Azure resources with Azure Monitor](https://learn.microsoft.com/azure/azure-monitor/platform/monitor-azure-resource) — use for the basic monitoring surface: Activity Log, Alerts, Metrics, Diagnostic settings, and Logs.
+- [Introduction to Application Insights - OpenTelemetry observability](https://learn.microsoft.com/azure/azure-monitor/app/app-insights-overview) — use for Application Insights investigation views, telemetry paths, and OpenTelemetry-oriented instrumentation expectations.
+- [Architecture strategies for designing a monitoring system](https://learn.microsoft.com/azure/well-architected/operational-excellence/observability) — use for the broader observability-system architecture, including Azure Monitor, Log Analytics, Network Watcher, and operational design.
+- [Architecture best practices for Log Analytics](https://learn.microsoft.com/azure/well-architected/service-guides/azure-log-analytics) — use for workspace design, reliability, retention, and operational-excellence tradeoffs.
+- [Architecture best practices for Application Insights](https://learn.microsoft.com/azure/well-architected/service-guides/application-insights) — use for environment separation, workspace dependency, and alerting or instrumentation quality.
+- [Azure Monitor alerts overview](https://learn.microsoft.com/azure/azure-monitor/alerts/alerts-overview) — use for alert types, routing, and action-group behavior.
+- [Azure MCP Server tools inventory](https://learn.microsoft.com/azure/developer/azure-mcp-server/tools/) — use to verify `monitor`, `applicationinsights`, `workbooks`, `grafana`, or other documented namespaces before naming them.
+
+## Grounded insights worth carrying into the skill
+
+- Resource logs do not become queryable just because a service exists; Microsoft explicitly states you need diagnostic settings to route them.
+- Application Insights is part of Azure Monitor and depends on its underlying workspace and routing design; do not treat it as a standalone magic box.
+- Microsoft recommends one Application Insights resource per workload per environment to avoid mixed telemetry and investigation confusion.
+- Dashboards and workbooks are downstream views. If the underlying logs and metrics are missing or misrouted, the pretty dashboard proves nothing.

--- a/skills/azure/azure-observability-investigator/references/workflow-and-output.md
+++ b/skills/azure/azure-observability-investigator/references/workflow-and-output.md
@@ -1,0 +1,131 @@
+# Workflow and Output Contract
+
+## Workflow
+
+1. Classify the problem before querying anything.
+   - metrics symptom,
+   - logs symptom,
+   - traces or dependency symptom,
+   - alerting symptom,
+   - configuration or coverage gap,
+   - mixed incident where multiple signal types must be correlated.
+2. Establish incident frame and uncertainty.
+   - what broke,
+   - when it started,
+   - whether the issue is current or historical,
+   - affected workload, region, environment, and blast radius,
+   - what telemetry is expected but may be missing.
+3. Gather the highest-value evidence first.
+   - current or recent alerts,
+   - resource and application metrics,
+   - relevant Log Analytics tables,
+   - Application Insights failures, dependencies, requests, exceptions, or availability signals,
+   - workbook or dashboard views only after validating the underlying data source.
+4. Separate evidence from correlation from inference.
+   - **Evidence**: direct signal observed in metrics, logs, traces, or alert configuration.
+   - **Correlation**: timing or co-occurrence that suggests a relationship.
+   - **Inference**: likely explanation that is not directly proven by the collected signals.
+5. Investigate alert quality, not just whether an alert fired.
+   - signal type and threshold quality,
+   - action-group wiring,
+   - alert-processing rules that suppress, route, or mutate behavior,
+   - duplicate or overlapping alerts,
+   - stale alerts tied to bad dimensions, wrong scope, or wrong evaluation windows,
+   - absence-of-data situations that may actually be ingestion or telemetry failure.
+6. Review telemetry coverage and workspace posture.
+   - whether the right resource or app emits telemetry at all,
+   - whether logs, metrics, and traces land in the expected workspace or resource,
+   - whether workspace sprawl is obscuring triage,
+   - whether retention, table design, or access mode blocks investigation,
+   - whether cross-resource or cross-workspace queries are required.
+   - whether diagnostic settings were ever enabled; without them, many platform logs will never be queryable.
+   - whether Application Insights is separated per workload and environment or mixed together into unusable noise.
+7. Use KQL deliberately.
+   - start narrow with timeframe, resource, operation, or failure boundary,
+   - verify table/schema assumptions before writing fancy joins,
+   - correlate requests, dependencies, exceptions, and platform logs only when the data actually exists,
+   - if no query can prove the claim, say so.
+8. Assess observability outputs.
+   - workbooks should reflect validated source data, not decorative charts,
+   - Grafana or workbook dashboards are downstream views, not primary evidence,
+   - recommend query, visualization, or ownership fixes only after validating source signals.
+9. End with operator actions.
+   - immediate triage next steps,
+   - alert tuning or suppression fixes,
+   - telemetry additions or routing corrections,
+   - ownership handoff if platform versus application responsibility is split,
+   - residual blind spots that prevent stronger conclusions.
+
+## Output contract
+
+Return all of the following:
+
+- **Issue summary**: what symptom is being investigated and its apparent blast radius.
+- **Signals reviewed**: metrics, logs, traces, alerts, workbooks, dashboards, and namespaces actually used.
+- **Evidence table**: direct evidence, correlated signals, and explicit inferences kept separate.
+- **Likely failure domain**: application, platform configuration, alerting design, workspace design, telemetry gap, or unresolved.
+- **Telemetry gaps**: what data is missing, delayed, misrouted, or too low-quality to support confident diagnosis.
+- **Recommended improvements**: concrete query, alert, action-group, alert-processing-rule, workbook, or workspace changes.
+- **Next diagnostic steps**: bounded follow-up actions in priority order.
+- **Assumptions and unknowns**: what remains unproven.
+
+Use a response shape like:
+
+```text
+Issue summary
+- ...
+
+Signals reviewed
+- Metrics: ...
+- Logs: ...
+- Traces/Application Insights: ...
+- Alerts and routing: ...
+
+Evidence vs inference
+- Evidence: ...
+- Correlation: ...
+- Inference: ...
+
+Likely failure domain
+- ...
+
+Telemetry gaps
+- ...
+
+Recommended improvements
+- ...
+
+Next diagnostic steps
+- ...
+
+Assumptions and unknowns
+- ...
+```
+
+## Eval gate
+
+Treat the answer as failing if it does any of the following:
+
+- claims root cause without separating evidence from inference,
+- ignores ingestion delay or missing telemetry risk,
+- recommends alert changes without checking signal quality, scope, or routing,
+- treats workbook or dashboard visuals as proof without validating underlying data,
+- skips Log Analytics or Application Insights when they are central to the ask,
+- omits telemetry gaps and residual blind spots,
+- returns generic Azure Monitor advice with no operator next steps.
+
+Minimum scenarios this skill should handle:
+
+1. noisy or duplicate alert review,
+2. recent application or platform failure investigation,
+3. baseline telemetry-gap assessment for an under-instrumented workload.
+
+## Safety notes
+
+- Do not pretend logs prove what they do not prove.
+- Do not collapse correlation into causation.
+- Do not assume lack of logs means lack of failure; it may mean telemetry never arrived.
+- Do not recommend broad alert proliferation as a fix for poor signal design.
+- Do not expose secrets, customer payloads, tokens, or sensitive query results in the response.
+- Do not suggest mutating production alerting or workbook content without calling out rollback or verification steps.
+- Be explicit when a conclusion is based on partial telemetry, stale dashboards, or unverified workspace assumptions.

--- a/skills/azure/azure-platform-automation-devops/SKILL.md
+++ b/skills/azure/azure-platform-automation-devops/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: azure-platform-automation-devops
+description: Design and review Azure platform automation and DevOps delivery for landing zones, shared platform services, and safe infrastructure rollout flows. Use for IaC approach selection, Bicep versus Terraform positioning, bootstrap/run phase separation, pipeline control design, secret-handling posture, and rollout validation gates.
+metadata:
+  author: github: Raishin
+  version: 0.1.0
+---
+
+# Azure Platform Automation DevOps
+
+## Role Charter
+
+Act as a ruthless Azure platform automation and DevOps reviewer. Your job is to stop fragile platform delivery, not to rubber-stamp pipelines.
+
+Force clarity on:
+
+- platform landing zone scope versus workload scope,
+- bootstrap versus steady-state run phases,
+- Bicep versus Terraform decision criteria,
+- platform pipeline versus application pipeline separation,
+- identity and secret-handling model,
+- validation gates, approvals, rollback path, and blast radius.
+
+Default posture:
+
+- Prefer official Microsoft guidance and official Azure MCP capabilities when they reduce guesswork.
+- Treat production mutations as high risk unless the rollout path, approvals, and rollback path are explicit.
+- Never ask the user to paste secrets, client secrets, certificates, tokens, publish profiles, or tenant-specific credentials into chat.
+- Do not assume one IaC language, one CI/CD system, or one branching model fits every Azure platform.
+
+## Trigger Situations
+
+Use this skill when the user asks to:
+
+- design or review Azure landing-zone automation delivery,
+- choose between Bicep, Terraform, or Azure landing zone accelerator patterns,
+- separate bootstrap, platform, and workload deployment flows,
+- define CI/CD controls for Azure platform changes,
+- harden secret handling for infrastructure delivery,
+- design safe rollout patterns for App Service or other Azure platform-hosted deployments,
+- add validation gates such as lint, what-if, schema checks, approvals, smoke tests, and rollback steps.
+
+Do not use this skill for:
+
+- narrow RBAC-only questions with no automation design component,
+- workload code-release strategy that is unrelated to Azure platform delivery,
+- writing a full production pipeline before the control model is agreed,
+- pretending application deployment and platform governance can share one uncontrolled pipeline.
+
+## Lean operating rules
+
+- Prefer live Azure or Microsoft evidence first when the active client exposes it; otherwise fall back to official documentation and sanitized user evidence.
+- Separate confirmed facts from inference. If state was not queried or shown, say so.
+- Challenge broad access, broad scope, destructive changes, and hand-wavy production claims.
+- Keep the answer scoped, reversible, least-privilege, and explicit about blockers or unknowns.
+
+## References
+
+Load these only when needed:
+
+- [MCP and evidence path](references/mcp-and-evidence.md) — use when choosing live Azure evidence, confirming Microsoft MCP capability, or switching to documentation mode.
+- [Workflow and output contract](references/workflow-and-output.md) — use when executing the full review, applying stress checks, or formatting the final answer.
+- [Official sources](references/official-sources.md) — use when you need the detailed Microsoft documentation list or source notes.
+
+## Response minimum
+
+Return, at minimum:
+
+- the scoped target and evidence level,
+- the main risks or control gaps,
+- the safest next actions,
+- the assumptions or blockers that prevent stronger conclusions.

--- a/skills/azure/azure-platform-automation-devops/metadata.json
+++ b/skills/azure/azure-platform-automation-devops/metadata.json
@@ -1,0 +1,32 @@
+{
+  "id": "azure-platform-automation-devops",
+  "name": "Azure Platform Automation DevOps",
+  "type": "skill",
+  "provider": "azure",
+  "harnesses": [
+    "codex",
+    "claude-code",
+    "cursor",
+    "gemini",
+    "kiro",
+    "other"
+  ],
+  "summary": "Design and review Azure platform automation delivery across landing-zone IaC choices, bootstrap-versus-run separation, infra-versus-app pipelines, secret handling, validation gates, and safe rollout patterns.",
+  "source_type": "original",
+  "official_docs": [
+    "https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/",
+    "https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/implementation-options",
+    "https://learn.microsoft.com/en-us/azure/architecture/landing-zones/bicep/landing-zone-bicep",
+    "https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/terraform-landing-zone",
+    "https://learn.microsoft.com/en-us/azure/app-service/deploy-best-practices",
+    "https://learn.microsoft.com/en-us/azure/app-service/deploy-staging-slots?view=azure-devops-2020",
+    "https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/",
+    "https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/azure-deploy",
+    "https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/bicep-mcp-server",
+    "https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/"
+  ],
+  "security_notes": "Keep bootstrap and steady-state delivery separate, do not mix platform and application pipelines without control boundaries, never store secrets in repo or pipeline definitions, and require preview, validation, approval, and rollback paths before production-impacting Azure changes.",
+  "last_verified": "2026-04-27",
+  "path": "skills/azure/azure-platform-automation-devops",
+  "author": "github: Raishin"
+}

--- a/skills/azure/azure-platform-automation-devops/references/mcp-and-evidence.md
+++ b/skills/azure/azure-platform-automation-devops/references/mcp-and-evidence.md
@@ -1,0 +1,37 @@
+# MCP and Evidence Path
+
+## Official Azure MCP Linkage
+
+Use only official Azure MCP capabilities that are actually exposed in the active client runtime. Do not invent tools.
+
+Preferred official linkage for this role:
+
+- `deploy` for Azure deployment workflows when the client exposes official Azure deploy tooling.
+- `bicepschema` when the client exposes Azure MCP schema retrieval for Bicep-oriented infrastructure definition.
+- `extension` when the user needs official guidance for Azure Developer CLI or related deployment tooling setup.
+
+Rules:
+
+- Verify available Azure MCP capabilities from the official Azure MCP tool inventory before leaning on them.
+- Treat read-only discovery differently from mutating deployment operations.
+- Do not imply that Bicep MCP authoring tools can deploy resources directly when the official documentation says they are for code-generation support rather than direct deployment.
+- If the expected Azure MCP capability is absent, switch cleanly to documentation-based guidance instead of hallucinating a tool path.
+
+## Platform-Agnostic Execution
+
+This skill must work across macOS, Windows, Linux, and MCP-only clients.
+
+- Prefer architecture decisions, pipeline stages, and control patterns over shell-specific commands.
+- When examples are useful, show neutral placeholders such as `<subscription>`, `<management-group>`, `<pipeline>`, `<service-connection>`, and `<identity>`.
+- Adapt command syntax only after the user’s actual runtime or CI system is known.
+- Keep Bicep, Terraform, Azure DevOps, GitHub Actions, and Azure Developer CLI examples conceptually portable unless the user has already fixed the toolchain.
+
+## Documentation Fallback When Live Data Is Unavailable
+
+Live Azure MCP evidence beats static guidance for current-state validation. If live Azure inspection is unavailable, incomplete, unsafe, or denied:
+
+- fall back to official Microsoft Learn and Azure Architecture Center guidance listed above,
+- ask for sanitized pipeline structure, repo layout, stage diagram, or redacted deployment definitions if current-state evidence is required,
+- label conclusions as `live evidence`, `documentation-based`, `user-provided sanitized evidence`, or `inference`,
+- do not claim the user’s current pipeline is safe merely because a Microsoft pattern exists,
+- do not claim a tool is available in the user’s runtime unless it was confirmed live.

--- a/skills/azure/azure-platform-automation-devops/references/official-sources.md
+++ b/skills/azure/azure-platform-automation-devops/references/official-sources.md
@@ -1,0 +1,16 @@
+# Official Sources
+
+## References
+
+Load these only when needed:
+
+- [Azure landing zone overview](https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/) — use for platform-versus-application landing zone boundaries and Microsoft’s recommended Azure landing zone operating model.
+- [Platform landing zone implementation options](https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/implementation-options) — use for choosing between IaC accelerator, Bicep, Terraform, and portal-based approaches.
+- [Azure landing zone Bicep guidance](https://learn.microsoft.com/en-us/azure/architecture/landing-zones/bicep/landing-zone-bicep) — use for Bicep accelerator structure, modular delivery, and deployment-stack-aware platform automation.
+- [Terraform landing zone guidance](https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/terraform-landing-zone) — use when the user is standardizing on Terraform for Azure landing zone delivery.
+- [Deployment best practices for Azure App Service](https://learn.microsoft.com/en-us/azure/app-service/deploy-best-practices) — use for deployment-source/build/deploy separation, slot-safe release patterns, and production safety.
+- [App Service staging slots](https://learn.microsoft.com/en-us/azure/app-service/deploy-staging-slots?view=azure-devops-2020) — use for swap-based rollout, warm-up, and rollback patterns.
+- [Azure MCP Server tools inventory](https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/) — use to verify which official Azure MCP capabilities actually exist before suggesting them.
+- [Azure Deploy tools for Azure MCP Server](https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/azure-deploy) — use when live deploy-oriented MCP support is relevant.
+- [Bicep MCP server](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/bicep-mcp-server) — use when schema-aware Bicep authoring support is relevant and to avoid inventing deploy behavior it does not provide.
+- [Bicep documentation](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/) — use for authoritative Bicep deployment, modules, scopes, and what-if references.

--- a/skills/azure/azure-platform-automation-devops/references/workflow-and-output.md
+++ b/skills/azure/azure-platform-automation-devops/references/workflow-and-output.md
@@ -1,0 +1,109 @@
+# Workflow and Output Contract
+
+## Safe Workflow
+
+1. **Classify the automation boundary**
+   - platform landing zone, shared platform service, workload infrastructure, or app release;
+   - bootstrap-only, steady-state run, or both.
+2. **Separate ownership and blast radius**
+   - who owns management-group or subscription bootstrap,
+   - who owns platform baselines,
+   - who owns workload delivery,
+   - whether app teams can trigger infra mutations.
+3. **Choose the IaC control model**
+   - use Microsoft’s recommended Azure landing zone IaC accelerator when landing-zone delivery needs structured bootstrap and continuous delivery;
+   - choose Bicep when Azure-native schema fidelity, ARM alignment, and Azure-first modularity are primary;
+   - choose Terraform when cross-team standardization, existing Terraform operating model, or broader multi-environment consistency is the real driver;
+   - reject tool choice by fashion.
+4. **Split bootstrap from run**
+   - bootstrap phase: initial credentials, repository wiring, runner/service-connection setup, state or deployment control prerequisites, management-group/subscription onboarding;
+   - run phase: repeatable policy, networking, identity, platform service, and workload-safe deployment flows.
+5. **Separate infrastructure and application pipelines**
+   - infrastructure pipeline handles landing-zone and shared-platform changes,
+   - application pipeline consumes approved platform contracts,
+   - production application deployment should not bypass platform guardrails by mutating foundational infrastructure directly.
+6. **Lock down secret handling**
+   - no secrets in repo,
+   - no secrets in pipeline variables unless the platform’s approved secret store and identity model justify it,
+   - prefer managed identity, workload identity, or equivalent non-secret trust paths where the platform supports them,
+   - minimize human-held credentials in bootstrap and rotate any unavoidable temporary credentials.
+7. **Define validation gates**
+   - schema/lint validation,
+   - dependency and scope review,
+   - plan or what-if style preview before mutation,
+   - nonproduction deployment,
+   - smoke or health validation,
+   - explicit approval before production-impacting rollout,
+   - documented rollback or reverse-deploy path.
+8. **Choose safe release mechanics**
+   - prefer staged rollout patterns for platform-impacting change,
+   - for App Service, prefer nonproduction slot validation and swap-based promotion where applicable,
+   - avoid direct-to-production deployment when staging, warm-up, and rollback are available.
+9. **Return a go/no-go verdict**
+   - include blockers, residual risks, required evidence, and the next safest step.
+
+## Role-Specific Stress Checks
+
+- Reject any design that mixes management-group bootstrap, platform governance rollout, and workload deployment into one opaque pipeline with shared credentials.
+- Reject any “Bicep vs Terraform” answer that does not name the operating reason. Tool tribalism is not architecture.
+- Reject pipelines that let application release jobs modify shared platform baselines without separate controls.
+- Reject any secret-handling model that depends on pasting secrets into YAML, repo variables, markdown, or chat.
+- Challenge any claim that “continuous deployment to production” is safe if preview, slotting, smoke validation, or approvals were skipped.
+- Challenge bootstrap designs that require standing global admin or subscription-owner credentials long after initial setup.
+- Distinguish `bootstrap convenience` from `steady-state safety`; they are not the same phase and should not keep the same privileges.
+- Do not treat Azure MCP presence as proof that mutation should be automated. Capability is not authorization.
+
+## Output Template
+
+```markdown
+# Azure Platform Automation Review: <scope>
+
+## Verdict
+- Status: READY / READY WITH RISKS / NOT READY
+- Biggest risk:
+- Evidence level: live evidence / documentation-based / sanitized evidence / inference
+
+## Scope
+- Platform boundary:
+- Environment(s):
+- Ownership model:
+- Requested change:
+
+## Delivery model
+- IaC approach:
+- Why this approach:
+- Bootstrap phase:
+- Run phase:
+- Infra/app pipeline split:
+
+## Control and safety findings
+| Area | Finding | Severity | Evidence | Recommendation | Owner |
+|---|---|---|---|---|---|
+
+## Validation gates
+| Gate | Required | Why | Blocking if absent |
+|---|---|---|---|
+
+## Rollout path
+1.
+2.
+3.
+
+## Rollback path
+1.
+2.
+3.
+
+## Open questions
+- 
+```
+
+## Red Flags
+
+- The plan deploys foundational Azure changes straight to production with no preview, no stage validation, and no rollback.
+- The same pipeline identity can bootstrap tenant or subscription foundations and also run routine app releases.
+- The answer says “use Terraform” or “use Bicep” without naming the actual operating constraints.
+- The design stores secrets in source control, static pipeline YAML, copied variables, or chat.
+- The pipeline mixes platform baselines, workload infrastructure, and application code promotion without separate control points.
+- The recommendation assumes Azure MCP deploy or Bicep tooling exists in the runtime without live confirmation.
+- The release strategy ignores App Service slot-based safety even when the target platform supports it.

--- a/skills/azure/azure-private-endpoint-adoption-planner/SKILL.md
+++ b/skills/azure/azure-private-endpoint-adoption-planner/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: azure-private-endpoint-adoption-planner
+description: Use this skill for Azure Private Link and private endpoint adoption planning, including hub-versus-spoke placement, private DNS zone linkage, route implications, centralized versus workload-local endpoint trade-offs, and safe rollout validation.
+metadata:
+  author: github: Raishin
+  version: 0.1.0
+---
+
+# Azure Private Endpoint Adoption Planner
+
+## Role Charter
+
+Act as a ruthless Azure private connectivity planner. Your job is to stop weak Private Link designs before they become DNS outages, route surprises, or over-centralized bottlenecks. Force exact scope, target PaaS services, consumer networks, subscription boundaries, DNS ownership, and rollback expectations before recommending endpoint placement.
+
+Default posture:
+
+- Prefer official Microsoft Learn and Azure Architecture Center guidance over memory or blog lore.
+- Prefer read-only Azure MCP evidence when the active client exposes useful official Azure capabilities.
+- Do not invent Azure MCP tools or namespaces for private endpoints, DNS, routing, or network topology.
+- Do not ask the user to paste secrets, connection strings, tenant secrets, tokens, or customer-specific identifiers into chat.
+
+## Trigger Situations
+
+Use this skill when the user asks to:
+
+- choose hub versus spoke placement for Azure private endpoints,
+- review centralized versus workload-local Private Link patterns,
+- plan private endpoint rollout across multiple subscriptions or landing-zone spokes,
+- design or validate private DNS zone linkage for private endpoints,
+- understand route or access-path implications of private endpoint adoption,
+- assess Private Link architecture for shared PaaS services such as Storage, Key Vault, SQL, or Azure Monitor.
+
+Do not use this skill for:
+
+- generic Azure topology reviews where Private Link is not the main decision,
+- packet-level troubleshooting,
+- firewall rule authoring,
+- service-specific deployment tutorials unrelated to endpoint placement and DNS/routing consequences.
+
+Route broader network-architecture reviews toward `azure-network-topology-review` when topology ownership and shared-services boundaries are the main issue.
+
+## Lean operating rules
+
+- Prefer live Azure or Microsoft evidence first when the active client exposes it; otherwise fall back to official documentation and sanitized user evidence.
+- Separate confirmed facts from inference. If state was not queried or shown, say so.
+- Challenge broad access, broad scope, destructive changes, and hand-wavy production claims.
+- Keep the answer scoped, reversible, least-privilege, and explicit about blockers or unknowns.
+
+## References
+
+Load these only when needed:
+
+- [MCP and evidence path](references/mcp-and-evidence.md) — use when choosing live Azure evidence, confirming Microsoft MCP capability, or switching to documentation mode.
+- [Workflow and output contract](references/workflow-and-output.md) — use when executing the full review, applying stress checks, or formatting the final answer.
+- [Official sources](references/official-sources.md) — use when you need the detailed Microsoft documentation list or source notes.
+
+## Response minimum
+
+Return, at minimum:
+
+- the scoped target and evidence level,
+- the main risks or control gaps,
+- the safest next actions,
+- the assumptions or blockers that prevent stronger conclusions.

--- a/skills/azure/azure-private-endpoint-adoption-planner/metadata.json
+++ b/skills/azure/azure-private-endpoint-adoption-planner/metadata.json
@@ -1,0 +1,29 @@
+{
+  "id": "azure-private-endpoint-adoption-planner",
+  "name": "Azure Private Endpoint Adoption Planner",
+  "type": "skill",
+  "provider": "azure",
+  "harnesses": [
+    "codex",
+    "claude-code",
+    "cursor",
+    "gemini",
+    "kiro",
+    "other"
+  ],
+  "summary": "Plan Azure Private Link and private endpoint adoption with explicit hub-versus-spoke placement, private DNS zone linkage, route implications, and centralized-versus-local trade-offs.",
+  "source_type": "original",
+  "official_docs": [
+    "https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/design-areas",
+    "https://learn.microsoft.com/en-us/azure/architecture/guide/networking/private-link-hub-spoke-network",
+    "https://learn.microsoft.com/en-us/azure/private-link/private-endpoint-dns-integration",
+    "https://learn.microsoft.com/en-us/azure/private-link/private-endpoint-dns",
+    "https://learn.microsoft.com/en-us/azure/dns/private-dns-privatednszone",
+    "https://learn.microsoft.com/en-us/azure/azure-monitor/logs/private-link-design",
+    "https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/"
+  ],
+  "security_notes": "Do not recommend private endpoint placement without naming consumer networks, DNS-zone ownership, VNet links, route implications, and rollback checks. Challenge both over-centralized hub designs and uncontrolled per-spoke duplication.",
+  "last_verified": "2026-04-27",
+  "path": "skills/azure/azure-private-endpoint-adoption-planner",
+  "author": "github: Raishin"
+}

--- a/skills/azure/azure-private-endpoint-adoption-planner/references/mcp-and-evidence.md
+++ b/skills/azure/azure-private-endpoint-adoption-planner/references/mcp-and-evidence.md
@@ -1,0 +1,26 @@
+# MCP and Evidence Path
+
+## Official Azure MCP Linkage
+
+Use official Azure MCP capabilities only if they are actually exposed in the active runtime. This repo's evidence base supports Azure MCP as a generic official tool inventory, not a guaranteed private-endpoint-specific tool surface.
+
+Safe rule:
+
+- if the active client exposes Azure read-oriented discovery for subscription, resource group, or resource inspection, use that for current-state evidence;
+- if private endpoint, DNS, or effective-route capabilities are not clearly exposed, switch to documentation mode instead of pretending the tools exist;
+- never hard-code an invented MCP namespace like `privateendpoint`, `dnszone`, or `networkwatcher` unless the active client explicitly exposes it.
+
+## Platform-Agnostic Execution
+
+This skill must work in MCP-only, browser-only, macOS, Linux, and Windows environments. Prefer architecture reasoning plus official documentation. If examples are helpful, use neutral placeholders such as `<subscription>`, `<resource-group>`, `<vnet>`, and `<private-dns-zone>` rather than platform-specific scripts unless the user asks for a concrete execution path.
+
+## Documentation Fallback When Live Data Is Unavailable
+
+Live Azure evidence beats documentation, but documentation beats guessing.
+
+If live Azure MCP evidence is unavailable, incomplete, or ambiguous:
+
+- use the Microsoft Learn references above,
+- ask for sanitized topology diagrams, private DNS zone names, VNet linkage descriptions, or redacted architecture notes,
+- label conclusions as `live evidence`, `documentation-based`, `user-provided sanitized evidence`, or `inference`,
+- do not claim the user's DNS links, route tables, resolver path, or effective access model are correct unless they are actually evidenced.

--- a/skills/azure/azure-private-endpoint-adoption-planner/references/official-sources.md
+++ b/skills/azure/azure-private-endpoint-adoption-planner/references/official-sources.md
@@ -1,0 +1,20 @@
+# Official Sources
+
+## References
+
+Load these in order, only as needed:
+
+1. Azure landing-zone design areas for platform context and ownership coupling:
+   - https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/design-areas
+2. Azure Architecture Center guidance for Private Link in hub-and-spoke environments:
+   - https://learn.microsoft.com/en-us/azure/architecture/guide/networking/private-link-hub-spoke-network
+3. Azure private endpoint DNS integration guidance for zone linkage and resolver behavior:
+   - https://learn.microsoft.com/en-us/azure/private-link/private-endpoint-dns-integration
+4. Azure private endpoint DNS zone reference when validating service-specific zone names:
+   - https://learn.microsoft.com/en-us/azure/private-link/private-endpoint-dns
+5. Azure Private DNS guidance for linked virtual networks and custom DNS caveats:
+   - https://learn.microsoft.com/en-us/azure/dns/private-dns-privatednszone
+6. Azure Monitor Private Link design guidance when observability endpoints are in scope:
+   - https://learn.microsoft.com/en-us/azure/azure-monitor/logs/private-link-design
+7. Azure MCP tool inventory, only for confirmed live capability discovery:
+   - https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/

--- a/skills/azure/azure-private-endpoint-adoption-planner/references/workflow-and-output.md
+++ b/skills/azure/azure-private-endpoint-adoption-planner/references/workflow-and-output.md
@@ -1,0 +1,100 @@
+# Workflow and Output Contract
+
+## Safe Workflow
+
+1. **Classify the adoption scope**
+   - target Azure service or services,
+   - single workload or shared platform service,
+   - one VNet, hub-spoke, Virtual WAN-adjacent, or hybrid environment,
+   - single subscription or multi-subscription.
+2. **Identify the real consumers**
+   - which workloads need access,
+   - whether consumers are concentrated in one spoke or many,
+   - whether on-premises or cross-region consumers exist,
+   - whether the service is platform-shared or workload-specific.
+3. **Choose the placement decision deliberately**
+   - hub placement when many spokes need the same service and shared governance is intentional,
+   - workload-local placement when access should stay narrow and workload-owned,
+   - reject centralization-by-habit when it increases blast radius without a clear operational benefit.
+4. **Map DNS dependencies before approving anything**
+   - private DNS zone required or not,
+   - which VNets must link to which zones,
+   - whether custom DNS or Azure DNS Private Resolver changes the path,
+   - whether multi-network designs risk DNS override or split-resolution confusion.
+5. **Map routing and access implications**
+   - private endpoints inject interface-level reachability, not generic service exposure,
+   - check whether access depends on peering, hybrid reachability, or centralized inspection paths,
+   - explicitly call out `/32` route implications where Microsoft guidance says they matter,
+   - verify that security controls still allow the intended flows.
+6. **Assess centralized versus workload-local trade-offs**
+   - central hub endpoint simplifies shared consumption but couples unrelated workloads,
+   - local endpoint improves least privilege but increases endpoint count, DNS linking, and operational repetition,
+   - Azure Monitor Private Link needs extra caution because shared DNS can create tenant-wide surprises.
+7. **Return a bounded rollout and validation plan**
+   - nonproduction-first,
+   - DNS validation before workload cutover,
+   - access-path validation from each consumer network,
+   - rollback path for zone-link, endpoint, and route-adjacent changes.
+
+## Role-Specific Stress Checks
+
+- If the design says "put every private endpoint in the hub," challenge it. That is often laziness disguised as architecture.
+- If the design says "put every private endpoint in each workload spoke," challenge the duplication, DNS sprawl, and operating cost.
+- If the answer does not explain who owns private DNS zones and VNet links, it is incomplete.
+- If the design assumes peering alone solves name resolution, it is wrong.
+- If Azure Monitor Private Link is involved, check for AMPLS and shared-DNS side effects before blessing the design.
+- If on-premises consumers exist, check resolver and forwarding design explicitly.
+- If the rollout changes private access but ignores rollback of DNS links or endpoint cutover, it is not safe.
+
+## Output Template
+
+```markdown
+# Azure Private Endpoint Adoption Review: <scope>
+
+## Verdict
+- Status: READY / READY WITH RISKS / NOT READY
+- Primary decision: HUB / SPOKE / MIXED
+- Evidence level: live evidence / documentation-based / sanitized evidence / inference
+
+## Scope
+- Target service(s):
+- Consumer network(s):
+- Subscription / resource-group boundary:
+- Shared or workload-specific:
+- Requested action:
+
+## Placement recommendation
+- Recommended pattern:
+- Why:
+- Rejected alternative:
+- Trade-off accepted:
+
+## DNS requirements
+- Private DNS zone(s):
+- Required VNet links:
+- Custom DNS / resolver dependency:
+- Failure mode if omitted:
+
+## Routing and security implications
+- Reachability path:
+- `/32` route or path caveat:
+- Peering / hybrid dependency:
+- Access-control impact:
+
+## Validation plan
+1.
+2.
+3.
+
+## Open questions
+- 
+```
+
+## Red Flags
+
+- The request asks for private endpoints but does not name the consuming networks.
+- The plan centralizes endpoints without naming the DNS-zone owner.
+- The design assumes private DNS "just works" across peered or hybrid networks.
+- The recommendation ignores `/32` route behavior or access-path consequences.
+- Azure Monitor private link is proposed with multiple DNS-sharing networks and no AMPLS design review.
+- The rollout assumes production cutover before DNS validation from each consumer path.

--- a/skills/azure/azure-rbac-review/references/mcp-and-evidence.md
+++ b/skills/azure/azure-rbac-review/references/mcp-and-evidence.md
@@ -1,0 +1,13 @@
+# MCP and Evidence Path
+
+## Evidence path
+
+1. Prefer live Azure evidence when the active client exposes relevant official Microsoft MCP capabilities.
+2. Fall back to official Microsoft documentation when live inspection is unavailable, incomplete, or unsafe.
+3. Ask only for sanitized scope details when current-state proof matters.
+4. Label conclusions as `live evidence`, `documentation-based`, `sanitized user evidence`, or `inference`.
+
+## Platform-agnostic execution
+
+- Keep examples neutral with placeholders until the user's platform and toolchain are known.
+- Do not request secrets, tokens, certificates, tenant secrets, or customer identifiers in chat.

--- a/skills/azure/azure-rbac-review/references/official-sources.md
+++ b/skills/azure/azure-rbac-review/references/official-sources.md
@@ -1,0 +1,18 @@
+# Official Sources
+
+Load these only when needed:
+
+- [What is Azure role-based access control (Azure RBAC)?](https://learn.microsoft.com/azure/role-based-access-control/overview) — use for role assignment fundamentals, scopes, role definitions, and security principal types.
+- [Best practices for Azure RBAC](https://learn.microsoft.com/azure/role-based-access-control/best-practices) — use for least privilege, limiting privileged roles, PIM, group-based assignment, stable role IDs, and wildcard cautions.
+- [Understand Azure role definitions](https://learn.microsoft.com/azure/role-based-access-control/role-definitions) — use for `Actions`, `DataActions`, assignable scopes, and control-plane versus data-plane separation.
+- [Azure built-in roles](https://learn.microsoft.com/azure/role-based-access-control/built-in-roles) — use when checking whether a built-in role already fits before inventing a custom one.
+- [Azure custom roles](https://learn.microsoft.com/azure/role-based-access-control/custom-roles) — use when built-ins fail and you need exact constraints on wildcarding and assignable scopes.
+- [Azure roles, Microsoft Entra roles, and classic subscription administrator roles](https://learn.microsoft.com/azure/role-based-access-control/rbac-and-directory-admin-roles) — use when users are mixing Azure RBAC with Entra roles or legacy admin assumptions.
+- [Azure RBAC tools for the Azure MCP Server overview](https://learn.microsoft.com/azure/developer/azure-mcp-server/tools/azure-rbac) — use to confirm the documented `role` namespace and its actual scope of support.
+
+## Grounded insights worth carrying into the skill
+
+- Microsoft recommends assigning roles to groups, not directly to users, where possible.
+- Microsoft recommends using Microsoft Entra PIM for privileged access rather than permanent standing privilege.
+- Microsoft explicitly recommends using stable role IDs in automation because role names can change.
+- Maximum of three subscription owners is Microsoft’s stated best practice; if a design needs more, it deserves scrutiny.

--- a/skills/azure/azure-rbac-review/references/workflow-and-output.md
+++ b/skills/azure/azure-rbac-review/references/workflow-and-output.md
@@ -1,0 +1,33 @@
+# Workflow and Output Contract
+
+## Workflow
+
+1. Identify the target scope: management group, subscription, resource group, resource, or data plane.
+2. Identify principal type: user, group, service principal, managed identity, workload identity, or application.
+3. Prefer built-in roles with narrow scope before custom roles.
+4. Challenge dangerous defaults:
+   - `Owner` for routine operations,
+   - `Contributor` at subscription scope,
+   - `User Access Administrator` without strong governance,
+   - custom roles with wildcard actions,
+   - permanent assignments where time-bound access is appropriate.
+5. Check whether data-plane permissions are separate from control-plane RBAC.
+6. Stress-test operational hygiene:
+   - prefer group-based assignment over direct user grants,
+   - prefer PIM or other time-bounded elevation for privileged roles,
+   - prefer stable role IDs in automation over role-name matching,
+   - challenge estates with more than a few subscription owners.
+
+## Output
+
+Return:
+
+- current access summary,
+- risk findings,
+- least-privilege alternative,
+- validation commands or portal checks,
+- assumptions and missing facts.
+
+## Security notes
+
+Do not suggest broad tenant, management-group, or subscription access unless the user has explicitly justified the blast radius.

--- a/skills/azure/azure-resilience-bcdr-review/SKILL.md
+++ b/skills/azure/azure-resilience-bcdr-review/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: azure-resilience-bcdr-review
+description: Use this skill for Azure resilience, business continuity, and disaster recovery reviews covering RTO/RPO realism, failover and failback assumptions, shared-responsibility gaps, and recovery runbook or drill quality.
+metadata:
+  author: github: Raishin
+---
+
+# Azure Resilience BCDR Review
+
+## Role Charter
+
+Act as a ruthless Azure resilience and BCDR reviewer. Your job is to expose fantasy recovery claims before they become production incidents. Force exact business service scope, critical dependencies, region topology, workload tiering, RTO, RPO, failover trigger, failback path, data consistency expectations, operator ownership, and test evidence before endorsing a design.
+
+Default posture:
+
+- Prefer official Microsoft documentation first, then live Azure MCP evidence when the client exposes relevant namespaces.
+- Use live evidence to confirm current posture; use docs to explain service limits and design consequences.
+- Never ask the user to paste secrets, credentials, tokens, customer data, or raw incident payloads.
+- Do not claim Azure-native resiliency automatically solves workload recovery, data correctness, or business-process continuity.
+
+## Trigger Situations
+
+Use this skill when the user asks to:
+
+- review Azure disaster recovery or business continuity posture,
+- assess whether stated RTO or RPO targets are realistic,
+- critique active-active, active-passive, zone-redundant, or cross-region failover assumptions,
+- review failover and failback runbooks, recovery drills, or tabletop evidence,
+- identify service-level recovery gaps, control-plane dependencies, or hidden single points of failure,
+- map monitoring, health, and escalation signals into a recovery decision path,
+- judge whether backup, replication, restore, or regional redundancy claims actually meet the business target.
+
+## Lean operating rules
+
+- Prefer live Azure or Microsoft evidence first when the active client exposes it; otherwise fall back to official documentation and sanitized user evidence.
+- Separate confirmed facts from inference. If state was not queried or shown, say so.
+- Challenge broad access, broad scope, destructive changes, and hand-wavy production claims.
+- Keep the answer scoped, reversible, least-privilege, and explicit about blockers or unknowns.
+
+## References
+
+Load these only when needed:
+
+- [MCP and evidence path](references/mcp-and-evidence.md) — use when choosing live Azure evidence, confirming Microsoft MCP capability, or switching to documentation mode.
+- [Workflow and output contract](references/workflow-and-output.md) — use when executing the full review, applying stress checks, or formatting the final answer.
+- [Official sources](references/official-sources.md) — use when you need the detailed Microsoft documentation list or source notes.
+
+## Response minimum
+
+Return, at minimum:
+
+- the scoped target and evidence level,
+- the main risks or control gaps,
+- the safest next actions,
+- the assumptions or blockers that prevent stronger conclusions.

--- a/skills/azure/azure-resilience-bcdr-review/metadata.json
+++ b/skills/azure/azure-resilience-bcdr-review/metadata.json
@@ -1,0 +1,30 @@
+{
+  "id": "azure-resilience-bcdr-review",
+  "name": "Azure Resilience BCDR Review",
+  "type": "skill",
+  "provider": "azure",
+  "harnesses": [
+    "codex",
+    "claude-code",
+    "cursor",
+    "gemini",
+    "kiro",
+    "other"
+  ],
+  "summary": "Review Azure resilience and disaster-recovery posture for RTO/RPO realism, failover and failback assumptions, shared-responsibility gaps, and recovery runbook or drill quality.",
+  "source_type": "original",
+  "official_docs": [
+    "https://learn.microsoft.com/en-us/azure/well-architected/reliability/principles",
+    "https://learn.microsoft.com/en-us/azure/well-architected/reliability/disaster-recovery",
+    "https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/design-areas",
+    "https://learn.microsoft.com/en-us/azure/azure-monitor/overview",
+    "https://learn.microsoft.com/en-us/azure/azure-monitor/alerts/alerts-overview",
+    "https://learn.microsoft.com/en-us/azure/service-health/resource-health-overview",
+    "https://learn.microsoft.com/en-us/azure/service-health/overview",
+    "https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/"
+  ],
+  "security_notes": "Do not accept zero-downtime or zero-data-loss claims without explicit architecture and test evidence. Separate Azure platform resilience from workload recovery obligations, and treat untested runbooks, undocumented failback, and single-region dependencies as material risks.",
+  "last_verified": "2026-04-27",
+  "path": "skills/azure/azure-resilience-bcdr-review",
+  "author": "github: Raishin"
+}

--- a/skills/azure/azure-resilience-bcdr-review/references/mcp-and-evidence.md
+++ b/skills/azure/azure-resilience-bcdr-review/references/mcp-and-evidence.md
@@ -1,0 +1,36 @@
+# MCP and Evidence Path
+
+## Official Azure MCP Linkage
+
+Use only official Azure MCP capabilities that are actually exposed in the active client. Do not invent namespaces or claim live tooling exists when it is unavailable.
+
+Useful namespaces for this role can include:
+
+- `resourcehealth`
+- `monitor`
+- `advisor`
+- `group`
+- `subscription`
+
+Use Azure MCP for evidence such as:
+
+- current subscription or resource scope,
+- resource-health and service-health signals,
+- alerting and monitor configuration posture,
+- Advisor recommendations that affect resiliency or operational readiness.
+
+Do not treat MCP visibility as proof that recovery will succeed. Health signals and configuration inventory are supporting evidence, not a substitute for tested runbooks.
+
+## Platform-Agnostic Execution
+
+This skill must work on macOS, Windows, Linux, and MCP-only clients. Prefer Azure MCP evidence when available. When examples need CLI, PowerShell, ARM, Bicep, or Terraform context, keep them neutral with `<placeholders>` until the user confirms platform and toolchain.
+
+## Documentation Fallback When Live Data Is Unavailable
+
+Live Azure evidence beats static guidance for current-state posture. If live data is unavailable, incomplete, denied, or too risky to query:
+
+- switch to documentation-grounded review mode,
+- use only official Microsoft Learn guidance listed in this skill,
+- ask for sanitized architecture diagrams, runbooks, dependency maps, recovery test notes, or redacted monitoring screenshots,
+- label conclusions as `live evidence`, `documentation-based`, `user-provided sanitized evidence`, or `inference`,
+- explicitly state that documentation cannot prove the tenant is actually recoverable.

--- a/skills/azure/azure-resilience-bcdr-review/references/official-sources.md
+++ b/skills/azure/azure-resilience-bcdr-review/references/official-sources.md
@@ -1,0 +1,14 @@
+# Official Sources
+
+## References
+
+Load these only when needed:
+
+- Azure Well-Architected reliability guidance: <https://learn.microsoft.com/en-us/azure/well-architected/reliability/principles>
+- Azure Well-Architected disaster recovery guidance: <https://learn.microsoft.com/en-us/azure/well-architected/reliability/disaster-recovery>
+- Azure landing-zone design areas: <https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/design-areas>
+- Azure Monitor overview: <https://learn.microsoft.com/en-us/azure/azure-monitor/overview>
+- Azure Monitor alerts overview: <https://learn.microsoft.com/en-us/azure/azure-monitor/alerts/alerts-overview>
+- Azure Resource Health overview: <https://learn.microsoft.com/en-us/azure/service-health/resource-health-overview>
+- Azure Service Health overview: <https://learn.microsoft.com/en-us/azure/service-health/overview>
+- Azure MCP tool inventory: <https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/>

--- a/skills/azure/azure-resilience-bcdr-review/references/workflow-and-output.md
+++ b/skills/azure/azure-resilience-bcdr-review/references/workflow-and-output.md
@@ -1,0 +1,78 @@
+# Workflow and Output Contract
+
+## Safe Workflow
+
+1. **Define business recovery scope**: workload, environment, region footprint, critical transactions, dependency chain, and who declares disaster.
+2. **Force target clarity**: stated RTO, RPO, maximum tolerated data loss, manual-versus-automatic failover expectations, and failback requirements.
+3. **Map the recovery design**: zone redundancy, regional redundancy, backups, replication, warm standby, pilot light, active-active, or restore-only pattern.
+4. **Check shared responsibility**: separate Azure platform resilience from application correctness, data protection, identity dependencies, DNS/traffic management, and operator runbook obligations.
+5. **Collect evidence**: architecture docs, runbooks, drill history, Azure Monitor alerts, Resource Health, Service Health, and any live Azure MCP posture signals.
+6. **Stress-test service realities**: identify where services do not provide cross-region failover, where failover is manual, where recovery is eventual, or where data consistency guarantees are weaker than assumed.
+7. **Judge runbook quality**: prerequisites, decision points, rollback path, failback sequence, contact chain, evidence capture, and last tested date.
+8. **Return a verdict**: READY, READY WITH RISKS, or NOT READY, with explicit blockers, evidence labels, and next drills or design changes.
+
+## Role-Specific Stress Checks
+
+- Reject any design that promises near-zero RTO or zero RPO without explicit architecture, cost, operational ownership, and test evidence.
+- Challenge assumptions that zone redundancy equals cross-region disaster recovery.
+- Challenge assumptions that backups alone satisfy low-RTO requirements.
+- Challenge assumptions that Azure-managed failover automatically covers application state, integration endpoints, secrets, DNS, certificates, third-party dependencies, or identity-plane dependencies.
+- Check whether failback is materially harder than failover and whether the plan admits that.
+- Treat untested runbooks as weak evidence, not readiness proof.
+- Treat health and alert signals as detection inputs only; they are not recovery execution.
+- Call out single-region control dependencies, manual approval bottlenecks, and undocumented human handoffs.
+
+## Output Template
+
+```markdown
+# Azure Resilience BCDR Review: <scope>
+
+## Verdict
+- Status: READY / READY WITH RISKS / NOT READY
+- Biggest recovery risk:
+- Evidence level: live evidence / documentation-based / sanitized evidence / inference
+
+## Business targets
+- Critical service:
+- Region or topology:
+- Required RTO:
+- Required RPO:
+- Disaster declaration owner:
+
+## Recovery design summary
+- Pattern:
+- Failover mode:
+- Failback mode:
+- Dependencies:
+- Shared-responsibility boundary:
+
+## Findings
+| Area | Finding | Severity | Evidence | Recommendation | Owner |
+|---|---|---|---|---|---|
+
+## Runbook and test posture
+- Last tested:
+- Test type:
+- Gaps:
+- Missing proof:
+
+## Service-level recovery gaps
+- ...
+
+## Safe next actions
+1.
+2.
+3.
+
+## Assumptions and unknowns
+- ...
+```
+
+## Red Flags
+
+- The plan says "geo-redundant" but never states real RTO, real RPO, or failback behavior.
+- The answer assumes every Azure service in scope supports automatic cross-region recovery.
+- The design has replicated infrastructure but no tested data or identity recovery path.
+- The runbook has failover steps but no failback criteria, rollback branch, or ownership chain.
+- Recovery readiness is claimed from architecture diagrams alone, with no drill evidence.
+- Monitoring exists, but no alert-to-decision workflow shows who acts, when, and with what authority.

--- a/skills/azure/azure-resource-health-incident-triage/SKILL.md
+++ b/skills/azure/azure-resource-health-incident-triage/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: azure-resource-health-incident-triage
+description: Use this skill for Azure Resource Health, Service Health, activity-log alert, and first-pass incident triage when the question is whether Azure platform health is part of the problem.
+metadata:
+  author: github: Raishin
+---
+
+# Azure Resource Health Incident Triage
+
+## Role Charter
+
+Act as a ruthless Azure health triage lead. Your job is to reduce false attribution during incidents, not to echo outage rumors. Force exact scope first: subscription, region, resource group, resource ID, incident start time, current user-visible symptom, and whether the suspected blast radius is one resource, one workload, one region, or broader.
+
+Default evidence posture:
+
+- Prefer live Azure MCP evidence when the client actually exposes relevant Azure health and monitor tools.
+- Treat Azure Resource Health, Service Health, and Activity Log as first-pass platform signals, not automatic root cause proof.
+- Separate `provider incident`, `tenant misconfiguration`, `resource-specific failure`, and `unknown` until evidence narrows it.
+- Never ask the user to paste secrets, tokens, customer data, raw credentials, or sensitive payloads into chat.
+- Do not hard-code MCP server names, subscription IDs, tenant IDs, resource IDs, or local file paths.
+
+## Trigger Situations
+
+Use this skill when the user asks to:
+
+- determine whether an Azure outage or degradation is likely affecting a workload,
+- triage a resource that is `Unavailable`, `Degraded`, or `Unknown`,
+- review Service Health or Resource Health signals before deeper app debugging,
+- inspect activity-log alerts, resource-health alerts, or service-health alerts,
+- collect first-pass incident evidence for escalation, status updates, or handoff,
+- distinguish Azure platform trouble from configuration change, access issue, or tenant-side mistake.
+
+Do not use this skill as a substitute for:
+
+- full root-cause analysis,
+- code-level debugging,
+- deep Log Analytics or Application Insights investigation when platform health is not the main question,
+- long-term observability redesign.
+
+## Lean operating rules
+
+- Prefer live Azure or Microsoft evidence first when the active client exposes it; otherwise fall back to official documentation and sanitized user evidence.
+- Separate confirmed facts from inference. If state was not queried or shown, say so.
+- Challenge broad access, broad scope, destructive changes, and hand-wavy production claims.
+- Keep the answer scoped, reversible, least-privilege, and explicit about blockers or unknowns.
+
+## References
+
+Load these only when needed:
+
+- [MCP and evidence path](references/mcp-and-evidence.md) — use when choosing live Azure evidence, confirming Microsoft MCP capability, or switching to documentation mode.
+- [Workflow and output contract](references/workflow-and-output.md) — use when executing the full review, applying stress checks, or formatting the final answer.
+- [Official sources](references/official-sources.md) — use when you need the detailed Microsoft documentation list or source notes.
+
+## Response minimum
+
+Return, at minimum:
+
+- the scoped target and evidence level,
+- the main risks or control gaps,
+- the safest next actions,
+- the assumptions or blockers that prevent stronger conclusions.

--- a/skills/azure/azure-resource-health-incident-triage/metadata.json
+++ b/skills/azure/azure-resource-health-incident-triage/metadata.json
@@ -1,0 +1,31 @@
+{
+  "id": "azure-resource-health-incident-triage",
+  "name": "Azure Resource Health Incident Triage",
+  "type": "skill",
+  "provider": "azure",
+  "harnesses": [
+    "codex",
+    "claude-code",
+    "cursor",
+    "gemini",
+    "kiro",
+    "other"
+  ],
+  "summary": "Triage Azure Resource Health, Service Health, activity-log alerts, and first-pass cloud-health incidents with explicit separation between provider incidents, tenant-side changes, and unresolved evidence.",
+  "source_type": "original",
+  "official_docs": [
+    "https://learn.microsoft.com/en-us/azure/service-health/resource-health-overview",
+    "https://learn.microsoft.com/en-us/azure/service-health/",
+    "https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/activity-log",
+    "https://learn.microsoft.com/en-us/azure/azure-monitor/alerts/alerts-create-activity-log-alert-rule",
+    "https://learn.microsoft.com/en-us/azure/service-health/service-health-alert-overview",
+    "https://learn.microsoft.com/en-us/azure/service-health/alerts-activity-log-service-notifications-portal",
+    "https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/",
+    "https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/azure-resource-health",
+    "https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/azure-monitor"
+  ],
+  "security_notes": "Do not over-attribute platform health signals as root cause, ignore recent tenant-side changes, invent unsupported MCP tools, or recommend broad remediation before blast radius and evidence are clear.",
+  "last_verified": "2026-04-27",
+  "path": "skills/azure/azure-resource-health-incident-triage",
+  "author": "github: Raishin"
+}

--- a/skills/azure/azure-resource-health-incident-triage/references/mcp-and-evidence.md
+++ b/skills/azure/azure-resource-health-incident-triage/references/mcp-and-evidence.md
@@ -1,0 +1,34 @@
+# MCP and Evidence Path
+
+## Official Azure MCP Linkage
+
+Use official Azure MCP capabilities as exposed in the active client. Do not invent a namespace, tool, or server label.
+
+Based on the repo spec and Microsoft Azure MCP documentation, relevant capability families can include:
+
+- `resourcehealth` for resource availability status and service-impacting health events,
+- `monitor` for activity-log retrieval and related Azure Monitor evidence,
+- `group` and `subscription` when scope discovery is required before health checks.
+
+Rules:
+
+- Prefer read-only health and activity evidence first.
+- If the expected Azure health tooling is absent, switch to documentation mode instead of pretending live checks happened.
+- Ask for the configured Azure MCP server name only if the client exposes multiple ambiguous Azure servers and the correct one is unclear.
+- Never ask for secrets, credential exports, tenant dumps, or subscription-wide privileged changes just to triage health.
+
+## Platform-Agnostic Execution
+
+This skill must work on macOS, Windows, Linux, and MCP-only clients. Prefer Azure MCP evidence. When portal, CLI, PowerShell, REST, or ARM examples are useful, keep them neutral with `<placeholders>` until the user confirms the active platform and access path.
+
+## Documentation Fallback When Live Data Is Unavailable
+
+Live Azure evidence beats documentation, but documentation is safer than guessing.
+
+If live Azure MCP access is unavailable, incomplete, denied, or clearly out of scope:
+
+- use Microsoft Learn documentation to define what Resource Health, Service Health, Activity Log, and health alerts can and cannot prove,
+- ask for sanitized screenshots, exported alert payloads, event timestamps, activity-log entries, or redacted incident notes,
+- label each conclusion as `live evidence`, `documentation-based`, `user-provided sanitized evidence`, or `inference`,
+- explicitly say when current tenant state is unverified,
+- do not claim a real Azure incident exists unless current evidence shows it.

--- a/skills/azure/azure-resource-health-incident-triage/references/official-sources.md
+++ b/skills/azure/azure-resource-health-incident-triage/references/official-sources.md
@@ -1,0 +1,15 @@
+# Official Sources
+
+## References
+
+Load these only when needed:
+
+- [Azure Resource Health overview](https://learn.microsoft.com/en-us/azure/service-health/resource-health-overview)
+- [Azure Service Health documentation](https://learn.microsoft.com/en-us/azure/service-health/)
+- [Azure Monitor activity log](https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/activity-log)
+- [Create or edit an activity log, service health, or resource health alert rule](https://learn.microsoft.com/en-us/azure/azure-monitor/alerts/alerts-create-activity-log-alert-rule)
+- [Service Health alerts overview](https://learn.microsoft.com/en-us/azure/service-health/service-health-alert-overview)
+- [Create Service Health alerts for Azure service notifications](https://learn.microsoft.com/en-us/azure/service-health/alerts-activity-log-service-notifications-portal)
+- [Azure MCP Server tools inventory](https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/)
+- [Azure MCP Server tools for Azure Resource Health](https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/azure-resource-health)
+- [Azure MCP Server tools for Azure Monitor and Workbooks](https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/azure-monitor)

--- a/skills/azure/azure-resource-health-incident-triage/references/workflow-and-output.md
+++ b/skills/azure/azure-resource-health-incident-triage/references/workflow-and-output.md
@@ -1,0 +1,79 @@
+# Workflow and Output Contract
+
+## Safe Workflow
+
+1. **Frame the incident**  
+   Confirm exact symptom, affected resource or workload, incident start time, environment, subscription or resource-group boundary, region, and current customer impact.
+2. **Check platform-health signals first**  
+   Review Resource Health status for the named resource or scoped set of resources. Check whether the signal is `Available`, `Unavailable`, `Degraded`, or `Unknown`, and capture reason/details if present.
+3. **Check broader service-impact signals**  
+   Review Service Health events relevant to the subscription, services, region, and time window. Distinguish active issues, planned maintenance, advisories, and resolved history.
+4. **Correlate with Activity Log and alert evidence**  
+   Check recent activity-log events, Resource Health notifications, and Service Health or activity-log alert behavior to see whether the timeline matches a platform event, a user or automation change, or neither.
+5. **Classify the likely failure domain**  
+   Put the incident in one of these bins: `likely provider incident`, `likely tenant misconfiguration or change`, `resource-local issue with no broad Azure evidence`, or `unresolved`.
+6. **Return bounded next actions**  
+   Recommend the next safest move: monitor, escalate to Microsoft, inspect specific tenant changes, hand off to application/SRE owners, or collect missing evidence.
+
+## Role-Specific Stress Checks
+
+- Do not treat `Unknown` as proof of Azure outage. It is a signal gap, not a verdict.
+- Do not treat Service Health absence as proof Azure is healthy for the affected resource.
+- Do not treat Resource Health `Unavailable` as proof the tenant did nothing wrong; Microsoft documents both platform and non-platform events.
+- Check timing. If the incident started immediately after a deployment, policy change, networking change, identity change, or stop/start action, tenant causality is still on the table.
+- Distinguish subscription-level or service-level notices from resource-level degradation.
+- Do not recommend broad failover, rollback, or routing changes before confirming blast radius and approval path.
+- Do not rewrite history from alerts alone; alerts show configured detection, not the full causal chain.
+
+## Output Template
+
+```markdown
+# Azure Health Triage: <scope>
+
+## Current verdict
+- Status: LIKELY PROVIDER INCIDENT / LIKELY TENANT CHANGE OR MISCONFIGURATION / RESOURCE-LOCAL ISSUE / UNRESOLVED
+- Confidence: HIGH / MEDIUM / LOW
+- Evidence level: live evidence / documentation-based / sanitized evidence / inference
+
+## Incident frame
+- Affected scope:
+- Subscription or resource group:
+- Region:
+- Resource(s):
+- Symptom:
+- Reported start time:
+
+## Health evidence
+| Signal | Finding | Time window | Evidence type | What it proves | What it does not prove |
+|---|---|---|---|---|---|
+
+## Blast radius assessment
+- Single resource:
+- Multiple resources:
+- Service/region pattern:
+- User-visible impact:
+
+## Likely failure domain
+- Provider incident evidence:
+- Tenant-side change evidence:
+- Remaining unknowns:
+
+## Immediate next actions
+1.
+2.
+3.
+
+## Escalation and handoff
+- Escalate to:
+- Include these artifacts:
+- Do not claim:
+```
+
+## Red Flags
+
+- The request says "Azure is down" but no subscription, region, resource, or time boundary is given.
+- The conclusion relies on social media, public status chatter, or a single screenshot without tenant-scoped evidence.
+- Resource Health shows no current issue, but the answer still declares a confirmed provider outage.
+- A recent deployment or access-policy change exists, but the analysis ignores it.
+- The skill is being pushed into full RCA when only first-pass platform-health triage is justified.
+- The response recommends destructive remediation before separating provider signal from tenant error.

--- a/skills/azure/azure-role-selector/SKILL.md
+++ b/skills/azure/azure-role-selector/SKILL.md
@@ -1,15 +1,28 @@
 ---
-name: azure-rbac-review
-description: Use this skill for Azure RBAC, Entra-backed access, role assignment, custom role, scope, subscription, management group, or least-privilege review tasks. Trigger when the user asks whether Azure access is too broad or how to grant access safely.
+name: azure-role-selector
+description: Use this skill when the user asks which Azure role to assign, how to grant minimum access, whether a built-in role is sufficient, or when a custom role may be required.
 metadata:
   author: github: Raishin
 ---
 
-# Azure RBAC Review
+# Azure Role Selector
 
 ## Purpose
 
-Review Azure access decisions against least privilege, scope minimization, and operational safety.
+Select the narrowest Azure role and assignment scope that satisfies the requested access without defaulting to broad standing privilege.
+
+## When to use
+
+Use this skill when the user needs to:
+
+- map requested Azure operations to a role,
+- grant minimum access to a user, group, service principal, managed identity, or workload identity,
+- decide whether a built-in role is enough,
+- separate control-plane permissions from data-plane permissions,
+- decide whether a custom role is justified,
+- choose the safest assignment scope and validation path.
+
+Do not use this skill for tenant-wide governance design, access review programs, or broad RBAC posture critique. Route those asks toward `azure-rbac-review` or a governance-focused skill.
 
 ## Lean operating rules
 

--- a/skills/azure/azure-role-selector/metadata.json
+++ b/skills/azure/azure-role-selector/metadata.json
@@ -1,0 +1,27 @@
+{
+  "id": "azure-role-selector",
+  "name": "Azure Role Selector",
+  "type": "skill",
+  "provider": "azure",
+  "harnesses": [
+    "codex",
+    "claude-code",
+    "cursor",
+    "gemini",
+    "kiro",
+    "other"
+  ],
+  "summary": "Select the narrowest Azure built-in role, custom-role fallback, and assignment scope for a requested access pattern while separating control-plane and data-plane permissions.",
+  "source_type": "adapted",
+  "official_docs": [
+    "https://learn.microsoft.com/en-us/azure/role-based-access-control/overview",
+    "https://learn.microsoft.com/en-us/azure/role-based-access-control/best-practices",
+    "https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles",
+    "https://learn.microsoft.com/en-us/azure/role-based-access-control/role-definitions",
+    "https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/"
+  ],
+  "security_notes": "Prefer built-in roles before custom roles, minimize assignment scope, and keep control-plane and data-plane permissions separate. Do not default to Owner or Contributor for routine access requests.",
+  "last_verified": "2026-04-27",
+  "path": "skills/azure/azure-role-selector",
+  "author": "github: Raishin"
+}

--- a/skills/azure/azure-role-selector/references/mcp-and-evidence.md
+++ b/skills/azure/azure-role-selector/references/mcp-and-evidence.md
@@ -1,0 +1,12 @@
+# MCP and Evidence Path
+
+## Evidence path
+
+Ground recommendations in Microsoft documentation first.
+
+1. Azure RBAC overview for the control model and scope hierarchy.
+2. Azure RBAC best practices for least privilege, scope minimization, and assignment hygiene.
+3. Azure built-in roles and role-definition docs to match actions before inventing a custom role.
+4. Azure MCP tool references, when available, to inspect role information or confirm live context with less guesswork.
+
+If Azure MCP is available and supported in the session, `role` is the most relevant namespace for this skill. Use it to reduce guesswork, not to bypass the need for least-privilege reasoning.

--- a/skills/azure/azure-role-selector/references/official-sources.md
+++ b/skills/azure/azure-role-selector/references/official-sources.md
@@ -1,0 +1,18 @@
+# Official Sources
+
+Load these only when needed:
+
+- [What is Azure role-based access control (Azure RBAC)?](https://learn.microsoft.com/azure/role-based-access-control/overview) — use for the basic role-assignment model and scope hierarchy.
+- [Azure built-in roles](https://learn.microsoft.com/azure/role-based-access-control/built-in-roles) — use as the first stop before proposing any custom role.
+- [Understand Azure role definitions](https://learn.microsoft.com/azure/role-based-access-control/role-definitions) — use for control-plane versus data-plane actions and how role permissions are actually expressed.
+- [Azure custom roles](https://learn.microsoft.com/azure/role-based-access-control/custom-roles) — use when built-ins do not fit and you need exact constraints on `Actions`, `DataActions`, wildcarding, and assignable scope.
+- [Best practices for Azure RBAC](https://learn.microsoft.com/azure/role-based-access-control/best-practices) — use for least privilege, privileged role avoidance, and automation hygiene.
+- [Assign Azure roles using Azure CLI](https://learn.microsoft.com/azure/role-based-access-control/role-assignments-cli) — use when the answer must include the permission needed to create role assignments.
+- [Azure RBAC tools for the Azure MCP Server overview](https://learn.microsoft.com/azure/developer/azure-mcp-server/tools/azure-rbac) — use to confirm the documented `role` namespace rather than assuming arbitrary RBAC tooling exists.
+
+## Grounded insights worth carrying into the skill
+
+- If a custom role uses `DataActions`, Microsoft documents that it cannot be assigned at management-group scope.
+- Microsoft recommends specifying `Actions` and `DataActions` explicitly instead of using `*` wildcards in custom roles.
+- Role names can change; role IDs are the safer automation anchor.
+- Control plane and data plane are separate authorization paths. A “close enough” role often is not close enough if the wrong plane is involved.

--- a/skills/azure/azure-role-selector/references/workflow-and-output.md
+++ b/skills/azure/azure-role-selector/references/workflow-and-output.md
@@ -1,0 +1,102 @@
+# Workflow and Output Contract
+
+## Workflow
+
+1. Parse the request exactly.
+   - Identify the target resource type and exact operations.
+   - Identify principal type: user, group, service principal, managed identity, or workload identity.
+   - Identify whether the ask is permanent, temporary, human, or machine access.
+2. Separate permission planes.
+   - Control plane: Azure Resource Manager actions such as create, update, delete, deploy, read configuration, or assign policy.
+   - Data plane: service data actions such as reading blobs, secrets, queues, tables, or database data.
+   - If the user mixes both, keep them separate in the answer.
+3. Minimize scope before role selection.
+   - Prefer resource scope over resource-group scope.
+   - Prefer resource-group scope over subscription scope.
+   - Prefer subscription scope over management-group scope.
+   - Treat broad inherited scope as a risk that must be justified.
+4. Prefer the narrowest built-in role.
+   - Check whether a Microsoft built-in role already matches the required actions.
+   - Reject habitual escalation to `Owner`, `Contributor`, or other broad roles unless the requested actions truly require them.
+   - If a role includes meaningful extra privilege, say so explicitly.
+5. Decide whether custom role fallback is justified.
+   - Only consider a custom role when no built-in role safely matches the needed actions.
+   - State which required actions are missing from the closest built-in role.
+   - Keep custom-role scope and assignable scopes narrow.
+   - Avoid wildcard-heavy custom roles unless the user has explicitly accepted the blast radius.
+   - If the design requires `DataActions`, remember that Microsoft documents these custom roles as not assignable at management-group scope.
+6. Recommend assignment scope.
+   - Return the lowest workable scope.
+   - Call out inherited access risk if the user asks for a broader scope than needed.
+   - If the ask spans multiple resources, say whether one shared scope is acceptable or whether split assignments are safer.
+7. Define the validation path.
+   - Validate the role definition or built-in role against the requested actions.
+   - Validate the assignment at the chosen scope.
+   - Validate the real task with a bounded operator test instead of assuming the grant works.
+
+## Output contract
+
+Return all of the following:
+
+- requested access summary,
+- control-plane needs,
+- data-plane needs,
+- recommended built-in role first, or explicit custom-role fallback rationale,
+- recommended assignment scope,
+- validation path,
+- risks, assumptions, and any missing facts.
+
+Use this response shape:
+
+```text
+Requested access
+- <principal> needs <actions> on <resource>
+
+Plane split
+- Control plane: ...
+- Data plane: ...
+
+Recommended role
+- Built-in role: <name> at <scope>
+- Why: <why it fits>
+- Gaps or excess privilege: <if any>
+
+Custom role fallback
+- Needed: yes|no
+- Why: <only if built-in roles do not fit>
+
+Validation path
+- Confirm role definition
+- Confirm assignment scope
+- Perform bounded task test
+
+Risks and assumptions
+- ...
+```
+
+## Eval gate
+
+Treat the skill output as failing if any of the following are missing:
+
+- the requested actions were not parsed into concrete operations,
+- control plane and data plane were not separated,
+- a built-in role search was skipped,
+- a custom role was suggested without stating why built-in roles failed,
+- the assignment scope was omitted,
+- the validation path did not include an actual bounded verification step,
+- risks or assumptions were omitted when facts are incomplete.
+
+Minimum scenarios this skill should handle:
+
+1. read-only storage access,
+2. narrow deploy-oriented application access,
+3. custom-role fallback when built-in roles are too broad or incomplete.
+
+## Safety notes
+
+- Do not recommend `Owner` for routine operations.
+- Do not recommend `Contributor` by default for application onboarding.
+- Do not blur Azure control-plane RBAC with service data-plane permissions.
+- Do not suggest management-group or subscription-wide grants unless the blast radius is explicitly justified.
+- Do not invent custom roles when a built-in role is already close enough and safer.
+- Do not claim least privilege if the answer has not identified excess privilege, missing facts, or validation steps.

--- a/skills/azure/azure-security-posture-hardening/SKILL.md
+++ b/skills/azure/azure-security-posture-hardening/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: azure-security-posture-hardening
+description: Use this skill for Azure security posture review, baseline hardening, managed identity adoption, Key Vault posture, private access decisions, Azure Policy guardrails, and logging or audit gap analysis. Trigger when the user asks how to harden an Azure workload or platform without defaulting to broad access or public exposure.
+metadata:
+  author: github: Raishin
+---
+
+# Azure Security Posture Hardening
+
+## Purpose
+
+Review and harden Azure platform or workload posture using operator-grade controls:
+
+- least privilege,
+- managed identities over stored secrets,
+- private access where justified,
+- Key Vault hardening,
+- policy-enforced controls,
+- audit and diagnostic coverage,
+- staged remediation with rollout safety.
+
+## When to use
+
+Use this skill when the user asks for:
+
+- Azure security baseline or posture review,
+- managed identity migration guidance,
+- Key Vault hardening or secret-handling critique,
+- private endpoint or public exposure decisions for sensitive services,
+- Azure Policy or Defender-backed hardening recommendations,
+- logging, diagnostics, or auditability expectations for Azure security controls,
+- zero-trust-oriented review of platform or workload controls.
+
+Do not use this skill as a full compliance audit, incident forensics runbook, or a substitute for deep service-specific implementation docs.
+
+## Lean operating rules
+
+- Prefer live Azure or Microsoft evidence first when the active client exposes it; otherwise fall back to official documentation and sanitized user evidence.
+- Separate confirmed facts from inference. If state was not queried or shown, say so.
+- Challenge broad access, broad scope, destructive changes, and hand-wavy production claims.
+- Keep the answer scoped, reversible, least-privilege, and explicit about blockers or unknowns.
+
+## References
+
+Load these only when needed:
+
+- [MCP and evidence path](references/mcp-and-evidence.md) — use when choosing live Azure evidence, confirming Microsoft MCP capability, or switching to documentation mode.
+- [Workflow and output contract](references/workflow-and-output.md) — use when executing the full review, applying stress checks, or formatting the final answer.
+- [Official sources](references/official-sources.md) — use when you need the detailed Microsoft documentation list or source notes.
+
+## Response minimum
+
+Return, at minimum:
+
+- the scoped target and evidence level,
+- the main risks or control gaps,
+- the safest next actions,
+- the assumptions or blockers that prevent stronger conclusions.

--- a/skills/azure/azure-security-posture-hardening/metadata.json
+++ b/skills/azure/azure-security-posture-hardening/metadata.json
@@ -1,0 +1,33 @@
+{
+  "id": "azure-security-posture-hardening",
+  "name": "Azure Security Posture Hardening",
+  "type": "skill",
+  "provider": "azure",
+  "harnesses": [
+    "codex",
+    "claude-code",
+    "cursor",
+    "gemini",
+    "kiro",
+    "other"
+  ],
+  "summary": "Review Azure security posture with least privilege, managed identities, Key Vault hardening, private access decisions, policy guardrails, and audit-ready logging expectations.",
+  "source_type": "original",
+  "official_docs": [
+    "https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/design-area/security",
+    "https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/design-areas",
+    "https://learn.microsoft.com/en-us/azure/security/fundamentals/best-practices-and-patterns",
+    "https://learn.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/managed-identity-best-practice-recommendations",
+    "https://learn.microsoft.com/en-us/azure/key-vault/general/best-practices",
+    "https://learn.microsoft.com/en-us/azure/key-vault/general/rbac-guide",
+    "https://learn.microsoft.com/en-us/azure/key-vault/general/how-to-azure-key-vault-network-security",
+    "https://learn.microsoft.com/en-us/azure/key-vault/general/howto-logging",
+    "https://learn.microsoft.com/en-us/azure/key-vault/general/monitor-key-vault",
+    "https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/",
+    "https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/services/azure-mcp-server-for-key-vault"
+  ],
+  "security_notes": "Do not recommend broad admin roles, stored secrets, or public exposure by default. Prefer managed identities, scoped RBAC, policy-enforced controls, private access where justified, and verified logging coverage.",
+  "last_verified": "2026-04-27",
+  "path": "skills/azure/azure-security-posture-hardening",
+  "author": "github: Raishin"
+}

--- a/skills/azure/azure-security-posture-hardening/references/mcp-and-evidence.md
+++ b/skills/azure/azure-security-posture-hardening/references/mcp-and-evidence.md
@@ -1,0 +1,23 @@
+# MCP and Evidence Path
+
+## Evidence path
+
+Ground the review in this order:
+
+1. **Live Azure evidence when available**
+   - resource exposure,
+   - identity model,
+   - role assignments,
+   - policy assignments/exemptions,
+   - Key Vault configuration,
+   - diagnostic settings and monitoring paths.
+2. **Azure MCP evidence when supported by the client and enabled**
+   - `keyvault` for vault inventory and secret/certificate posture,
+   - `role` for RBAC evidence,
+   - `policy` for guardrail posture,
+   - `monitor` for diagnostic and logging checks,
+   - `advisor` for supporting posture signals.
+3. **Official Microsoft documentation** for design decisions and corrective guidance.
+4. **Explicit assumptions** when live evidence is missing.
+
+If the evidence is incomplete, say so. Do not claim the environment is secure from design intent alone.

--- a/skills/azure/azure-security-posture-hardening/references/official-sources.md
+++ b/skills/azure/azure-security-posture-hardening/references/official-sources.md
@@ -1,0 +1,15 @@
+# Official Sources
+
+## Official sources
+
+- Azure landing zone security design area: https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/design-area/security
+- Azure landing zone design areas: https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/design-areas
+- Azure security best practices and patterns: https://learn.microsoft.com/en-us/azure/security/fundamentals/best-practices-and-patterns
+- Managed identity best practice recommendations: https://learn.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/managed-identity-best-practice-recommendations
+- Secure your Azure Key Vault: https://learn.microsoft.com/en-us/azure/key-vault/general/best-practices
+- Azure Key Vault RBAC guide: https://learn.microsoft.com/en-us/azure/key-vault/general/rbac-guide
+- Configure network security for Azure Key Vault: https://learn.microsoft.com/en-us/azure/key-vault/general/how-to-azure-key-vault-network-security
+- Enable Key Vault logging: https://learn.microsoft.com/en-us/azure/key-vault/general/howto-logging
+- Monitor Azure Key Vault: https://learn.microsoft.com/en-us/azure/key-vault/general/monitor-key-vault
+- Azure MCP Server tools: https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/
+- Manage Azure Key Vault with Azure MCP Server: https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/services/azure-mcp-server-for-key-vault

--- a/skills/azure/azure-security-posture-hardening/references/workflow-and-output.md
+++ b/skills/azure/azure-security-posture-hardening/references/workflow-and-output.md
@@ -1,0 +1,96 @@
+# Workflow and Output Contract
+
+## Workflow
+
+1. **Scope the review**
+   - Identify tenant, management group, subscription, resource group, workload, or service scope.
+   - Separate platform controls from workload-local controls.
+   - Identify whether the ask is greenfield hardening, brownfield remediation, or exception review.
+
+2. **Map identity and secret flows**
+   - List human admins, workload identities, service principals, and managed identities.
+   - Challenge stored credentials, connection strings in code/config, and over-scoped service principals.
+   - Prefer system-assigned or user-assigned managed identities when they reduce secret handling and blast radius.
+   - Check whether Key Vault access uses Azure RBAC and whether permissions are scoped narrowly.
+
+3. **Check network exposure and private access posture**
+   - Identify internet-reachable management or data paths.
+   - Challenge public endpoints for sensitive data paths by default.
+   - Recommend private endpoints, Private Link, or tighter network restrictions when justified by data sensitivity, lateral-movement risk, or zero-trust requirements.
+   - Do not force private access blindly; call out DNS, routing, operational, and cost implications.
+
+4. **Review Key Vault posture**
+   - Check whether secrets, keys, and certificates are centralized appropriately instead of embedded in apps or pipelines.
+   - Check RBAC model, network restrictions, diagnostic logging, and access patterns.
+   - Prefer vault-per-application-per-environment patterns unless there is a justified shared-services design.
+   - Flag broad vault administrator access, uncontrolled secret sprawl, and missing monitoring.
+
+5. **Review policy-enforced controls**
+   - Check for Azure Policy assignments or equivalent guardrails that enforce the intended baseline.
+   - Distinguish audit-only, deny, deployIfNotExists, and remediation-driven controls.
+   - Look for missing controls around public exposure, diagnostics, encryption expectations, approved regions/SKUs, and identity hygiene.
+
+6. **Review detection, audit, and logging coverage**
+   - Check whether critical services emit diagnostics to the intended destination.
+   - Check whether Key Vault logging/monitoring is enabled and retained in an auditable destination.
+   - Call out when security recommendations lack detection coverage, ownership, or alert routing.
+   - Separate “control exists” from “control is monitored.”
+
+7. **Prioritize remediation safely**
+   - Classify findings into urgent, near-term, and strategic.
+   - Sequence changes to avoid breaking apps, pipelines, or operators.
+   - For brownfield environments, recommend validate-first rollout steps and rollback expectations.
+
+## Output contract
+
+Return all of the following:
+
+- **Scope and evidence summary**
+  - reviewed scope,
+  - evidence sources used,
+  - important unknowns.
+- **Current posture summary**
+  - identity model,
+  - secret handling model,
+  - network exposure posture,
+  - policy and monitoring posture.
+- **High-risk findings**
+  - issue,
+  - why it matters,
+  - likely blast radius.
+- **Prioritized hardening plan**
+  - urgent actions,
+  - near-term actions,
+  - strategic improvements.
+- **Safe sequencing**
+  - dependency notes,
+  - validation steps,
+  - rollback cautions.
+- **Assumptions and evidence gaps**
+  - what was inferred,
+  - what must be verified before change approval.
+
+## Eval gate
+
+The skill output is only acceptable if it:
+
+1. identifies identities, secret flows, and network exposure explicitly,
+2. separates control-plane, data-plane, and policy/monitoring concerns,
+3. recommends managed identities and least privilege where applicable,
+4. addresses Key Vault posture, not just generic “use a vault” advice,
+5. includes logging or diagnostic expectations,
+6. prioritizes actions by risk and rollout safety,
+7. states assumptions and missing evidence when live posture is incomplete.
+
+Fail the response if it defaults to broad access, treats public exposure as harmless, ignores telemetry, or gives generic compliance prose without an operator action path.
+
+## Safety notes
+
+- Do not request or expose secrets, tokens, certificates, keys, tenant secrets, or customer data.
+- Do not recommend `Owner`, subscription-wide `Contributor`, or broad vault admin access unless the user has justified the blast radius.
+- Do not recommend public endpoints by default for sensitive services or secret-bearing paths.
+- Do not present private endpoints as free or automatic; call out DNS, routing, and operational dependencies.
+- Do not assume Azure Policy enforcement exists just because a standard is documented.
+- Do not treat diagnostic settings as optional for sensitive services.
+- If the task becomes a deep RBAC redesign, route to `azure-rbac-review` or a role-selection skill.
+- If the task becomes a broader governance initiative rollout, route to a governance/policy guardrail skill.

--- a/skills/azure/azure-subscription-resource-organization/SKILL.md
+++ b/skills/azure/azure-subscription-resource-organization/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: azure-subscription-resource-organization
+description: Use this skill for Azure management-group hierarchy, subscription placement, resource-group boundary, and platform-versus-workload ownership decisions that affect governance, operations, and landing-zone scale.
+metadata:
+  author: github: Raishin
+  version: 0.1.0
+---
+
+# Azure Subscription Resource Organization
+
+## Role Charter
+
+Act as a ruthless Azure resource-organization architect. Your job is to stop weak hierarchy decisions before they become permanent governance debt. Force clarity on management-group purpose, subscription boundary, resource-group lifecycle, policy inheritance, operating ownership, and workload isolation before recommending structure changes.
+
+Default posture:
+
+- Prefer official Microsoft Learn guidance for Azure landing zones, resource organization, and governance.
+- Prefer live Azure MCP evidence when the client exposes relevant official Azure tools and current-state inspection reduces guesswork.
+- Do not invent management-group or subscription capabilities that the active client does not actually expose.
+- Do not ask the user to paste secrets, credentials, tenant secrets, access tokens, or customer identifiers into chat.
+- Do not hard-code tenant names, management-group IDs, subscription IDs, resource-group names, or organizational structure unless the user provides them as confirmed context.
+
+## Trigger Situations
+
+Use this skill when the user asks to:
+
+- Design or review an Azure management-group hierarchy.
+- Decide where subscriptions should sit in a platform or application landing-zone model.
+- Separate platform subscriptions from workload subscriptions.
+- Decide whether a boundary belongs at management-group, subscription, or resource-group level.
+- Review governance, policy inheritance, cost, operations, or security implications of resource organization choices.
+- Clarify which team should own shared services, platform controls, or workload-local resources.
+- Critique brownfield Azure estates with subscription sprawl, flat hierarchy drift, or weak ownership boundaries.
+
+## Lean operating rules
+
+- Prefer live Azure or Microsoft evidence first when the active client exposes it; otherwise fall back to official documentation and sanitized user evidence.
+- Separate confirmed facts from inference. If state was not queried or shown, say so.
+- Challenge broad access, broad scope, destructive changes, and hand-wavy production claims.
+- Keep the answer scoped, reversible, least-privilege, and explicit about blockers or unknowns.
+
+## References
+
+Load these only when needed:
+
+- [MCP and evidence path](references/mcp-and-evidence.md) — use when choosing live Azure evidence, confirming Microsoft MCP capability, or switching to documentation mode.
+- [Workflow and output contract](references/workflow-and-output.md) — use when executing the full review, applying stress checks, or formatting the final answer.
+- [Official sources](references/official-sources.md) — use when you need the detailed Microsoft documentation list or source notes.
+
+## Response minimum
+
+Return, at minimum:
+
+- the scoped target and evidence level,
+- the main risks or control gaps,
+- the safest next actions,
+- the assumptions or blockers that prevent stronger conclusions.

--- a/skills/azure/azure-subscription-resource-organization/metadata.json
+++ b/skills/azure/azure-subscription-resource-organization/metadata.json
@@ -1,0 +1,30 @@
+{
+  "id": "azure-subscription-resource-organization",
+  "name": "Azure Subscription Resource Organization",
+  "type": "skill",
+  "provider": "azure",
+  "harnesses": [
+    "codex",
+    "claude-code",
+    "cursor",
+    "gemini",
+    "kiro",
+    "other"
+  ],
+  "summary": "Design and review Azure management-group, subscription, and resource-group boundaries with explicit governance, ownership, and landing-zone operating-model consequences.",
+  "source_type": "original",
+  "official_docs": [
+    "https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/design-areas",
+    "https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/",
+    "https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/design-area/resource-org",
+    "https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/design-area/resource-org-management-groups",
+    "https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/design-area/governance",
+    "https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/",
+    "https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/subscription",
+    "https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/resource-group"
+  ],
+  "security_notes": "Do not recommend flat hierarchies, fake isolation via resource groups, or subscription moves without proving governance, ownership, policy inheritance, and operational blast-radius implications.",
+  "last_verified": "2026-04-27",
+  "path": "skills/azure/azure-subscription-resource-organization",
+  "author": "github: Raishin"
+}

--- a/skills/azure/azure-subscription-resource-organization/references/mcp-and-evidence.md
+++ b/skills/azure/azure-subscription-resource-organization/references/mcp-and-evidence.md
@@ -1,0 +1,32 @@
+# MCP and Evidence Path
+
+## Official Azure MCP Linkage
+
+Use official Azure MCP tools only if they are actually available in the active client.
+
+Preferred evidence path:
+
+- `subscription` for current subscription inventory and placement context.
+- `group` for resource-group inventory and workload grouping inside a subscription.
+- `group` only if the active client exposes an official group-related Azure capability; do not assume this means management-group mutation support.
+
+Important constraint:
+
+- The official Azure MCP documentation identified for this repo clearly documents subscription and resource-group tools. It does **not** prove that every client exposes management-group tools. If management-group inspection is unavailable, switch to documentation mode plus sanitized user-provided hierarchy evidence.
+
+## Platform-Agnostic Execution
+
+This skill must work on macOS, Windows, Linux, and MCP-only clients.
+
+- Prefer Azure MCP evidence first when available.
+- When examples need commands or checks, keep them abstract with `<placeholders>` unless the user’s active platform and toolchain are known.
+- Do not anchor the workflow to Azure CLI, PowerShell, Terraform, or portal-only steps unless the user asks for that execution path next.
+
+## Documentation Fallback When Live Data Is Unavailable
+
+Live Azure evidence beats documentation for current-state questions. If live MCP data is unavailable, denied, incomplete, or unsafe to query:
+
+- Fall back to the Microsoft Learn references listed above.
+- Ask for sanitized hierarchy diagrams, subscription inventories, policy-assignment views, naming standards, or ownership maps if current-state proof matters.
+- Label conclusions as `live evidence`, `documentation-based`, `user-provided sanitized evidence`, or `inference`.
+- Do not pretend Microsoft Learn proves the user’s actual hierarchy, subscription sprawl, policy inheritance, or team ownership reality.

--- a/skills/azure/azure-subscription-resource-organization/references/official-sources.md
+++ b/skills/azure/azure-subscription-resource-organization/references/official-sources.md
@@ -1,0 +1,14 @@
+# Official Sources
+
+## References
+
+Ground conclusions only in these official Microsoft documentation paths and live Azure evidence when available:
+
+- [Azure landing zone design areas](https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/design-areas) — top-level design-area map and relationship to landing-zone structure.
+- [Azure landing zones overview](https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/) — platform landing zones versus application landing zones and reference-architecture framing.
+- [Resource organization design area](https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/design-area/resource-org) — management-group design, subscription design, naming, tagging, and scaling considerations.
+- [Management groups design guidance](https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/design-area/resource-org-management-groups) — management-group depth, inheritance, and hierarchy recommendations.
+- [Governance design area](https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/design-area/governance) — policy, compliance, and operating-model consequences of scope choices.
+- [Azure MCP tools inventory](https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/) — official Azure MCP namespace discovery and shared parameter behavior.
+- [Azure MCP subscription tools](https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/subscription) — official subscription inspection capability when available.
+- [Azure MCP resource-group tools](https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/resource-group) — official resource-group inspection capability when available.

--- a/skills/azure/azure-subscription-resource-organization/references/workflow-and-output.md
+++ b/skills/azure/azure-subscription-resource-organization/references/workflow-and-output.md
@@ -1,0 +1,95 @@
+# Workflow and Output Contract
+
+## Safe Workflow
+
+1. **Classify the estate**
+   - greenfield or brownfield,
+   - single subscription or multi-subscription,
+   - centralized platform model or team-local sprawl,
+   - regulated or lightly governed.
+2. **Identify the real boundary decision**
+   - management group,
+   - subscription,
+   - resource group,
+   - or no new boundary because the existing one is already correct.
+3. **Map ownership before structure**
+   - platform team,
+   - security/governance team,
+   - networking/shared-services team,
+   - workload or application teams,
+   - billing/FinOps accountability.
+4. **Test hierarchy intent**
+   - inheritance target for policy and RBAC,
+   - separation needed for compliance, residency, or operational autonomy,
+   - subscription democratization needs,
+   - shared-services placement,
+   - exception-handling model.
+5. **Stress subscription placement**
+   - platform landing zones versus application landing zones,
+   - shared connectivity, identity, management, and security services,
+   - blast radius of putting unrelated workloads together,
+   - cost and quota implications,
+   - lifecycle mismatch across teams.
+6. **Stress resource-group usage**
+   - lifecycle affinity,
+   - access boundary assumptions,
+   - whether the team is trying to use resource groups to solve a subscription or governance problem they cannot safely solve.
+7. **Return a go/no-go structure verdict**
+   - what should stay,
+   - what should move,
+   - what should not be split yet,
+   - and which governance or operations dependencies block the reorganization.
+
+## Role-Specific Stress Checks
+
+- Reject “one big subscription is simpler” when multiple teams, environments, workloads, or control boundaries clearly differ.
+- Reject “just mirror the org chart” as a management-group strategy. Organizational charts change faster than good governance boundaries.
+- Reject designs that use resource groups as fake tenancy, fake billing isolation, or fake compliance boundaries.
+- Challenge any platform model that mixes shared connectivity, identity, monitoring, or security controls into arbitrary workload subscriptions without a reason.
+- Call out when management-group placement creates policy or RBAC inheritance that the operating model cannot actually support.
+- Challenge subscription splits that create excessive operational friction without a real governance, ownership, quota, or blast-radius benefit.
+- Force explicit ownership for platform subscriptions; if nobody owns them, the design is incomplete.
+
+## Output Template
+
+```markdown
+# Azure Resource Organization Review: <scope>
+
+## Verdict
+- Status: READY / READY WITH RISKS / NOT READY
+- Primary boundary decision:
+- Biggest organizational risk:
+- Evidence level: live evidence / documentation-based / user-provided sanitized evidence / inference
+
+## Current or proposed structure
+- Tenant/platform context:
+- Management-group shape:
+- Subscription model:
+- Resource-group pattern:
+- Platform owners:
+- Workload owners:
+
+## Findings
+| Area | Finding | Severity | Evidence | Recommendation | Owner |
+|---|---|---|---|---|---|
+
+## Boundary decisions
+| Decision | Best boundary | Why | Governance impact | Operations impact |
+|---|---|---|---|---|
+
+## Safe next actions
+1.
+2.
+3.
+
+## Assumptions and unknowns
+- 
+```
+
+## Red Flags
+
+- The request asks for management-group hierarchy advice without naming who owns governance, policy, or shared services.
+- The design assumes resource groups provide the same isolation as subscriptions.
+- The proposed split or consolidation ignores policy inheritance, quota boundaries, or billing accountability.
+- The answer claims confidence about the current hierarchy without live evidence or sanitized user proof.
+- The plan moves subscriptions for “tidiness” without a governance, operations, security, or ownership reason.


### PR DESCRIPTION
## Summary

Add a first-wave Azure role-based skill portfolio and harden it with progressive-disclosure references grounded in current Microsoft documentation.

This PR moves the repo from Azure-thin coverage to a real Azure role-lane portfolio, with lean `SKILL.md` entrypoints and on-demand `references/` content to reduce bloat and improve trigger quality.

## What changed

### Azure portfolio expansion
Added Azure role-based skills for:

- Azure AI Foundry governance
- AKS platform operations
- App Service production readiness
- Cost estimation review
- Cost optimization governance
- Governance / policy guardrails
- Identity governance review
- Key Vault secret lifecycle auditing
- Landing zone architecture
- Migrate / landing zone cutover
- Network topology review
- Observability investigation
- Platform automation / DevOps
- Private endpoint adoption planning
- RBAC review
- Resilience / BCDR review
- Resource health incident triage
- Role selection
- Security posture hardening
- Subscription / resource organization

### Progressive-disclosure refactor
Refactored Azure skills to use:
- lean `SKILL.md`
- `references/mcp-and-evidence.md`
- `references/workflow-and-output.md`
- `references/official-sources.md`

This keeps the skill entrypoints token-lean and pushes heavy detail into lazy-loaded references.

### Documentation and portfolio artifacts
Added:
- `skills/azure/README.md`
- `docs/azure-role-skill-gap-analysis.md`
- `docs/azure-role-skill-specs.md`
- `.claude/evals/azure-role-skills-reference-refactor.md`

### Grounding and hardening
Re-grounded Azure references against Microsoft Learn and Azure MCP documentation.

Also tightened several important skill assumptions, including:
- Azure Policy scope and remediation caveats
- landing-zone vs application landing-zone boundaries
- private endpoint `/32` route and DNS implications
- observability dependence on diagnostic settings and telemetry routing
- RBAC best-practice constraints
- documented Azure MCP namespace usage

## Validation

Ran successfully:
- `npm run manifest:write`
- `npm run validate`

## Notes

- `.mcp.json` was intentionally left uncommitted as local runtime wiring.
- This PR prepares the Azure portfolio for a next step of runtime-truth / compliance evaluation against actually exposed MCP tools.
