### PR TITLE
feat(marketplace): add cross-platform agent export workflow

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "vanguard-frontier-agentic",
+  "interface": {
+    "displayName": "Vanguard Frontier Agentic"
+  },
+  "plugins": [
+    {
+      "name": "cross-platform-agent-template",
+      "source": {
+        "source": "local",
+        "path": "./plugins/cross-platform-agent-template"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
+    }
+  ]
+}

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,47 @@
+# Vanguard Frontier Agentic repository instructions
+
+This repository is a curated marketplace for **cloud**, **zero-trust**, and **compliance-aware** AI workflows.
+
+## What to optimize for
+
+- Evidence-backed guidance over confident guessing
+- Least privilege over convenience
+- Zero-trust design over implicit trust
+- Safe automation with approval, validation, and rollback paths
+- Clear separation between facts, assumptions, inference, and unknowns
+
+## Repo structure
+
+- `skills/` = reusable workflows
+- `agents/` = expert roles
+- `rules/` = harness-specific instructions
+- `mcp/` = MCP references and trust notes
+- `catalog/` = machine-readable indexes
+- `schemas/` = metadata contracts
+- `docs/` = governance, taxonomy, quality, compatibility
+
+## Rules for changes
+
+- Keep changes tightly scoped to the request.
+- Do not add secrets, credentials, tokens, tenant IDs, wallets, or customer data.
+- Prefer official docs and live evidence for cloud/compliance claims.
+- Treat destructive actions, broad permissions, and MCP mutation paths as high risk.
+- Update catalog metadata when adding, moving, or removing cataloged assets.
+- If intentional changes are made under cataloged `skills/**`, refresh the skill manifest with `npm run manifest:write`.
+- Run `npm run validate` before finishing.
+
+## Cross-platform asset rule
+
+This repo supports multiple harnesses without pretending they are identical.
+
+- Keep portable logic in canonical/shared assets.
+- Keep harness-specific behavior in the correct adapter format.
+- Do not invent unsupported executable metadata fields.
+
+## Read these when relevant
+
+- `README.md`
+- `AGENTS.md`
+- `docs/compatibility.md`
+- `docs/normalized-platform-matrix.md`
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     branches:
-      - main
+      - master
 
 permissions:
   contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,14 +22,29 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "lts/*"
+          node-version: "22"
 
       - uses: actions/setup-python@v5
         with:
           python-version: "3.x"
 
+      - name: Capture pre-release state
+        run: |
+          PRE_TAG="$(git describe --tags --abbrev=0 2>/dev/null || echo none)"
+          PRE_VERSION="$(node -p "require('./package.json').version")"
+          echo "PRE_TAG=$PRE_TAG" >> "$GITHUB_ENV"
+          echo "PRE_VERSION=$PRE_VERSION" >> "$GITHUB_ENV"
+
       - name: Install semantic-release plugins
-        run: npm install --no-save semantic-release @semantic-release/changelog @semantic-release/git
+        run: |
+          npm install --no-save \
+            semantic-release@25.0.3 \
+            @semantic-release/changelog@6.0.3 \
+            @semantic-release/git@10.0.1 \
+            @semantic-release/npm@13.1.5 \
+            @semantic-release/github@12.0.6 \
+            @semantic-release/commit-analyzer@13.0.1 \
+            @semantic-release/release-notes-generator@14.1.0
 
       - name: Validate
         run: |
@@ -42,3 +57,48 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx semantic-release
+
+      - name: Verify release result and write summary
+        if: always()
+        env:
+          PACKAGE_NAME: "@raishin/vanguard-frontier-agentic"
+        run: |
+          POST_TAG="$(git describe --tags --abbrev=0 2>/dev/null || echo none)"
+          POST_VERSION="$(node -p "require('./package.json').version")"
+          RELEASE_CREATED=false
+
+          if [ "$POST_TAG" != "$PRE_TAG" ] || [ "$POST_VERSION" != "$PRE_VERSION" ]; then
+            RELEASE_CREATED=true
+          fi
+
+          NPM_VERSION=""
+          if [ "$RELEASE_CREATED" = true ]; then
+            for attempt in 1 2 3 4 5; do
+              NPM_VERSION="$(npm view "$PACKAGE_NAME" version 2>/dev/null || true)"
+              if [ "$NPM_VERSION" = "$POST_VERSION" ]; then
+                break
+              fi
+              sleep 5
+            done
+          fi
+
+          {
+            echo "# Release verification"
+            echo
+            echo "- Branch: \`master\`"
+            echo "- Pre-release tag: \`$PRE_TAG\`"
+            echo "- Pre-release version: \`$PRE_VERSION\`"
+            echo "- Post-release tag: \`$POST_TAG\`"
+            echo "- Post-release version: \`$POST_VERSION\`"
+            echo "- Release created: \`$RELEASE_CREATED\`"
+            if [ "$RELEASE_CREATED" = true ]; then
+              echo "- npm version seen: \`${NPM_VERSION:-not-found}\`"
+            else
+              echo "- npm version check: skipped because no new release was detected"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "$RELEASE_CREATED" = true ] && [ "$NPM_VERSION" != "$POST_VERSION" ]; then
+            echo "Release appears to have been created, but npm does not show version $POST_VERSION for $PACKAGE_NAME" >&2
+            exit 1
+          fi

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,5 +1,5 @@
 {
-  "branches": ["main"],
+  "branches": ["master"],
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,44 @@
+# Vanguard Frontier Agentic
+
+This repository is a curated marketplace for **cloud**, **zero-trust**, and **compliance-aware** AI workflows.
+
+## What this repo contains
+
+- `skills/` — reusable workflows for recurring engineering tasks
+- `agents/` — expert roles with judgment for review, architecture, and operations
+- `rules/` — harness-specific operating guidance
+- `mcp/` — MCP references and trust-boundary notes
+- `catalog/` — machine-readable indexes
+- `schemas/` — metadata contracts
+- `docs/` — governance, taxonomy, compatibility, and quality guidance
+
+## Operating stance
+
+- Prefer **official docs** and **live evidence** over memory.
+- Default to **least privilege**, **zero trust**, and **safe rollback paths**.
+- Separate **verified facts**, **judgment**, **assumptions**, and **unknowns**.
+- Treat broad permissions, destructive automation, and MCP mutation paths as high risk.
+- Do not add secrets, credentials, tokens, tenant IDs, or customer data.
+
+## When working in this repo
+
+- Keep changes scoped and traceable to the task.
+- Update catalog metadata when adding, moving, or removing cataloged assets.
+- Run `npm run validate` before finishing.
+- If `skills/**` changed intentionally, also refresh `catalog/skill-manifest.json` with `npm run manifest:write`.
+
+## Cross-platform asset rule
+
+This repo supports multiple harnesses without pretending they are identical.
+
+- Keep portable logic in canonical specs and shared docs.
+- Keep harness-specific behavior in the right adapter format.
+- Do not invent unsupported metadata fields in executable agent files.
+
+## Important files
+
+- `README.md` — human-facing vision and repository story
+- `AGENTS.md` — compressed agent-focused repo guidance
+- `docs/compatibility.md` — harness support contract
+- `docs/normalized-platform-matrix.md` — naming and platform normalization
+

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,51 @@
+# Vanguard Frontier Agentic
+
+Use this repository as a **curated cloud and zero-trust AI workflow marketplace**, not as a generic prompt dump.
+
+## Repository intent
+
+The north star is practical, evidence-backed cloud engineering:
+
+- secure by default
+- least privilege by default
+- compliance-aware
+- understandable by engineers of any seniority
+
+## What matters most
+
+- Prefer **official documentation** and **observable evidence** over assumptions.
+- Challenge vague architecture claims, broad access, and unsafe automation.
+- Ask: who has access, why, where is the evidence, how is abuse/drift detected, and how is recovery handled?
+
+## Repo map
+
+- `skills/` — step-by-step workflows
+- `agents/` — expert role definitions
+- `rules/` — harness guidance
+- `mcp/` — tool/server integration references
+- `catalog/` — machine-readable indexes
+- `schemas/` — metadata contracts
+- `docs/` — governance, taxonomy, compatibility, and quality bar
+
+## Change discipline
+
+- Keep edits surgical.
+- Preserve source grounding for cloud and compliance claims.
+- Update catalog metadata when cataloged assets move or change.
+- Run `npm run validate` before finishing.
+- If intentional changes occur under cataloged `skills/**`, run `npm run manifest:write`.
+
+## Cross-platform rule
+
+Do not pretend Claude, Codex, Cursor, Copilot, Gemini, and Kiro use the same executable format.
+
+- portable core: name, description, instructions
+- non-portable details: file format, tool fields, model fields, MCP wiring, metadata support
+
+See:
+
+- `AGENTS.md`
+- `README.md`
+- `docs/compatibility.md`
+- `docs/normalized-platform-matrix.md`
+

--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ Think of it as a toolbox:
 The goal is simple: **make AI-assisted cloud work safer, reusable,
 compliance-aware, and easier to understand.**
 
+> 📦 **npm status (verified 2026-04-28):** `@raishin/vanguard-frontier-agentic`
+> is **not published yet** on the public npm registry. Check live status with:
+> `npm view @raishin/vanguard-frontier-agentic version`
+
 ---
 
 ## 🌍 Vision
@@ -163,6 +167,125 @@ Use these principles when creating or reviewing assets:
 | [`templates/`](templates/) | Starter templates for new assets                 | 🧱 “How do I add one?”                 |
 | [`docs/`](docs/)           | Quality rules, taxonomy, and marketplace notes   | 📚 “How should this repo work?”        |
 | [`assets/`](assets/)       | Logos and visual assets                          | 🎨 “What images can docs use?”         |
+
+---
+
+## 📦 Consumer install and export selected agents
+
+This repository is designed so consumers can install **selected marketplace
+agents** into their own project instead of copying everything by hand.
+
+### Current package status
+
+As of **2026-04-28**, the public npm package:
+
+```bash
+@raishin/vanguard-frontier-agentic
+```
+
+was verified as **not yet published** on npm.
+
+Live check:
+
+```bash
+npm view @raishin/vanguard-frontier-agentic version
+```
+
+If that command returns `404 Not Found`, the package is still unpublished.
+
+### Use it today from GitHub
+
+Until npm publishing is live, install from GitHub:
+
+```bash
+npm install github:Raishin/vanguard-frontier-agentic
+```
+
+### Export selected agents into a consumer repository
+
+After installation, this package ships a CLI:
+
+```bash
+vfa-export-agents
+```
+
+It copies selected agent harness files from this marketplace into the correct
+runtime folders in a consumer repository.
+
+List available agent IDs:
+
+```bash
+npx vfa-export-agents --list
+```
+
+Export one agent to **Claude Code**:
+
+```bash
+npx vfa-export-agents \
+  --platform claude-code \
+  --agents azure-cosmosdb-platform-operator-agent \
+  --repo /path/to/consumer-repo
+```
+
+Export one agent to **GitHub Copilot**:
+
+```bash
+npx vfa-export-agents \
+  --platform copilot \
+  --agents azure-cosmosdb-platform-operator-agent \
+  --repo /path/to/consumer-repo
+```
+
+Export one agent to **Kiro** (both IDE + CLI adapters):
+
+```bash
+npx vfa-export-agents \
+  --platform kiro \
+  --agents azure-cosmosdb-platform-operator-agent \
+  --repo /path/to/consumer-repo
+```
+
+Export **all** agents for a platform:
+
+```bash
+npx vfa-export-agents --platform codex --all --repo /path/to/consumer-repo
+```
+
+Overwrite existing exported files intentionally:
+
+```bash
+npx vfa-export-agents --platform copilot --all --repo /path/to/consumer-repo --force
+```
+
+### Platform destination folders
+
+The exporter writes into the destination repository using platform-native
+runtime paths:
+
+| Platform | Destination path(s) |
+| -------- | ------------------- |
+| Codex | `.codex/agents/` |
+| Claude Code | `.claude/agents/` |
+| GitHub Copilot | `.github/agents/` |
+| Cursor | `.cursor/agents/` |
+| Gemini CLI | `.gemini/agents/` |
+| Kiro IDE | `.kiro/agents/` |
+| Kiro CLI | `.kiro/agents/` |
+
+### Important limitation
+
+This exporter installs **custom agent files**, not full repo-level guidance.
+
+If the consumer also wants the repository-level instruction layer, they should
+use the matching project entrypoints in their own repo as appropriate:
+
+- `AGENTS.md`
+- `CLAUDE.md`
+- `GEMINI.md`
+- `.github/copilot-instructions.md`
+
+See [`docs/normalized-platform-matrix.md`](docs/normalized-platform-matrix.md)
+for the exact distinction between repo guidance and custom agent installation.
 
 ---
 

--- a/docs/normalized-platform-matrix.md
+++ b/docs/normalized-platform-matrix.md
@@ -1,0 +1,109 @@
+# Normalized Platform Matrix
+
+Last reviewed: 2026-04-28
+
+This matrix separates three things that are easy to blur:
+
+1. the **normalized labels** this repo uses for cross-harness assets,
+2. the **vendor product names** users recognize,
+3. the **actual file or adapter shapes** needed for each platform.
+
+Do not pretend these platforms are interchangeable. Some are Markdown-family adapters, some are structured configs, and some are broader agent products that this repo does **not** target yet.
+
+## Repo-supported normalized labels
+
+These are the labels currently used by this repository in metadata, docs, and harness variants.
+
+| Normalized label | User-facing product | Adapter family | Typical repo artifact(s) | Current repo support | Notes |
+| --- | --- | --- | --- | --- | --- |
+| `codex` | OpenAI Codex | Structured config | `harnesses/codex.toml` | Supported | Native TOML adapter, not Markdown body. |
+| `copilot` | GitHub Copilot / VS Code custom agent | Markdown + YAML frontmatter | `harnesses/copilot.agent.md` | Supported | Also related to Copilot Agent Skills, but skills are a separate portability layer. |
+| `claude-code` | Claude Code | Markdown + YAML frontmatter | `harnesses/claude-code.agent.md` | Supported | Uses subagent-style Markdown definitions. |
+| `cursor` | Cursor | Markdown + YAML frontmatter | `harnesses/cursor.agent.md` | Supported | Keep Cursor-specific fields out unless verified. |
+| `gemini` | Gemini CLI | Markdown + YAML frontmatter | `harnesses/gemini.agent.md` | Supported | Treat Gemini CLI as the concrete executable target, not “Gemini” in the abstract. |
+| `kiro` | Kiro | Split target: Markdown + JSON | `harnesses/kiro-ide.agent.md`, `harnesses/kiro-cli.agent.json` | Supported | Kiro IDE and Kiro CLI are related but not interchangeable. |
+| `other` | Unclassified / future | Varies | none by default | Placeholder only | Use only when a platform is real but not yet normalized in repo conventions. |
+
+## Repo-level instruction entrypoints
+
+If the goal is to let a platform **open this repository and immediately inherit project guidance**, the runtime entrypoint matters as much as the agent adapter format.
+
+| Platform | Repo-level guidance file or path | Status in this repo | Notes |
+| --- | --- | --- | --- |
+| Codex | `AGENTS.md` | Present | Use `AGENTS.md` for repo guidance; custom subagents are separate TOML files under `.codex/agents/` when needed. |
+| Cursor | `AGENTS.md` | Present | Cursor docs explicitly support root `AGENTS.md` for project instructions. |
+| Kiro IDE | `AGENTS.md` or `.kiro/steering/` | `AGENTS.md` present | Kiro docs support `AGENTS.md`; steering files are an additional option. |
+| Claude Code | `CLAUDE.md` | Present | Claude Code uses `CLAUDE.md` for project memory and `.claude/agents/` for custom subagents. |
+| Gemini CLI | `GEMINI.md` | Present | Gemini CLI uses hierarchical `GEMINI.md` memory and `.gemini/agents/` for custom subagents. |
+| GitHub Copilot | `.github/copilot-instructions.md` | Present | Repo-level instructions are separate from `.github/agents/` custom agent profiles. |
+| GitHub Copilot custom agents | `.github/agents/` | Not populated by default | This repo ships harness adapters under `agents/**/harnesses/`; consumers can copy selected adapters into `.github/agents/` when they want active repo-level custom agents. |
+| Kiro CLI custom agents | `.kiro/agents/*.json` | Not populated by default | This repo stores Kiro CLI adapters under `agents/**/harnesses/kiro-cli.agent.json`; copy selected ones into `.kiro/agents/` in a consuming repo. |
+| Claude Code custom subagents | `.claude/agents/*.md` | Not populated by default | This repo stores Claude adapters under `agents/**/harnesses/claude-code.agent.md`; copy selected ones into `.claude/agents/` in a consuming repo. |
+| Gemini CLI custom subagents | `.gemini/agents/*.md` | Not populated by default | This repo stores Gemini adapters under `agents/**/harnesses/gemini.agent.md`; copy selected ones into `.gemini/agents/` in a consuming repo. |
+
+The important distinction:
+
+- **repo-level guidance files** tell the main agent how to behave in this repository
+- **custom agent/subagent files** add specialized delegates that can be installed separately
+
+## Broader agentic platform candidates
+
+These matter for market awareness, but they are **not** normalized repo labels yet.
+
+| Candidate product | Suggested future normalized label | Why it matters | Current repo status | Why not normalized yet |
+| --- | --- | --- | --- | --- |
+| Windsurf | `windsurf` | Agentic IDE with MCP-aware workflows | Not supported | No harness convention or repo adapter contract yet. |
+| Cline | `cline` | Strong customization model with rules, skills, workflows, hooks, CLI | Not supported | Different customization surface than the current harness set. |
+| Continue | `continue` | Agent mode plus hosted/shared agents | Not supported | Needs a clear adapter contract before adding to repo taxonomy. |
+
+## Product names that users may mention but should be normalized carefully
+
+| User says | Normalize to | Why |
+| --- | --- | --- |
+| “Claude” | `claude-code` only when they mean Claude Code subagents | Claude the model family is not the same thing as Claude Code the agent surface. |
+| “Gemini” | `gemini` only when they mean Gemini CLI adapter support | Gemini as a model/vendor is broader than the executable harness target. |
+| “Kiro” | `kiro` plus explicit IDE vs CLI distinction when generating files | Kiro has at least two materially different adapter shapes in this repo. |
+| “Copilot” | `copilot` | This was an easy miss when listing agentic platforms; it is already a first-class harness here. |
+
+## Recommended naming rule for this repo
+
+When updating catalog entries, agent metadata, or skills:
+
+- use the **normalized label** in machine-readable metadata,
+- use the **user-facing product name** in prose,
+- and keep the **exact adapter filename** specific to the executable target.
+
+Example:
+
+- metadata harness label: `kiro`
+- prose name: `Kiro`
+- executable adapters:
+  - `harnesses/kiro-ide.agent.md`
+  - `harnesses/kiro-cli.agent.json`
+
+## What was missing from the original short list
+
+The strongest miss was:
+
+- **GitHub Copilot**
+
+Additional serious candidates for later normalization:
+
+- **Windsurf**
+- **Cline**
+- **Continue**
+
+## Source grounding
+
+Official references reviewed for this normalization work:
+
+- Anthropic Claude Code subagents: <https://docs.anthropic.com/en/docs/claude-code/sub-agents>
+- GitHub Copilot custom agents: <https://code.visualstudio.com/docs/copilot/customization/custom-agents>
+- GitHub Copilot agent skills: <https://code.visualstudio.com/docs/copilot/customization/agent-skills>
+- OpenAI Codex docs: <https://platform.openai.com/docs/codex>
+- Cursor docs: <https://docs.cursor.com/>
+- Kiro steering and hooks docs: <https://kiro.dev/docs/steering/> and <https://kiro.dev/docs/hooks/types/>
+- Gemini CLI repo/docs entrypoint: <https://github.com/google-gemini/gemini-cli>
+- Windsurf docs: <https://docs.windsurf.com/>
+- Cline docs: <https://docs.cline.bot/home>
+- Continue docs: <https://docs.continue.dev/intro>

--- a/package.json
+++ b/package.json
@@ -4,9 +4,13 @@
   "description": "Cloud and zero-trust agentic workflow marketplace for skills, agents, rules, MCP references, and compliance-aware architecture.",
   "license": "Apache-2.0",
   "type": "commonjs",
+  "bin": {
+    "vfa-export-agents": "./scripts/export-marketplace-agents.mjs"
+  },
   "files": [
     "README.md",
     "LICENSE",
+    "scripts/",
     "catalog/",
     "schemas/",
     "skills/",
@@ -18,6 +22,7 @@
     "assets/"
   ],
   "scripts": {
+    "agents:export": "node scripts/export-marketplace-agents.mjs",
     "manifest:write": "python3 tests/validate-skill-manifest.py --write",
     "manifest:check": "python3 tests/validate-skill-manifest.py",
     "validate:catalog": "python3 tests/validate-catalog.py",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "README.md",
     "LICENSE",
     "scripts/",
+    "plugins/",
     "catalog/",
     "schemas/",
     "skills/",

--- a/plugins/cross-platform-agent-template/.codex-plugin/plugin.json
+++ b/plugins/cross-platform-agent-template/.codex-plugin/plugin.json
@@ -1,0 +1,40 @@
+{
+  "name": "cross-platform-agent-template",
+  "version": "0.1.0",
+  "description": "Cross-platform agent templates for a curated cloud and zero-trust AI workflow marketplace, with explicit portability boundaries across major coding-agent platforms.",
+  "author": {
+    "name": "Raishin",
+    "url": "https://github.com/Raishin"
+  },
+  "repository": "https://github.com/Raishin/vanguard-frontier-agentic",
+  "license": "Apache-2.0",
+  "keywords": [
+    "agentic",
+    "agents",
+    "cross-platform",
+    "codex",
+    "copilot",
+    "claude-code",
+    "cursor",
+    "gemini",
+    "kiro"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Cross-Platform Agent Template",
+    "shortDescription": "Portable agent templates for secure cloud and zero-trust AI workflows.",
+    "longDescription": "A cross-platform agent template plugin for Vanguard Frontier Agentic: a curated marketplace of cloud, security, compliance-aware, and zero-trust AI workflows. It helps authors define one strong canonical agent specification, then adapt it honestly across Codex, GitHub Copilot, Claude Code, Cursor, Gemini CLI, and Kiro without pretending the platforms are identical.",
+    "developerName": "Raishin",
+    "category": "Productivity",
+    "capabilities": [
+      "Interactive",
+      "Write"
+    ],
+    "defaultPrompt": [
+      "Create a cloud-security agent spec and adapt it to Codex, Copilot, Claude Code, Cursor, Gemini CLI, and Kiro.",
+      "Normalize a zero-trust workflow across supported agent platforms and show the non-portable fields.",
+      "Generate only the requested adapters and keep compliance, least-privilege, and evidence-backed guidance intact."
+    ],
+    "brandColor": "#3B82F6"
+  }
+}

--- a/scripts/export-marketplace-agents.mjs
+++ b/scripts/export-marketplace-agents.mjs
@@ -1,0 +1,244 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+const PLATFORM_CONFIG = {
+  codex: {
+    variants: [["codex", ".codex/agents", ".toml"]],
+  },
+  copilot: {
+    variants: [["copilot", ".github/agents", ".agent.md"]],
+  },
+  "claude-code": {
+    variants: [["claude-code", ".claude/agents", ".md"]],
+  },
+  cursor: {
+    variants: [["cursor", ".cursor/agents", ".md"]],
+  },
+  gemini: {
+    variants: [["gemini", ".gemini/agents", ".md"]],
+  },
+  "kiro-ide": {
+    variants: [["kiro-ide", ".kiro/agents", ".md"]],
+  },
+  "kiro-cli": {
+    variants: [["kiro-cli", ".kiro/agents", ".json"]],
+  },
+  kiro: {
+    variants: [
+      ["kiro-ide", ".kiro/agents", ".md"],
+      ["kiro-cli", ".kiro/agents", ".json"],
+    ],
+  },
+};
+
+const PLATFORM_ALIASES = {
+  claude: "claude-code",
+  kiroide: "kiro-ide",
+  kirocli: "kiro-cli",
+};
+
+function usage(exitCode = 0) {
+  const message = `
+Export selected marketplace agents into a consumer repository.
+
+Usage:
+  vfa-export-agents --platform <platform> --agents <agent-id[,agent-id...]> [--repo <path>] [--force]
+  vfa-export-agents --platform <platform> --all [--repo <path>] [--force]
+  vfa-export-agents --list
+
+Platforms:
+  codex, copilot, claude-code, cursor, gemini, kiro, kiro-ide, kiro-cli
+
+Examples:
+  vfa-export-agents --list
+  vfa-export-agents --platform claude-code --agents azure-cosmosdb-platform-operator-agent
+  vfa-export-agents --platform kiro --agents azure-cosmosdb-platform-operator-agent --repo ../consumer-repo
+  vfa-export-agents --platform copilot --all --repo /path/to/project --force
+`.trim();
+  console[exitCode === 0 ? "log" : "error"](message);
+  process.exit(exitCode);
+}
+
+function parseArgs(argv) {
+  const args = {
+    repo: process.cwd(),
+    force: false,
+    list: false,
+    all: false,
+    agents: [],
+    platform: null,
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--help" || arg === "-h") usage(0);
+    if (arg === "--list") {
+      args.list = true;
+      continue;
+    }
+    if (arg === "--force") {
+      args.force = true;
+      continue;
+    }
+    if (arg === "--all") {
+      args.all = true;
+      continue;
+    }
+    if (arg === "--repo") {
+      args.repo = path.resolve(argv[++i] ?? "");
+      continue;
+    }
+    if (arg === "--platform") {
+      args.platform = argv[++i] ?? "";
+      continue;
+    }
+    if (arg === "--agents") {
+      args.agents = (argv[++i] ?? "")
+        .split(",")
+        .map((value) => value.trim())
+        .filter(Boolean);
+      continue;
+    }
+    usage(1);
+  }
+
+  return args;
+}
+
+function walk(dir, matcher, results = []) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walk(fullPath, matcher, results);
+      continue;
+    }
+    if (matcher(fullPath)) results.push(fullPath);
+  }
+  return results;
+}
+
+function loadAgents() {
+  const metadataPaths = walk(path.join(repoRoot, "agents"), (fullPath) =>
+    fullPath.endsWith(`${path.sep}metadata.json`)
+  );
+
+  const agents = metadataPaths.map((metadataPath) => {
+    const raw = fs.readFileSync(metadataPath, "utf8");
+    const metadata = JSON.parse(raw);
+    return {
+      id: metadata.id,
+      name: metadata.name,
+      provider: metadata.provider,
+      summary: metadata.summary,
+      harness_variants: metadata.harness_variants ?? {},
+      metadataPath,
+    };
+  });
+
+  const byId = new Map(agents.map((agent) => [agent.id, agent]));
+  return { agents, byId };
+}
+
+function normalizePlatform(platform) {
+  const lowered = platform.toLowerCase();
+  return PLATFORM_ALIASES[lowered] ?? lowered;
+}
+
+function ensurePlatform(platform) {
+  if (!platform) usage(1);
+  const normalized = normalizePlatform(platform);
+  if (!PLATFORM_CONFIG[normalized]) {
+    console.error(`Unsupported platform: ${platform}`);
+    usage(1);
+  }
+  return normalized;
+}
+
+function copyFile(source, destination, force) {
+  if (!force && fs.existsSync(destination)) {
+    throw new Error(`Refusing to overwrite existing file without --force: ${destination}`);
+  }
+  fs.mkdirSync(path.dirname(destination), { recursive: true });
+  fs.copyFileSync(source, destination);
+}
+
+function listAgents(agents) {
+  for (const agent of agents.sort((a, b) => a.id.localeCompare(b.id))) {
+    console.log(`${agent.id}\t${agent.provider}\t${agent.name}`);
+  }
+}
+
+function buildDestinations(agent, platform) {
+  const config = PLATFORM_CONFIG[platform];
+  const destinations = [];
+
+  for (const [variantKey, folder, extension] of config.variants) {
+    const relativeSource = agent.harness_variants[variantKey];
+    if (!relativeSource) {
+      throw new Error(`Agent ${agent.id} does not have a ${variantKey} harness variant.`);
+    }
+    destinations.push({
+      variantKey,
+      source: path.join(repoRoot, relativeSource),
+      destRelative: path.join(folder, `${agent.id}${extension}`),
+    });
+  }
+
+  return destinations;
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const { agents, byId } = loadAgents();
+
+  if (args.list) {
+    listAgents(agents);
+    return;
+  }
+
+  const platform = ensurePlatform(args.platform);
+  const selectedAgents = args.all
+    ? agents
+    : args.agents.map((agentId) => {
+        const agent = byId.get(agentId);
+        if (!agent) {
+          throw new Error(`Unknown agent id: ${agentId}`);
+        }
+        return agent;
+      });
+
+  if (selectedAgents.length === 0) {
+    throw new Error("No agents selected. Use --agents or --all.");
+  }
+
+  const operations = [];
+  for (const agent of selectedAgents) {
+    for (const destination of buildDestinations(agent, platform)) {
+      operations.push({
+        ...destination,
+        dest: path.join(args.repo, destination.destRelative),
+        agentId: agent.id,
+      });
+    }
+  }
+
+  for (const operation of operations) {
+    copyFile(operation.source, operation.dest, args.force);
+    console.log(
+      `installed\t${operation.agentId}\t${operation.variantKey}\t${path.relative(args.repo, operation.dest)}`
+    );
+  }
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(error.message);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary

Add a first real cross-platform marketplace/export path for agent consumers and harden the first npm release flow.

This PR does four things:

1. scaffolds and defines the `cross-platform-agent-template` plugin
2. adds a normalized platform matrix and repo-level guidance entrypoints for major agentic coding platforms
3. adds a consumer CLI to export selected marketplace agents into platform-native folders
4. hardens semantic-release + npm packaging so first release is less likely to fail

---

## What changed

### Cross-platform plugin and marketplace scaffolding
- add `plugins/cross-platform-agent-template/.codex-plugin/plugin.json`
- add `.agents/plugins/marketplace.json`
- align plugin metadata with the repo vision:
  - curated cloud + zero-trust AI workflow marketplace
  - compliance-aware and evidence-backed positioning
  - no fake homepage / website fields

### Platform normalization and repo entrypoints
- add `docs/normalized-platform-matrix.md`
- add project-level entrypoints so the repo can be consumed directly by:
  - Claude Code via `CLAUDE.md`
  - Gemini CLI via `GEMINI.md`
  - GitHub Copilot via `.github/copilot-instructions.md`
- keep root `AGENTS.md` as the shared repo guidance layer already usable by Codex / Cursor / Kiro patterns

### Consumer export workflow
- add `scripts/export-marketplace-agents.mjs`
- expose CLI via package bin:
  - `vfa-export-agents`
- add npm script:
  - `npm run agents:export`
- support exporting selected marketplace agents into native target folders:
  - Codex → `.codex/agents/`
  - Claude Code → `.claude/agents/`
  - Copilot → `.github/agents/`
  - Cursor → `.cursor/agents/`
  - Gemini CLI → `.gemini/agents/`
  - Kiro → `.kiro/agents/`

### README and release readiness
- document current npm status honestly:
  - package was not yet published at verification time
- document GitHub install fallback and selected-agent export usage
- switch release automation from `main` to `master`
- add release verification summary in GitHub Actions
- pin Node/runtime assumptions and semantic-release package versions more explicitly
- include `plugins/` in the npm package `files` whitelist so the plugin actually ships

---

## Why

This repo already had strong cross-harness agent assets, but the consumer story was incomplete:

- platform naming was not normalized enough
- repo-level onboarding guidance was missing for some platforms
- plugin packaging existed only as scaffolding
- consumers had no simple way to install selected agents
- release automation was pointing at the wrong default branch
- npm packaging initially excluded the plugin payload

This PR closes those gaps.

---

## Validation

Ran and checked:

- `npm run validate`
- `npm pack --dry-run`
- `npm publish --dry-run`
- export smoke test with:
  - `node scripts/export-marketplace-agents.mjs --platform copilot --agents azure-cosmosdb-platform-operator-agent --repo <temp-dir>`

Verified:
- selected agent export lands in the expected consumer path
- package tarball includes the export script
- package tarball now includes `plugins/`
- release workflow now targets `master`

---

## Risks / notes

- npm publish still depends on valid `NPM_TOKEN` and package ownership for `@raishin/vanguard-frontier-agentic`
- release automation is improved, but first publish should still be watched closely
- `.mcp.json` was intentionally left out of this PR because it was unrelated local state

---
