### PR TITLE
fix(release): validate before installing release dependencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,12 @@ jobs:
           echo "PRE_TAG=$PRE_TAG" >> "$GITHUB_ENV"
           echo "PRE_VERSION=$PRE_VERSION" >> "$GITHUB_ENV"
 
+      - name: Validate
+        run: |
+          python3 tests/validate-catalog.py
+          python3 tests/validate-skill-manifest.py
+          python3 tests/validate-links.py --offline
+
       - name: Install semantic-release plugins
         run: |
           npm install --no-save \
@@ -45,12 +51,6 @@ jobs:
             @semantic-release/github@12.0.6 \
             @semantic-release/commit-analyzer@13.0.1 \
             @semantic-release/release-notes-generator@14.1.0
-
-      - name: Validate
-        run: |
-          python3 tests/validate-catalog.py
-          python3 tests/validate-skill-manifest.py
-          python3 tests/validate-links.py --offline
 
       - name: Release
         env:


### PR DESCRIPTION
## Summary

Fix the release workflow ordering so repository validation runs before ephemeral release dependencies are installed.

## Why

The release workflow was installing `semantic-release` packages into `node_modules/` before running:

- `python3 tests/validate-catalog.py`
- `python3 tests/validate-skill-manifest.py`
- `python3 tests/validate-links.py --offline`

That polluted the validation surface with transient dependency files and caused a false-positive secret-pattern failure in:

- `node_modules/registry-auth-token/README.md`

This was a workflow-order bug, not a real repository-content issue.

## What changed

Reordered `.github/workflows/release.yml` so it now does:

1. checkout
2. setup node/python
3. capture pre-release state
4. **validate repository content**
5. install pinned semantic-release dependencies
6. run semantic-release
7. verify release result and write workflow summary

## Impact

- validation is now scoped to actual repo content
- release tooling no longer contaminates validation results
- first publish path is safer and less noisy
- avoids false failures before semantic-release even starts

## Validation

Reviewed the workflow ordering and confirmed the validator failure path was caused by `node_modules` being created too early.

## Notes

This is a targeted release-pipeline fix only.
Unrelated local file `.mcp.json` remains intentionally excluded.
