### PR TITLE
feat: marketplace governance + companion-skill bundling + least-privilege skill surface

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,66 @@
+# CODEOWNERS
+#
+# This file defines code ownership for pull request review routing.
+# GitHub automatically requests a review from the listed owner(s) whenever
+# a pull request modifies files that match a rule below.
+# The most-specific matching rule wins.
+#
+# Reference:
+# https://docs.github.com/en/repositories/managing-your-repositories-settings-and-customizations/customizing-your-repository/about-code-owners
+
+# Default fallback — covers anything not matched by a more-specific rule
+* @Raishin
+
+# ---------------------------------------------------------------------------
+# Critical infrastructure paths
+# ---------------------------------------------------------------------------
+/.github/       @Raishin
+/scripts/       @Raishin
+/schemas/       @Raishin
+/catalog/       @Raishin
+/tests/         @Raishin
+/CLAUDE.md      @Raishin
+
+# ---------------------------------------------------------------------------
+# Provider-scoped agent directories
+# ---------------------------------------------------------------------------
+/agents/argocd/         @Raishin
+/agents/aws/            @Raishin
+/agents/azure/          @Raishin
+/agents/backstage/      @Raishin
+/agents/cert-manager/   @Raishin
+/agents/cilium/         @Raishin
+/agents/falco/          @Raishin
+/agents/finops/         @Raishin
+/agents/fluxcd/         @Raishin
+/agents/istio/          @Raishin
+/agents/kubernetes/     @Raishin
+/agents/kyverno/        @Raishin
+/agents/oci/            @Raishin
+/agents/opentelemetry/  @Raishin
+/agents/prometheus/     @Raishin
+/agents/sigstore/       @Raishin
+/agents/terraform/      @Raishin
+/agents/velero/         @Raishin
+
+# ---------------------------------------------------------------------------
+# Provider-scoped skill directories
+# ---------------------------------------------------------------------------
+/skills/argocd/         @Raishin
+/skills/aws/            @Raishin
+/skills/azure/          @Raishin
+/skills/backstage/      @Raishin
+/skills/cert-manager/   @Raishin
+/skills/cilium/         @Raishin
+/skills/falco/          @Raishin
+/skills/finops/         @Raishin
+/skills/fluxcd/         @Raishin
+/skills/istio/          @Raishin
+/skills/kubernetes/     @Raishin
+/skills/kyverno/        @Raishin
+/skills/oci/            @Raishin
+/skills/opentelemetry/  @Raishin
+/skills/prometheus/     @Raishin
+/skills/sigstore/       @Raishin
+/skills/terraform/      @Raishin
+/skills/velero/         @Raishin

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,84 @@
+name: Bug report
+description: Report a broken skill, agent, validation script, catalog entry, or documentation error.
+title: "bug: <short description>"
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Before filing, run `npm run validate` locally and confirm whether the failure reproduces on a clean clone.
+        Do not report security vulnerabilities here. See [SECURITY.md](https://github.com/Raishin/vanguard-frontier-agentic/blob/main/SECURITY.md) for responsible disclosure.
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: Which part of the repository is affected?
+      options:
+        - skill
+        - agent
+        - rule
+        - catalog / manifest
+        - schema
+        - validation script
+        - docs
+        - CI / GitHub Actions
+        - other
+    validations:
+      required: true
+
+  - type: input
+    id: asset-path
+    attributes:
+      label: Asset path or file
+      description: "Relative path to the affected asset (e.g. `skills/aws/aws-iac-patch-executor/SKILL.md`). Leave blank if not applicable."
+      placeholder: "skills/<provider>/<name>/SKILL.md"
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What is broken?
+      description: Describe the incorrect behavior. Include exact error messages or unexpected output.
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: Provide the minimal sequence of commands or actions that trigger the problem.
+      placeholder: |
+        1. git clone ...
+        2. npm install
+        3. npm run validate
+        4. <error output>
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What should happen instead?
+    validations:
+      required: true
+
+  - type: input
+    id: node-version
+    attributes:
+      label: Node version
+      description: Output of `node --version`
+      placeholder: "v22.x.x"
+
+  - type: input
+    id: python-version
+    attributes:
+      label: Python version
+      description: Output of `python3 --version`
+      placeholder: "Python 3.12.x"
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Anything else that would help diagnose the issue (OS, harness, npm package version, etc.).

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/Raishin/vanguard-frontier-agentic/blob/main/SECURITY.md
+    about: Do not report security vulnerabilities through public issues. See SECURITY.md for the responsible disclosure process.

--- a/.github/ISSUE_TEMPLATE/skill-or-agent-proposal.yml
+++ b/.github/ISSUE_TEMPLATE/skill-or-agent-proposal.yml
@@ -1,0 +1,134 @@
+name: Skill or agent proposal
+description: Propose a new skill, agent, rule, or MCP reference for the marketplace.
+title: "proposal: <asset type> — <short name>"
+labels: ["proposal"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form to propose a new skill, agent, rule, or MCP reference.
+        Before submitting, search [existing issues](https://github.com/Raishin/vanguard-frontier-agentic/issues) and `catalog/skills.json` / `catalog/agents.json` to confirm the asset does not already exist under a different name.
+        Read [CONTRIBUTING.md](https://github.com/Raishin/vanguard-frontier-agentic/blob/main/CONTRIBUTING.md) before writing any code.
+
+  - type: dropdown
+    id: asset-type
+    attributes:
+      label: Asset type
+      options:
+        - skill
+        - agent
+        - rule
+        - MCP reference
+    validations:
+      required: true
+
+  - type: dropdown
+    id: provider
+    attributes:
+      label: Provider
+      description: Which cloud provider or technology does this asset target?
+      options:
+        - aws
+        - azure
+        - gcp
+        - oracle / oci
+        - kubernetes
+        - terraform
+        - multi-cloud
+        - generic
+        - other (describe below)
+    validations:
+      required: true
+
+  - type: input
+    id: proposed-id
+    attributes:
+      label: Proposed asset ID
+      description: "Lowercase, hyphen-separated identifier (e.g. `aws-eks-node-drain-safe`). This becomes the directory name."
+      placeholder: "<provider>-<short-description>"
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem-statement
+    attributes:
+      label: Problem this solves
+      description: Describe the recurring engineering task or gap this asset addresses. What does an engineer have to do manually today?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed-behavior
+    attributes:
+      label: Proposed behavior
+      description: |
+        For a skill: describe what the skill instructs the agent to do and what output it produces.
+        For an agent: describe the role, judgment calls it makes, and what evidence it emits.
+        For a rule or MCP reference: describe the operating constraint or integration it captures.
+    validations:
+      required: true
+
+  - type: textarea
+    id: official-sources
+    attributes:
+      label: Official documentation sources
+      description: |
+        List the official docs or live evidence that would ground this asset's guidance.
+        Claims not backed by official docs or live evidence should not appear in catalog assets.
+      placeholder: |
+        - https://docs.aws.amazon.com/...
+        - https://kubernetes.io/docs/...
+    validations:
+      required: true
+
+  - type: dropdown
+    id: harnesses
+    attributes:
+      label: Target harnesses
+      description: Which harnesses should this asset support?
+      multiple: true
+      options:
+        - claude-code
+        - codex
+        - copilot
+        - cursor
+        - gemini
+        - kiro
+        - other
+    validations:
+      required: true
+
+  - type: textarea
+    id: security-notes
+    attributes:
+      label: Security notes
+      description: |
+        Are there high-risk operations, broad permissions, destructive automation, or MCP mutation paths involved?
+        Note any zero-trust or least-privilege constraints that the asset must enforce.
+
+  - type: dropdown
+    id: roles
+    attributes:
+      label: Role membership (agents only)
+      description: If proposing an agent, which of the six defined roles does it belong to?
+      multiple: true
+      options:
+        - cloud-security-engineer
+        - cloud-platform-engineer
+        - cloud-dba
+        - cloud-finops-analyst
+        - cloud-solutions-architect
+        - cloud-devops-engineer
+        - not applicable
+
+  - type: checkboxes
+    id: pre-submission
+    attributes:
+      label: Pre-submission checks
+      options:
+        - label: I searched existing issues and catalog files and confirmed this asset does not already exist.
+          required: true
+        - label: I have read CONTRIBUTING.md and understand the validation requirements.
+          required: true
+        - label: The official documentation sources I listed are publicly accessible.
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,42 @@
+## Summary
+
+<!--
+Describe what this PR changes and why. Link to the issue it addresses.
+Closes #<issue-number>
+-->
+
+## Type of change
+
+- [ ] Skill (new or updated `skills/` asset)
+- [ ] Agent (new or updated `agents/` asset)
+- [ ] Rule (new or updated `rules/` asset)
+- [ ] Docs (changes under `docs/`, `CONTRIBUTING.md`, or other Markdown governance files)
+- [ ] Infra (schemas, catalog, scripts, tests, CI/CD)
+
+## Validation evidence
+
+<!--
+Paste the full output of `npm run validate` below. Every check must pass.
+-->
+
+```
+<paste npm run validate output here>
+```
+
+## Risk and rollback
+
+<!--
+Describe the blast radius of this change.
+If something goes wrong after merge, what is the rollback path?
+For catalog or schema changes: note which downstream consumers are affected.
+-->
+
+## Checklist
+
+- [ ] `npm run validate` passes with no errors
+- [ ] `npm run manifest:write` was run and `catalog/skill-manifest.json` is committed (skills changed only)
+- [ ] Catalog JSON files updated if an asset was added, moved, or removed
+- [ ] No secrets, credentials, tokens, tenant IDs, or customer data included
+- [ ] Relevant docs in `docs/` updated if behavior changed
+- [ ] Apache-2.0 license terms acknowledged — contributed content must be compatible
+- [ ] PR is scoped to one skill, one agent, or one coherent change

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,36 @@
+version: 2
+
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "chore(actions)"
+    groups:
+      actions:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 5
+    reviewers:
+      - Raishin
+
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
+    groups:
+      npm-runtime:
+        dependency-type: production
+        patterns:
+          - "*"
+      npm-dev:
+        dependency-type: development
+        patterns:
+          - "*"
+    open-pull-requests-limit: 5
+    reviewers:
+      - Raishin

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,9 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.x"
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,39 @@
+name: CodeQL
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+  schedule:
+    - cron: '17 6 * * 1'
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - javascript-typescript
+          - python
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@0daab03d71ff584ef619d027a3fd9146679c5d84 # v3.35.3
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-extended,security-and-quality
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@0daab03d71ff584ef619d027a3fd9146679c5d84 # v3.35.3
+        with:
+          category: /language:${{ matrix.language }}

--- a/.github/workflows/install-paths-smoke.yml
+++ b/.github/workflows/install-paths-smoke.yml
@@ -13,9 +13,9 @@ jobs:
   smoke:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "22"
 

--- a/.github/workflows/install-paths-smoke.yml
+++ b/.github/workflows/install-paths-smoke.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: "22"
+          node-version: "24"
 
       - name: Smoke 1 - all agents and skills (claude-code)
         run: |

--- a/.github/workflows/install-paths-smoke.yml
+++ b/.github/workflows/install-paths-smoke.yml
@@ -1,0 +1,96 @@
+name: Install Paths Smoke Test
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: "22"
+
+      - name: Smoke 1 - all agents and skills (claude-code)
+        run: |
+          node scripts/export-marketplace-agents.mjs \
+            --platform claude-code --all \
+            --repo "$RUNNER_TEMP/smoke-all"
+
+          agent_count=$(find "$RUNNER_TEMP/smoke-all/.claude/agents" -name "*.md" | wc -l)
+          if [ "$agent_count" -lt 100 ]; then
+            echo "ERROR: expected at least 100 agent files, got $agent_count" >&2
+            exit 1
+          fi
+          echo "OK: $agent_count agent files found"
+
+          skill_count=$(
+            find "$RUNNER_TEMP/smoke-all/.claude/skills" \
+              -mindepth 1 -maxdepth 1 -type d \
+              -exec test -f '{}/SKILL.md' \; -print \
+            | wc -l
+          )
+          if [ "$skill_count" -lt 100 ]; then
+            echo "ERROR: expected at least 100 skill directories with SKILL.md, got $skill_count" >&2
+            exit 1
+          fi
+          echo "OK: $skill_count skill directories with SKILL.md found"
+
+      - name: Smoke 2 - no-skills flag suppresses .claude/skills
+        run: |
+          node scripts/export-marketplace-agents.mjs \
+            --platform claude-code --all --no-skills \
+            --repo "$RUNNER_TEMP/smoke-noskills"
+
+          if [ -d "$RUNNER_TEMP/smoke-noskills/.claude/skills" ]; then
+            echo "ERROR: .claude/skills directory must not exist when --no-skills is used" >&2
+            exit 1
+          fi
+          echo "OK: no .claude/skills directory present"
+
+      - name: Smoke 3 - role export produces agents and skills
+        run: |
+          node scripts/export-marketplace-agents.mjs \
+            --platform claude-code --role cloud-security-engineer \
+            --repo "$RUNNER_TEMP/smoke-role"
+
+          agent_count=$(find "$RUNNER_TEMP/smoke-role/.claude/agents" -name "*.md" 2>/dev/null | wc -l)
+          if [ "$agent_count" -lt 1 ]; then
+            echo "ERROR: expected non-empty .claude/agents for role export, got $agent_count" >&2
+            exit 1
+          fi
+          echo "OK: $agent_count agent files for role cloud-security-engineer"
+
+          skill_count=$(find "$RUNNER_TEMP/smoke-role/.claude/skills" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | wc -l)
+          if [ "$skill_count" -lt 1 ]; then
+            echo "ERROR: expected non-empty .claude/skills for role export, got $skill_count" >&2
+            exit 1
+          fi
+          echo "OK: $skill_count skill directories for role cloud-security-engineer"
+
+      - name: Smoke 4 - cursor platform writes .cursor/agents and no .claude/skills
+        run: |
+          node scripts/export-marketplace-agents.mjs \
+            --platform cursor --agents aws-iac-patch-executor-agent \
+            --repo "$RUNNER_TEMP/smoke-cursor"
+
+          cursor_count=$(find "$RUNNER_TEMP/smoke-cursor/.cursor/agents" -name "*.md" 2>/dev/null | wc -l)
+          if [ "$cursor_count" -lt 1 ]; then
+            echo "ERROR: expected at least one file under .cursor/agents, got $cursor_count" >&2
+            exit 1
+          fi
+          echo "OK: $cursor_count file(s) under .cursor/agents"
+
+          if [ -d "$RUNNER_TEMP/smoke-cursor/.claude/skills" ]; then
+            echo "ERROR: .claude/skills must not be created for platform cursor" >&2
+            exit 1
+          fi
+          echo "OK: no .claude/skills directory for cursor platform"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,16 +15,16 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "22"
 
-      - uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.x"
 

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 logs
 *.log
 !.claude/evals/*.log
+
+# Local-only Claude Code worktrees (created by isolated subagents)
+.claude/worktrees/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,12 +20,14 @@
 - `package.json` → npm package metadata and validation scripts.
 
 ## Workflows
-- `npm run validate` → catalog + skill manifest + offline link validation.
+- `npm run validate` → catalog + AWS quality + manifest + `allowed-tools` + frontmatter schema + offline link validation (six gates).
 - `npm run manifest:write` → refresh `catalog/skill-manifest.json` after intentional skill edits.
 - `python3 tests/validate-links.py` → online link validation before release.
 - `npm pack --dry-run` → inspect npm package contents before publish.
 - `vfa-export-agents --list-roles` → list available role IDs with agent counts.
-- `vfa-export-agents --platform <p> --role <role-id> --repo <path>` → install all agents for a role.
+- `vfa-export-agents --platform claude-code --all --repo <path>` → install all agents AND auto-bundle their companion skills (default for `claude-code`).
+- `vfa-export-agents --platform claude-code --all --no-skills --repo <path>` → opt out of skill bundling (agents only).
+- `vfa-export-agents --platform <p> --role <role-id> --repo <path>` → install agents (and companion skills on `claude-code`) for a role.
 - `vfa-export-agents --platform <p> --role <role-id> --provider <provider> --repo <path>` → install role agents for one provider.
 
 ## Change Rules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,47 @@
+## 🚧 Unreleased
+
+> _Marketplace governance, supply-chain provenance, and least-privilege skill surface._
+>
+> Auto-generated release notes will replace this section on the next semantic-release run; this preview reflects what is on the release branch.
+
+### ✨ Features
+
+* `vfa-export-agents` bundles companion skills by default on `--platform claude-code`; pairing resolved from `companion_skills` metadata, name-stripping fallback, `--no-skills` opts out
+* `--all` exports every catalogued skill, including 4 skills with no agent peer
+* New optional `companion_skills` field on agent metadata; six previously orphan agents migrated
+* New `allowed-tools` field on every SKILL.md, classified by skill role (least-privilege baseline)
+* JSON Schema (Draft 2020-12) for SKILL.md frontmatter at `schemas/skill.frontmatter.schema.json`
+
+### 🔒 Security and supply chain
+
+* `SECURITY.md` with disclosure policy, response SLA, scope, and Safe Harbor
+* CodeQL workflow (JavaScript and Python) on push, PR, and weekly schedule
+* npm provenance attestations enabled on publish
+* Dependabot enabled for GitHub Actions and npm with weekly grouped PRs
+
+### 🧭 Governance and contributor experience
+
+* `CODEOWNERS` with provider-scoped review across 18 provider domains
+* `CONTRIBUTING.md` and structured issue / pull-request templates
+* `CODE_OF_CONDUCT.md` (Contributor Covenant 2.1)
+
+### 🧪 Schema, validation, and CI
+
+* New `validate:skill-schema` and `validate:allowed-tools` gates in `npm run validate`
+* Install-paths smoke test asserts documented commands behave as documented
+* GitHub Actions bumped to v6 (`actions/checkout@v6.0.2`, `actions/setup-node@v6.4.0`, `actions/setup-python@v6.2.0`); smoke test runs on Node 24
+
+### 📚 Documentation
+
+* `docs/integrations/skills-cli.md` — install-path trust matrix (npm, `vfa-export-agents`, third-party `skills` CLI)
+* `CLAUDE.md`, `AGENTS.md`, `README.md` synced with the new validation gates and metadata fields
+
+### 💥 Breaking changes
+
+* None. `--no-skills` is provided for callers that want the previous agents-only behaviour.
+
+---
+
 ## 🛡️ v1.3.0 &mdash; 2026-05-02
 
 > _Multi-cloud agent marketplace · `AWS` · `Azure` · `OCI` · `Terraform`_

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,8 +24,17 @@ This repository is a curated marketplace for **cloud**, **zero-trust**, and **co
 
 - Keep changes scoped and traceable to the task.
 - Update catalog metadata when adding, moving, or removing cataloged assets.
-- Run `npm run validate` before finishing.
-- If `skills/**` changed intentionally, also refresh `catalog/skill-manifest.json` with `npm run manifest:write`.
+- Run `npm run validate` before finishing. The pipeline runs:
+  `validate:catalog`, `validate:aws`, `manifest:check`,
+  `validate:allowed-tools`, `validate:skill-schema`, `validate:links`.
+- If `skills/**` changed intentionally, also refresh
+  `catalog/skill-manifest.json` with `npm run manifest:write`.
+- Every `SKILL.md` must declare an `allowed-tools` field
+  (least-privilege baseline) and conform to
+  `schemas/skill.frontmatter.schema.json`.
+- For agents that have a 1:1 companion skill, declare it explicitly via
+  `companion_skills: [<skill-id>]` in the agent's `metadata.json` rather
+  than relying on the name-stripping convention.
 
 ## Cross-platform asset rule
 
@@ -39,6 +48,12 @@ This repo supports multiple harnesses without pretending they are identical.
 
 - `README.md` — human-facing vision and repository story
 - `AGENTS.md` — compressed agent-focused repo guidance
+- `CONTRIBUTING.md` — contributor onboarding and submission path
+- `SECURITY.md` — vulnerability disclosure policy and SLA
+- `CODE_OF_CONDUCT.md` — community standards
 - `docs/compatibility.md` — harness support contract
 - `docs/normalized-platform-matrix.md` — naming and platform normalization
+- `docs/integrations/skills-cli.md` — install-path trust matrix
+- `schemas/skill.frontmatter.schema.json` — required SKILL.md frontmatter contract
+- `schemas/agent.schema.json` — agent metadata contract (includes `companion_skills`)
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,7 +1,23 @@
 # Code of Conduct
 
-This project follows a simple standard: be direct, technical, respectful, and security-minded.
+This project adopts the [Contributor Covenant](https://www.contributor-covenant.org/), version 2.1.
 
-Unacceptable behavior includes harassment, personal attacks, doxxing, spam, credential leaks, and attempts to add unsafe automation that could harm users or infrastructure.
+The canonical text is published at https://www.contributor-covenant.org/version/2/1/code_of_conduct/ and is incorporated here by reference.
 
-Maintainers may close, edit, or reject contributions that reduce safety, trust, or usefulness.
+## Project standard, in short
+
+Be direct, technical, respectful, and security-minded. Unacceptable behaviour includes harassment, personal attacks, doxxing, spam, credential leaks, and attempts to add unsafe automation that could harm users or infrastructure.
+
+## Scope
+
+This Code of Conduct applies within all project spaces — the repository, issues, pull requests, and discussions — and also applies when an individual is officially representing the project in public spaces.
+
+## Reporting
+
+Use the reporting path in [SECURITY.md](SECURITY.md). The maintainer contact configured there receives Code of Conduct reports as well as security reports.
+
+Reports are handled with discretion. Project maintainers are obligated to respect the privacy and security of the reporter.
+
+## Enforcement
+
+Project maintainers may remove, edit, or reject contributions that do not align with this Code of Conduct, and may temporarily or permanently ban any contributor whose behaviour they deem inappropriate, threatening, offensive, or harmful, in line with the Contributor Covenant 2.1 enforcement guidelines.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,46 +1,208 @@
-# Contributing
+# Contributing to Vanguard Frontier Agentic
 
-This project is curated, not crowdsourced chaos. Contributions are welcome only when they improve trust, coverage, or installability.
+This guide covers everything you need to add a skill, agent, rule, MCP reference, schema fix, or doc improvement to this repository. Read it alongside the companion docs it links to — this file adds the contributor-specific glue, not the full governance narrative.
 
-## Acceptance bar
+---
 
-Every contribution must:
-
-- Include metadata that passes `python tests/validate-catalog.py`.
-- Link to official provider documentation when making provider-specific claims.
-- State supported harnesses honestly.
-- Include security notes, especially for IAM, RBAC, Terraform, MCP, credentials, and production mutation.
-- Avoid secrets, example real credentials, private endpoints, and customer-specific data.
-- Prefer least privilege and read-only discovery before mutation.
-
-## Asset types
-
-- **Skills**: repeatable workflows with clear triggers and output expectations.
-- **Agents**: role definitions for review, architecture, operations, or remediation.
-- **Rules**: harness-specific behavioral guidance.
-- **MCP references**: vetted entries for official or community MCP servers.
-
-## Required checks
-
-Before opening a pull request:
+## Quick Start
 
 ```bash
-python tests/validate-catalog.py
-python tests/validate-links.py --offline
+git clone https://github.com/Raishin/vanguard-frontier-agentic.git
+cd vanguard-frontier-agentic
+npm install
+npm run validate
 ```
 
-For release-quality changes, also run online link validation:
+All checks must pass before you open a pull request. If `npm run validate` fails on a clean clone, open an issue rather than working around it.
+
+---
+
+## What you can contribute
+
+| Area | Where it lives | When to contribute |
+|------|----------------|--------------------|
+| **Skills** | `skills/<provider>/<name>/` | Reusable step-by-step workflows for recurring engineering tasks |
+| **Agents** | `agents/<provider>/<id>/` | Expert roles with judgment for review, architecture, and operations |
+| **Rules** | `rules/<harness>/` | Durable harness-specific operating instructions |
+| **MCP references** | `mcp/` | Trusted notes for connecting tools to real systems |
+| **Schema fixes** | `schemas/` | Corrections to JSON Schema metadata contracts |
+| **Docs** | `docs/` | Governance, taxonomy, compatibility, and quality guidance |
+
+Before writing anything, check `catalog/skills.json` and `catalog/agents.json` to confirm the asset does not already exist under a different name.
+
+---
+
+## Adding a Skill
+
+### Directory layout
+
+```
+skills/<provider>/<skill-id>/
+  SKILL.md          # required — the skill body with YAML frontmatter
+  metadata.json     # required — matches schemas/skill.schema.json
+  references/       # optional — source links, evidence templates, supporting context
+```
+
+Provider must be one of: `aws`, `azure`, `oracle`, `oci`, `gcp`, `kubernetes`, `terraform`, `multi-cloud`, `generic`.
+
+### SKILL.md frontmatter
+
+Skills use YAML frontmatter at the top of `SKILL.md`. Required fields:
+
+```yaml
+---
+name: <skill-id>               # lowercase, hyphen-separated; must match directory name
+description: <one-line prose>  # what this skill does and when it is invoked
+allowed-tools: Read Edit Write Grep Glob   # space-separated list of tools this skill may use
+metadata:
+  author: "github: <YourGitHubHandle>"    # use this exact format; do not use a top-level author key
+  version: "0.1.0"                        # semver; do not use a top-level version key
+---
+```
+
+The `allowed-tools` field is validated by `npm run validate:allowed-tools`. Omitting it or listing tools the skill body does not need will fail validation. List only the tools the skill actually uses. Common values: `Read`, `Edit`, `Write`, `MultiEdit`, `Grep`, `Glob`, `Bash`.
+
+### metadata.json
+
+Must satisfy `schemas/skill.schema.json`. Required fields: `id`, `name`, `version`, `type` (must be `"skill"`), `provider`, `harnesses`, `summary` (20+ chars), `source_type`, `official_docs` (array of URIs), `security_notes` (20+ chars), `last_verified` (YYYY-MM-DD), `path`.
+
+Valid `source_type` values: `original`, `adapted`, `reference-only`.
+
+Valid `harnesses` values: `codex`, `copilot`, `claude-code`, `cursor`, `gemini`, `kiro`, `other`.
+
+### Exemplar skills
+
+Study a well-structured skill before writing your own:
+
+- `skills/aws/aws-iac-patch-executor/` — progressive-disclosure pattern, safety checklist references, `allowed-tools` declaration
+
+### Catalog refresh
+
+After adding or modifying any skill, run:
 
 ```bash
-python tests/validate-links.py
+npm run manifest:write
 ```
+
+This regenerates `catalog/skill-manifest.json` with updated SHA hashes. Do not skip this step — `manifest:check` will fail in CI if the manifest is stale.
+
+Also update `catalog/skills.json` to include the new skill entry. See existing entries in that file for the expected shape.
+
+---
+
+## Adding an Agent
+
+### Directory layout
+
+```
+agents/<provider>/<agent-id>/
+  AGENT.md              # required — canonical agent body
+  metadata.json         # required — matches schemas/agent.schema.json
+  harnesses/            # required — one adapter per supported harness
+    claude-code.agent.md
+    codex.toml
+    copilot.agent.md
+    cursor.agent.md
+    gemini.agent.md
+    kiro-ide.agent.md
+    kiro-cli.agent.json
+```
+
+You do not need to supply every harness adapter on day one, but every adapter you do ship must be in the correct format for that harness. See `docs/compatibility.md` and `docs/normalized-platform-matrix.md` for adapter shapes and naming conventions.
+
+### metadata.json
+
+Must satisfy `schemas/agent.schema.json`. Fields are the same as skills except `type` must be `"agent"`.
+
+The `companion_skills` field is optional but recommended. It is an explicit array of skill IDs that pair with this agent. Set it to `[]` to declare intentional no-pair rather than leaving it absent.
+
+```json
+{
+  "id": "my-new-agent",
+  "type": "agent",
+  "companion_skills": ["my-companion-skill"]
+}
+```
+
+### Harness variants
+
+Keep portable agent logic in `AGENT.md`. Keep harness-specific behavior in the matching adapter under `harnesses/`. Do not invent metadata fields in executable adapter files unless official docs for that harness verify the field is supported. See `AGENTS.md` for the cross-harness metadata rule.
+
+### Role assignment
+
+If your agent belongs to one of the six defined roles, add it to `catalog/install-roles.json`:
+
+`cloud-security-engineer`, `cloud-platform-engineer`, `cloud-dba`, `cloud-finops-analyst`, `cloud-solutions-architect`, `cloud-devops-engineer`
+
+An agent may appear in multiple roles. See `AGENTS.md` for the role-based pattern.
+
+### Live-guard and review agents
+
+Any agent that produces verdicts must emit all five required evidence fields: `verdict`, `evidence_level`, `blockers`, `safe_next_actions`, `open_questions`. See `docs/evidence-output-spec.md`.
+
+---
+
+## Validation gates
+
+`npm run validate` runs the following checks in sequence. All must pass before merging.
+
+| Script | What it checks |
+|--------|----------------|
+| `npm run validate:catalog` (`tests/validate-catalog.py`) | Every entry in `catalog/skills.json`, `catalog/agents.json`, `catalog/rules.json`, and `catalog/mcp-references.json` references a real path and satisfies the relevant JSON Schema in `schemas/`. |
+| `npm run validate:aws` (`tests/validate-aws-skill-quality.py` + `tests/validate-aws-progressive-disclosure.py`) | AWS skills meet quality gates: progressive-disclosure structure, references directory, safety-checklist reference, and output-contract section present. |
+| `npm run manifest:check` (`tests/validate-skill-manifest.py`) | `catalog/skill-manifest.json` SHA hashes match current file contents. Fails if you edited skills without running `npm run manifest:write`. |
+| `npm run validate:allowed-tools` (`tests/validate-skill-allowed-tools.py`) | Every `SKILL.md` that declares `allowed-tools` in frontmatter uses only recognized tool names. |
+| `npm run validate:links` (`tests/validate-links.py --offline`) | Internal relative links in Markdown files resolve to real paths. Offline mode only — no HTTP calls during CI. |
+
+For an additional pre-release check that validates external URLs, run `python3 tests/validate-links.py` (online mode) before tagging.
+
+---
+
+## Catalog refresh
+
+The catalog is the machine-readable index that consumers use to discover and install assets. When your change affects skills, run:
+
+```bash
+npm run manifest:write
+```
+
+When your change adds, moves, or removes any cataloged asset (skill, agent, rule, MCP reference), also update the relevant JSON file in `catalog/`:
+
+- `catalog/skills.json`
+- `catalog/agents.json`
+- `catalog/rules.json`
+- `catalog/mcp-references.json`
+- `catalog/install-roles.json` (if role membership changed)
+
+Do not rely on validators to catch missing catalog entries after the fact — add catalog entries before opening the PR.
+
+---
 
 ## Provenance rules
 
 - Use `source_type: original` for assets created specifically for this repository.
-- Use `source_type: adapted` when derived from another public project; cite the source and confirm license compatibility.
+- Use `source_type: adapted` when derived from another public project; cite the source and confirm license compatibility with Apache-2.0.
 - Use `source_type: reference-only` for catalog entries that point to official or third-party resources without bundling their content.
 
-## Review philosophy
+---
 
-Ruthless truth: cloud automation can destroy real systems. Pretty prompts are not enough. Reviewers should reject contributions that are vague, unverifiable, unsafe, or too generic to be useful.
+## Pull Request expectations
+
+- **Small and scoped.** One skill, one agent, or one coherent doc change per PR. Large batches are hard to review safely.
+- **Linked to an issue.** Open an issue first for new skills and agents. PRs without an issue reference are acceptable for doc fixes and small corrections.
+- **Validation evidence included.** Paste the output of `npm run validate` in the PR description. The PR template provides a slot for this.
+- **No secrets or credentials.** Do not commit API keys, tokens, tenant IDs, account IDs, or customer data in any form. See `SECURITY.md` if you discover a secret already in the repo.
+- **Docs updated.** If your change touches a behavior documented in `docs/`, update the relevant doc in the same PR. Do not leave docs in a state that contradicts the code.
+- **Catalog updated.** If you added, moved, or removed a cataloged asset, the catalog JSON files must be updated in the same PR.
+
+---
+
+## Code of Conduct
+
+A `CODE_OF_CONDUCT.md` will be added to this repository separately. Until it is present, contributors are expected to engage constructively, assume good faith, and follow the operating stance described in `CLAUDE.md` and `AGENTS.md`.
+
+---
+
+## Security issues
+
+Do not report security vulnerabilities through public GitHub issues. See `SECURITY.md` for the responsible disclosure process.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@
     <a href="#agents">Agents</a> &nbsp;·&nbsp;
     <a href="https://github.com/Raishin/vanguard-frontier-agentic/issues">Issues</a> &nbsp;·&nbsp;
     <a href="#faq">FAQ</a> &nbsp;·&nbsp;
-    <a href="#feedback">Feedback</a>
+    <a href="#feedback">Feedback</a> &nbsp;·&nbsp;
+    <a href="SECURITY.md">Reporting security issues</a>
   </p>
 </div>
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,26 @@ npx vfa-export-agents --platform claude-code --role cloud-security-engineer --re
 
 **🗺️ Not sure which role or agent you need?** Jump to the [Install Reference](#install-reference) for the full map.
 
+### 📥 Install via the `skills` CLI ([skills.sh](https://skills.sh))
+
+All 138 skills in this repo are valid `SKILL.md` artifacts and are installable directly with the open [`skills` CLI](https://github.com/vercel-labs/skills) used by Claude Code, Codex, Cursor, OpenCode, Gemini CLI, Kiro, and 50+ other agents.
+
+```bash
+# 🔍 List every skill in this repo
+npx skills add Raishin/vanguard-frontier-agentic --list
+
+# 📦 Install a specific skill into the current project
+npx skills add Raishin/vanguard-frontier-agentic --skill aws-iac-patch-executor
+
+# ☸️  Install all Kubernetes skills globally for Claude Code
+npx skills add Raishin/vanguard-frontier-agentic --skill '*' -g -a claude-code
+
+# 🌐 Browse the same skills on the directory
+# https://skills.sh/Raishin/vanguard-frontier-agentic
+```
+
+The directory at [skills.sh](https://skills.sh) auto-indexes any public GitHub repo with valid `SKILL.md` files, so new skills added here become discoverable without a separate submission step.
+
 ---
 
 ## 🧠 Skills

--- a/README.md
+++ b/README.md
@@ -60,25 +60,13 @@ npx vfa-export-agents --platform claude-code --role cloud-security-engineer --re
 
 **🗺️ Not sure which role or agent you need?** Jump to the [Install Reference](#install-reference) for the full map.
 
-### 📥 Install via the `skills` CLI ([skills.sh](https://skills.sh))
+### Install paths
 
-All 138 skills in this repo are valid `SKILL.md` artifacts and are installable directly with the open [`skills` CLI](https://github.com/vercel-labs/skills) used by Claude Code, Codex, Cursor, OpenCode, Gemini CLI, Kiro, and 50+ other agents.
+There are three supported install paths — npm package, `vfa-export-agents` CLI, and the third-party `skills` CLI — each with different versioning, trust, and scope characteristics. See [`docs/integrations/skills-cli.md`](docs/integrations/skills-cli.md) for the full trust matrix, verified flag syntax, pinning guidance, and pre-install inspection steps.
 
 ```bash
-# 🔍 List every skill in this repo
-npx skills add Raishin/vanguard-frontier-agentic --list
-
-# 📦 Install a specific skill into the current project
-npx skills add Raishin/vanguard-frontier-agentic --skill aws-iac-patch-executor
-
-# ☸️  Install all Kubernetes skills globally for Claude Code
-npx skills add Raishin/vanguard-frontier-agentic --skill '*' -g -a claude-code
-
-# 🌐 Browse the same skills on the directory
-# https://skills.sh/Raishin/vanguard-frontier-agentic
+npm install @raishin/vanguard-frontier-agentic@latest
 ```
-
-The directory at [skills.sh](https://skills.sh) auto-indexes any public GitHub repo with valid `SKILL.md` files, so new skills added here become discoverable without a separate submission step.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,15 @@
   <p><strong>A curated marketplace for cloud and zero-trust AI workflows.</strong></p>
 
   <p>
+    <a href="https://www.npmjs.com/package/@raishin/vanguard-frontier-agentic"><img alt="npm version" src="https://img.shields.io/npm/v/@raishin/vanguard-frontier-agentic.svg?logo=npm" /></a>
+    <a href="LICENSE"><img alt="License: Apache-2.0" src="https://img.shields.io/badge/license-Apache--2.0-blue.svg" /></a>
+    <a href="https://github.com/Raishin/vanguard-frontier-agentic/actions/workflows/codeql.yml"><img alt="CodeQL" src="https://github.com/Raishin/vanguard-frontier-agentic/actions/workflows/codeql.yml/badge.svg?branch=master" /></a>
+    <a href="https://github.com/Raishin/vanguard-frontier-agentic/actions/workflows/install-paths-smoke.yml"><img alt="Install Paths Smoke" src="https://github.com/Raishin/vanguard-frontier-agentic/actions/workflows/install-paths-smoke.yml/badge.svg?branch=master" /></a>
+    <a href="https://docs.npmjs.com/generating-provenance-statements"><img alt="npm provenance" src="https://img.shields.io/badge/npm-provenance-26a566.svg?logo=npm" /></a>
+    <a href="CONTRIBUTING.md"><img alt="PRs welcome" src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" /></a>
+  </p>
+
+  <p>
     <a href="#get-started">Get Started</a> &nbsp;·&nbsp;
     <a href="#install-reference">Install Reference</a> &nbsp;·&nbsp;
     <a href="#skills">Skills</a> &nbsp;·&nbsp;
@@ -15,7 +24,9 @@
     <a href="https://github.com/Raishin/vanguard-frontier-agentic/issues">Issues</a> &nbsp;·&nbsp;
     <a href="#faq">FAQ</a> &nbsp;·&nbsp;
     <a href="#feedback">Feedback</a> &nbsp;·&nbsp;
-    <a href="SECURITY.md">Reporting security issues</a>
+    <a href="CONTRIBUTING.md">Contributing</a> &nbsp;·&nbsp;
+    <a href="SECURITY.md">Security</a> &nbsp;·&nbsp;
+    <a href="CODE_OF_CONDUCT.md">Code of Conduct</a>
   </p>
 </div>
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,31 +1,151 @@
 # Security Policy
 
-## Supported surface
+## Supported Versions
 
-This repository publishes agentic workflows and references. Treat every asset as executable influence over an AI system, even when it is "just markdown."
+The table below shows which versions of `@raishin/vanguard-frontier-agentic`
+(current published version: **1.3.0**) receive security fixes.
 
-## Never include
+| Version range | Supported          |
+| ------------- | ------------------ |
+| 1.3.x         | Yes — current minor |
+| 1.2.x         | Yes — previous minor |
+| < 1.2.0       | No                 |
 
-- Access keys, API tokens, private keys, session tokens, passwords, or `.env` values.
-- Instructions to bypass approval, audit, least privilege, or change-management controls.
-- Credential-harvesting workflows.
-- Destructive production automation without explicit approval gates and rollback guidance.
+Fixes are back-ported to the previous minor only when the vulnerability is
+rated high or critical. Older versions receive no patches; upgrade to a
+supported range.
 
-## Reporting a vulnerability
+---
 
-Open a private security advisory if available, or contact the maintainers through the repository owner profile. Do not publish exploit details in a public issue.
+## Reporting a Vulnerability
 
-## MCP-specific risks
+**Primary channel — GitHub Security Advisories (preferred)**
 
-MCP servers can expose tools that read or mutate cloud resources. Every MCP reference must state:
+Use the private reporting form so the disclosure stays confidential:
 
-- vendor or maintainer,
-- official/community status,
-- authentication model,
-- expected permissions,
-- whether tools can mutate resources,
-- local/remote execution assumptions.
+> https://github.com/Raishin/vanguard-frontier-agentic/security/advisories/new
 
-## Review standard
+**Fallback channel — email**
 
-If a contribution gives an agent more power over cloud resources, reviewers should demand stronger provenance, least-privilege guidance, and verification evidence.
+A maintainer email address is to be configured by the maintainer; until that
+address is published here, use the Security Advisories link above as the sole
+reporting channel.
+
+Do not open a public GitHub issue, start a GitHub Discussion, or use any chat
+platform to report a suspected vulnerability. Those channels are public and
+expose other users before a fix is available.
+
+---
+
+## What to Include in Your Report
+
+A complete report helps us triage quickly. Include:
+
+1. **Reproduction steps** — a minimal, numbered sequence that reproduces the
+   issue reliably.
+2. **Affected component path** — the file or directory inside this repository
+   (for example `skills/aws/aws-iam-least-privilege-review/skill.md` or
+   `schemas/skill.schema.json`).
+3. **Impact assessment** — what an attacker could achieve by exploiting the
+   issue, and under what conditions.
+4. **Suggested fix** — optional, but appreciated if you have one.
+5. **Your contact information** — so we can reach you during the coordinated
+   disclosure window. We will not share it without your permission.
+
+If you are reporting a vulnerability in a dependency of this package, please
+also note the dependency name and version so we can file an upstream report.
+
+---
+
+## What NOT to Do
+
+- Do **not** open a public GitHub issue to report a security vulnerability.
+- Do **not** post vulnerability details in GitHub Discussions, Slack, Discord,
+  or any other public forum.
+- Do **not** send vulnerability reports as direct messages to individual
+  maintainers on social media or other platforms.
+- Do **not** exploit the vulnerability beyond the minimum proof-of-concept
+  needed to demonstrate the issue. Accessing, modifying, or exfiltrating data
+  beyond what is required to confirm the vulnerability is out of scope for this
+  policy.
+- Do **not** publish or share exploit details, proof-of-concept code, or
+  reproduction steps publicly until coordinated disclosure is complete.
+
+---
+
+## Response SLA
+
+| Milestone                             | Target                              |
+| ------------------------------------- | ----------------------------------- |
+| Acknowledgement of receipt            | Within 5 business days              |
+| Triage (severity assessment, scope)   | Within 10 business days of receipt  |
+| Coordinated disclosure window         | 90 days from initial acknowledgement, unless mutually extended in writing |
+
+If you have not received an acknowledgement within 5 business days, send a
+follow-up through the same private reporting channel.
+
+We will keep you informed of progress throughout the window. Extensions to the
+90-day window require mutual agreement and are granted when a fix is actively
+in progress and a realistic release date is established.
+
+---
+
+## Scope
+
+### In scope
+
+The following assets are in scope for this policy:
+
+- Source code and scripts in this repository (`scripts/`, `tests/`)
+- Skill workflow files (`skills/**`)
+- Agent definition files (`agents/**`)
+- Rule files (`rules/**`)
+- Schema files (`schemas/**`)
+- Catalog metadata (`catalog/**`)
+- MCP reference files (`mcp/**`)
+- Package configuration and CI/CD definitions (`.github/`, `package.json`)
+
+### Out of scope
+
+- **Third-party dependencies** — if you find a vulnerability in a package this
+  repository depends on, report it to that package's maintainers directly. We
+  will file an upstream report if you notify us.
+- **AI harnesses and platforms** — Claude Code, Codex, GitHub Copilot, Cursor,
+  Gemini CLI, Kiro, and other harnesses that consume assets from this
+  repository are independent products. Vulnerabilities in those platforms
+  should be reported to their respective vendors.
+- **Cloud provider services** — AWS, Azure, OCI, GCP, and other cloud services
+  referenced in skills and agents are not in scope here. Report those to the
+  relevant provider.
+- **User-managed infrastructure** — environments where end users have deployed
+  these assets are outside this repository's control.
+
+---
+
+## Safe Harbor
+
+We support responsible security research. If you discover and report a
+vulnerability in good faith and in accordance with this policy, we will:
+
+- not pursue or support legal action against you related to your research,
+- not refer your report to law enforcement, and
+- work with you on a mutually agreeable disclosure timeline.
+
+Good faith means: you limit testing to what is necessary to confirm the
+vulnerability, you do not access or modify data that does not belong to you,
+and you report the issue to us before disclosing it publicly.
+
+This safe harbor applies to activity that complies with this policy. It does
+not extend to conduct that is harmful, unlawful on independent grounds, or
+outside the scope defined above.
+
+---
+
+## Acknowledgements
+
+We recognise researchers who report valid vulnerabilities and help improve the
+security of this repository. With your permission, we will credit you by name
+or handle in the release notes and changelog for the fix.
+
+If you prefer to remain anonymous, say so in your report and we will honor
+that request.

--- a/agents/kubernetes/kubernetes-live-admission-policy-guard-agent/metadata.json
+++ b/agents/kubernetes/kubernetes-live-admission-policy-guard-agent/metadata.json
@@ -32,5 +32,6 @@
     "kiro-cli": "agents/kubernetes/kubernetes-live-admission-policy-guard-agent/harnesses/kiro-cli.agent.json"
   },
   "author": "github: Raishin",
-  "version": "0.1.0"
+  "version": "0.1.0",
+  "companion_skills": ["kyverno-policy-review"]
 }

--- a/agents/kubernetes/kubernetes-live-argocd-sync-guard-agent/metadata.json
+++ b/agents/kubernetes/kubernetes-live-argocd-sync-guard-agent/metadata.json
@@ -32,5 +32,6 @@
     "kiro-cli": "agents/kubernetes/kubernetes-live-argocd-sync-guard-agent/harnesses/kiro-cli.agent.json"
   },
   "author": "github: Raishin",
-  "version": "0.1.0"
+  "version": "0.1.0",
+  "companion_skills": ["argocd-gitops-review"]
 }

--- a/agents/kubernetes/kubernetes-live-mesh-policy-guard-agent/metadata.json
+++ b/agents/kubernetes/kubernetes-live-mesh-policy-guard-agent/metadata.json
@@ -32,5 +32,6 @@
     "kiro-cli": "agents/kubernetes/kubernetes-live-mesh-policy-guard-agent/harnesses/kiro-cli.agent.json"
   },
   "author": "github: Raishin",
-  "version": "0.1.0"
+  "version": "0.1.0",
+  "companion_skills": ["istio-ambient-mesh-review"]
 }

--- a/agents/kubernetes/kubernetes-live-network-policy-guard-agent/metadata.json
+++ b/agents/kubernetes/kubernetes-live-network-policy-guard-agent/metadata.json
@@ -32,5 +32,6 @@
     "kiro-cli": "agents/kubernetes/kubernetes-live-network-policy-guard-agent/harnesses/kiro-cli.agent.json"
   },
   "author": "github: Raishin",
-  "version": "0.1.0"
+  "version": "0.1.0",
+  "companion_skills": ["cilium-network-policy-review"]
 }

--- a/agents/kubernetes/kubernetes-live-velero-restore-guard-agent/metadata.json
+++ b/agents/kubernetes/kubernetes-live-velero-restore-guard-agent/metadata.json
@@ -33,5 +33,6 @@
     "kiro-cli": "agents/kubernetes/kubernetes-live-velero-restore-guard-agent/harnesses/kiro-cli.agent.json"
   },
   "author": "github: Raishin",
-  "version": "0.1.0"
+  "version": "0.1.0",
+  "companion_skills": ["velero-backup-restore-guard"]
 }

--- a/agents/kubernetes/kubernetes-psa-review-agent/metadata.json
+++ b/agents/kubernetes/kubernetes-psa-review-agent/metadata.json
@@ -33,5 +33,6 @@
     "kiro-cli": "agents/kubernetes/kubernetes-psa-review-agent/harnesses/kiro-cli.agent.json"
   },
   "author": "github: Raishin",
-  "version": "0.1.0"
+  "version": "0.1.0",
+  "companion_skills": ["kubernetes-pod-security-admission-review"]
 }

--- a/catalog/skill-manifest.json
+++ b/catalog/skill-manifest.json
@@ -6,12 +6,12 @@
     {
       "id": "argo-rollouts-progressive-delivery-review",
       "path": "skills/argocd/argo-rollouts-progressive-delivery-review",
-      "aggregate_sha256": "e39b76eb9521400dd5412fd6e2f04323cd6b18f608b4aad1573521246f0d333c",
+      "aggregate_sha256": "716600e254bbe2ad05ba892fd18a702f779a38313b8a280250ecc5d3e2b8e01f",
       "files": [
         {
           "path": "skills/argocd/argo-rollouts-progressive-delivery-review/SKILL.md",
-          "sha256": "a68765c9281762193444289c2dbe5f181dd0080a9d3f0942ed86dac12ce6ded0",
-          "bytes": 3109
+          "sha256": "623e6621754b200a551a7e16e201606a2c7681c263c3a457148fbbb4d730374e",
+          "bytes": 3139
         },
         {
           "path": "skills/argocd/argo-rollouts-progressive-delivery-review/metadata.json",
@@ -28,12 +28,12 @@
     {
       "id": "argocd-gitops-review",
       "path": "skills/argocd/argocd-gitops-review",
-      "aggregate_sha256": "0439b3ed8ae0721788681fbb711a4cf2d91e2157679d6a60ad11be7a2f5b9ce4",
+      "aggregate_sha256": "f4b44a65d1ffb447569d00537afac9624b906f42b6564059e71d1427d92c02ef",
       "files": [
         {
           "path": "skills/argocd/argocd-gitops-review/SKILL.md",
-          "sha256": "6622f6e8acc3fcc2bfec62242d2c00077feff16e2af9ea2700309d48ab81852e",
-          "bytes": 3627
+          "sha256": "7c5db013310c466556e54684984e67a91c9dbb79750bf6b57689c9d38c4f29bc",
+          "bytes": 3657
         },
         {
           "path": "skills/argocd/argocd-gitops-review/metadata.json",
@@ -60,12 +60,12 @@
     {
       "id": "aws-agentcore",
       "path": "skills/aws/aws-agentcore",
-      "aggregate_sha256": "b72c83fc559891dfd0c52283166736b8d2b2bcb7a7fa9151eef7107a04874c16",
+      "aggregate_sha256": "877cd03e98107d1c03a338a72fc5c52f10cee390aff3dd5fc7493a73f7291277",
       "files": [
         {
           "path": "skills/aws/aws-agentcore/SKILL.md",
-          "sha256": "07dd0a98433c9c27ea1afe39aba4a0a8ed6843dfbe00071c01c82a9590a080f8",
-          "bytes": 3589
+          "sha256": "06dd099075826dc67747c161c06a548e7f14af647a7cc1e4d2a1aca9a987ab05",
+          "bytes": 3645
         },
         {
           "path": "skills/aws/aws-agentcore/agents/openai.yaml",
@@ -112,12 +112,12 @@
     {
       "id": "aws-api-edge-delivery-review",
       "path": "skills/aws/aws-api-edge-delivery-review",
-      "aggregate_sha256": "08112ec30b64a5efb7aa49673af87b04b216ace92de3090b670cc3de605bdbc2",
+      "aggregate_sha256": "71dbcea59b5ef5ab97b9326e147ece7d661aa7719b416123ee313001e8755c92",
       "files": [
         {
           "path": "skills/aws/aws-api-edge-delivery-review/SKILL.md",
-          "sha256": "84bf536f045a235be1f93a57925a3af5f4945bde63bf9cb8ad895ffbe13fce75",
-          "bytes": 2737
+          "sha256": "98c48d825b84e8a9f507c46c69e09f103a11fcdd79ce1953d995e90f0d3c8610",
+          "bytes": 2767
         },
         {
           "path": "skills/aws/aws-api-edge-delivery-review/metadata.json",
@@ -144,12 +144,12 @@
     {
       "id": "aws-bedrock-agent-security-governor",
       "path": "skills/aws/aws-bedrock-agent-security-governor",
-      "aggregate_sha256": "13235217c03a6566e6950f51557435c59e69b0ddbbe006460a7a68404453b872",
+      "aggregate_sha256": "d25613b9669da0e19725ee9a511517fb233d344c8167fedcf0efd623a6787aec",
       "files": [
         {
           "path": "skills/aws/aws-bedrock-agent-security-governor/SKILL.md",
-          "sha256": "668570867e5a7379a70b2f76ea9e77060841fa56801c9d65498ad34ec6777d2a",
-          "bytes": 2650
+          "sha256": "6dd37f43a8ac2a5fef01e0d1d96636e17ccd4a444f2ee4e66dc3783cb78f85ea",
+          "bytes": 2680
         },
         {
           "path": "skills/aws/aws-bedrock-agent-security-governor/metadata.json",
@@ -176,12 +176,12 @@
     {
       "id": "aws-change-impact-advisor",
       "path": "skills/aws/aws-change-impact-advisor",
-      "aggregate_sha256": "5639444e5bba7bb02f1479563e0ff0c64cca53572741f94b6bcd3f4cb1c5caab",
+      "aggregate_sha256": "199df51839f2e51941c0cdd4274aca21393a8b1efdec0a3c8321d1a4467950f5",
       "files": [
         {
           "path": "skills/aws/aws-change-impact-advisor/SKILL.md",
-          "sha256": "975c7d031e4ab35d413d910a121247357c932557119e462ed2b97621c376808b",
-          "bytes": 2714
+          "sha256": "6fb969249d29dec65d1152220d3483a49e95d681252afa204ce68132429ad463",
+          "bytes": 2753
         },
         {
           "path": "skills/aws/aws-change-impact-advisor/metadata.json",
@@ -208,12 +208,12 @@
     {
       "id": "aws-ci-cd-release-engineer",
       "path": "skills/aws/aws-ci-cd-release-engineer",
-      "aggregate_sha256": "3cb4d332169f023864e59b8d80560dcb254d911b9e8c2124953d6391f42fd17b",
+      "aggregate_sha256": "04f80cf1e80bd102b5bc5aff02bef46689d81f8440843bba13425b4b056ce7df",
       "files": [
         {
           "path": "skills/aws/aws-ci-cd-release-engineer/SKILL.md",
-          "sha256": "d1fdb0c264923efa9e8081260d4cc55b89ca90d2ba66c245ebd8b6ac63e717a2",
-          "bytes": 2756
+          "sha256": "e027c8e3654bf6f30e3c420f92a77370d07ef01b75cd54ed57ac73ffc8cdc2c2",
+          "bytes": 2786
         },
         {
           "path": "skills/aws/aws-ci-cd-release-engineer/metadata.json",
@@ -240,12 +240,12 @@
     {
       "id": "aws-compliance-evidence-mapper",
       "path": "skills/aws/aws-compliance-evidence-mapper",
-      "aggregate_sha256": "8e920433ba84721cde77791d3466e790207161e6c800aca4837b90aa716ccc49",
+      "aggregate_sha256": "74a732645a0abff5c9427ee3546e634b3ba471945a8e112bfd9f1c7af5b461c5",
       "files": [
         {
           "path": "skills/aws/aws-compliance-evidence-mapper/SKILL.md",
-          "sha256": "15bad6bb4c516f1f5ec2bff88ce2bf910a4e896034f29c5a939fb5bf9fa6cbce",
-          "bytes": 2617
+          "sha256": "bb0d43d41fbe8bb8568129fb32a98c0715cdb7dbb0d386bb348d87814ca49b92",
+          "bytes": 2647
         },
         {
           "path": "skills/aws/aws-compliance-evidence-mapper/metadata.json",
@@ -272,12 +272,12 @@
     {
       "id": "aws-cost-anomaly-watch-coordinator",
       "path": "skills/aws/aws-cost-anomaly-watch-coordinator",
-      "aggregate_sha256": "0f1fffc7d518a71b2840182e62d2bb5d00ad8351e72a38a2232b07f92a5f4051",
+      "aggregate_sha256": "695e3df2c1c0f4480342259670610c1e1f158c2ae8e754361c1a433ac41e3cf6",
       "files": [
         {
           "path": "skills/aws/aws-cost-anomaly-watch-coordinator/SKILL.md",
-          "sha256": "8ac8b5face182fce42e8decc7b12b06634346b3bc3f44ed267a2854384c71093",
-          "bytes": 2670
+          "sha256": "4cf4cb439fab8a422c8a40121c7ea582ac9ff8a4fe7d5533f910523c57c0bf03",
+          "bytes": 2709
         },
         {
           "path": "skills/aws/aws-cost-anomaly-watch-coordinator/metadata.json",
@@ -304,12 +304,12 @@
     {
       "id": "aws-cost-optimization-governor",
       "path": "skills/aws/aws-cost-optimization-governor",
-      "aggregate_sha256": "1cc5926303b8ca221d961bad9d294b8b9f860f062ee7d65399280d0ad737b4b1",
+      "aggregate_sha256": "e7b0c666ef2c9152f9e4f1e3e0021d50c407d7cdd8dc164cd3f3f4af22aeda89",
       "files": [
         {
           "path": "skills/aws/aws-cost-optimization-governor/SKILL.md",
-          "sha256": "260d984ad28d074561bd0d3acc69adb0a582dbba64dc855bb350f71d42c17140",
-          "bytes": 2583
+          "sha256": "c4b41cc340186dc8f5779cabb4cb0290ca575b00f97946a1b38c6cddc6501de1",
+          "bytes": 2613
         },
         {
           "path": "skills/aws/aws-cost-optimization-governor/metadata.json",
@@ -336,12 +336,12 @@
     {
       "id": "aws-daily-operations-briefing-coordinator",
       "path": "skills/aws/aws-daily-operations-briefing-coordinator",
-      "aggregate_sha256": "f387a7ef9ca16b27b5aff3e9c62a1c1267eb04ec3878149685d2a30cfeda25c8",
+      "aggregate_sha256": "e25c27001f024bc9337b99692abb5b0b256a052b4eaa08abdc148651888e2f3a",
       "files": [
         {
           "path": "skills/aws/aws-daily-operations-briefing-coordinator/SKILL.md",
-          "sha256": "b525af9b8d6ac7f4d5ff1a6a72801247d46af4d7df0dc3b6d6da4e08fcff42e7",
-          "bytes": 2778
+          "sha256": "e762ac35d06530dae45a905ceb80575514bd874ee1df0141a787132bcc852605",
+          "bytes": 2817
         },
         {
           "path": "skills/aws/aws-daily-operations-briefing-coordinator/metadata.json",
@@ -368,12 +368,12 @@
     {
       "id": "aws-data-protection-backup-steward",
       "path": "skills/aws/aws-data-protection-backup-steward",
-      "aggregate_sha256": "c84368740cb24335925b2906a6f55d65e41eaac7fe3c5d5c5a2d337bcf00555a",
+      "aggregate_sha256": "7210bf50c7ca6db1ebde640e4ec0595e8276182f983784c987198b6ed2c91843",
       "files": [
         {
           "path": "skills/aws/aws-data-protection-backup-steward/SKILL.md",
-          "sha256": "7cbc3527da0f96fde1ba3c58f283f5a24b2fec0bd6750e59198eeb0b0f9b9386",
-          "bytes": 2615
+          "sha256": "cf48fe8b1c54631eb705e0a1200c754e14cbcedca597b80cb06d2a293bcdbfbb",
+          "bytes": 2645
         },
         {
           "path": "skills/aws/aws-data-protection-backup-steward/metadata.json",
@@ -400,12 +400,12 @@
     {
       "id": "aws-deployment-hotfix-operator",
       "path": "skills/aws/aws-deployment-hotfix-operator",
-      "aggregate_sha256": "8d424dfe303ae1d928439e37611794328cc531a82b93a2c21e53004ec5b1b137",
+      "aggregate_sha256": "0c3294a471f16084427d9120f20e84bc5d0b2ee89e01c08c9432dcb106626156",
       "files": [
         {
           "path": "skills/aws/aws-deployment-hotfix-operator/SKILL.md",
-          "sha256": "102c32c08870c9f6efdecc63270133594051a43771292e491f495ca01ec6c1bd",
-          "bytes": 2758
+          "sha256": "faa9654b598a84f84059c8d7cc4e1cd737259e8f1009a5584cac875943f63e6c",
+          "bytes": 2809
         },
         {
           "path": "skills/aws/aws-deployment-hotfix-operator/metadata.json",
@@ -432,12 +432,12 @@
     {
       "id": "aws-devops-agent-skill-designer",
       "path": "skills/aws/aws-devops-agent-skill-designer",
-      "aggregate_sha256": "22489655ab000c13fa0b6af3fb5a5b8dcf904f1df266584a6b3847dc4cc66736",
+      "aggregate_sha256": "a902d6b7869a37c3cf6e544f1298c03a7f6af03a801d212a5b5f0e93469f2bf1",
       "files": [
         {
           "path": "skills/aws/aws-devops-agent-skill-designer/SKILL.md",
-          "sha256": "c2597f980b343343e6a815bf1f2b860cdcf9b358cdb972ea54e9693a6437846a",
-          "bytes": 2717
+          "sha256": "c0b4d1ddfd279041bc89bb71d683c18e41478dbc8fdbdb2161bfeaa65b6e0ed6",
+          "bytes": 2747
         },
         {
           "path": "skills/aws/aws-devops-agent-skill-designer/metadata.json",
@@ -464,12 +464,12 @@
     {
       "id": "aws-dynamodb-data-modeling-performance-review",
       "path": "skills/aws/aws-dynamodb-data-modeling-performance-review",
-      "aggregate_sha256": "6a22013bd314197e50f411f4e2d698671d05d780e000ba0de83172c915a1fe36",
+      "aggregate_sha256": "33c5e25b10217ea5b71d86ca3733beb50285a10285ad8713e0c7a6add7ed03ca",
       "files": [
         {
           "path": "skills/aws/aws-dynamodb-data-modeling-performance-review/SKILL.md",
-          "sha256": "0087b14dd3aee20398e926f97e1bbdb59c8d6935bf80d74e66ecda90782217cd",
-          "bytes": 2717
+          "sha256": "2fb15e5e95638831f2bcb024d5b78eedc5acc5422d79c8276c58f18f8be20cfe",
+          "bytes": 2747
         },
         {
           "path": "skills/aws/aws-dynamodb-data-modeling-performance-review/metadata.json",
@@ -496,12 +496,12 @@
     {
       "id": "aws-ec2-compute-operations-steward",
       "path": "skills/aws/aws-ec2-compute-operations-steward",
-      "aggregate_sha256": "69fe84db82f17a5013b242e1bbfe6f04bd64274bb6b7a14b6efba6ee8c388ed5",
+      "aggregate_sha256": "d133f2b9d4d7db6ff600c26b44047768af8fbe918db2c2e39ed33a2045988d9f",
       "files": [
         {
           "path": "skills/aws/aws-ec2-compute-operations-steward/SKILL.md",
-          "sha256": "83e2d3200fdcbfb0e8b748a14a6ec1bdfb0316fb582d29a6a17a02f97f5308a5",
-          "bytes": 2720
+          "sha256": "a72b8b941b73d95bc496ce048e2014c6c31cc5f10ce72dab6b30e6fa9f836bdc",
+          "bytes": 2750
         },
         {
           "path": "skills/aws/aws-ec2-compute-operations-steward/metadata.json",
@@ -528,12 +528,12 @@
     {
       "id": "aws-ecs-fargate-platform-operator",
       "path": "skills/aws/aws-ecs-fargate-platform-operator",
-      "aggregate_sha256": "85ff5eeedff00feda2f09cb10c55accafcc394bbad1491dea7768cad3180a126",
+      "aggregate_sha256": "c00b30e38214a93db613fd8a30a1e64ab9af5edbc1a384598e7fea46c008e1c4",
       "files": [
         {
           "path": "skills/aws/aws-ecs-fargate-platform-operator/SKILL.md",
-          "sha256": "fc6d23e222e7044b9bbbac23a00c677f8b040e3397f6376dc1bef763aa4455ed",
-          "bytes": 2724
+          "sha256": "29370deca5ad310f399cf753dd7c0088712381c98ad4094f484dd2c3e0c653de",
+          "bytes": 2754
         },
         {
           "path": "skills/aws/aws-ecs-fargate-platform-operator/metadata.json",
@@ -560,12 +560,12 @@
     {
       "id": "aws-ecs-service-remediation-operator",
       "path": "skills/aws/aws-ecs-service-remediation-operator",
-      "aggregate_sha256": "a5c3c7de028114dd38c7f0c92987705b5d5f37479202eddc7809185983c44d3d",
+      "aggregate_sha256": "e16a3f603e7f2595157e42fb74622f39c73a05fbf63039579998f861586c43c6",
       "files": [
         {
           "path": "skills/aws/aws-ecs-service-remediation-operator/SKILL.md",
-          "sha256": "9b3ea9f2524b69b9f4e1b21fb9cca55029849dc185ddf8388f7c37ad7cf6ace4",
-          "bytes": 2708
+          "sha256": "7b26c23e329d805887ddf667153d687a86224feb807371cdba150ce751bc432c",
+          "bytes": 2759
         },
         {
           "path": "skills/aws/aws-ecs-service-remediation-operator/metadata.json",
@@ -592,12 +592,12 @@
     {
       "id": "aws-eks-platform-operator",
       "path": "skills/aws/aws-eks-platform-operator",
-      "aggregate_sha256": "ac83111bd0c8f6b46c36d56ccdac392a0be83b26a798906049ec62239e7165a9",
+      "aggregate_sha256": "5c70050f3df68fc3780bd5008a8e1c0df74cf34780f9ed4527ff4050a75345e9",
       "files": [
         {
           "path": "skills/aws/aws-eks-platform-operator/SKILL.md",
-          "sha256": "216dced45a35a9b499514efbb1b3def9e5124f345412aa9e38a6a9d207c8e986",
-          "bytes": 2610
+          "sha256": "9558979248281d14abe5f079969e86f8664b69c12eaf563cb8be067bded7eeb6",
+          "bytes": 2640
         },
         {
           "path": "skills/aws/aws-eks-platform-operator/metadata.json",
@@ -624,12 +624,12 @@
     {
       "id": "aws-event-driven-architecture-review",
       "path": "skills/aws/aws-event-driven-architecture-review",
-      "aggregate_sha256": "69d733e7cf80966e1c4a37e06f58c1fec47b46531bf9f5202df8a67289ca647f",
+      "aggregate_sha256": "295ef34cfeebdeaa0af5929c7fab6e5ea7e3553bd6462204883aee30b8e49bbe",
       "files": [
         {
           "path": "skills/aws/aws-event-driven-architecture-review/SKILL.md",
-          "sha256": "6fda3ffdb38676c2375e85cf6cdca4297ac802169251cccb66dca42fdfd3bbb0",
-          "bytes": 2715
+          "sha256": "c2a2f24101a59d3e76146984a6485093f688441276cefcd79630510646601329",
+          "bytes": 2745
         },
         {
           "path": "skills/aws/aws-event-driven-architecture-review/metadata.json",
@@ -656,12 +656,12 @@
     {
       "id": "aws-generative-ai-developer",
       "path": "skills/aws/aws-generative-ai-developer",
-      "aggregate_sha256": "4278f3b30f678b2fb8967382fa7b1bbfc4c32b7cd1111a64bc7d83998f1f37b9",
+      "aggregate_sha256": "afb9bd267f174118235b0383f207858082d42db6379a6cf84429cca52554b9d9",
       "files": [
         {
           "path": "skills/aws/aws-generative-ai-developer/SKILL.md",
-          "sha256": "f6f2a3d31b2dfb4ef7888299e284bad6d7f4422be08a73e0d8d45e99f3307921",
-          "bytes": 3008
+          "sha256": "67a8e962decfc91057a6d516d75afe1ea6c15f609d516baf63b973a595cc77d1",
+          "bytes": 3064
         },
         {
           "path": "skills/aws/aws-generative-ai-developer/metadata.json",
@@ -688,12 +688,12 @@
     {
       "id": "aws-iac-change-safety-review",
       "path": "skills/aws/aws-iac-change-safety-review",
-      "aggregate_sha256": "ed4f83b98ccf475b25a9a8061a26915015f301147ac22a876d79ff477d8ed05e",
+      "aggregate_sha256": "74dc32e8de1f8b6841bd658bf852506576196c3a78600810bf576c6ee1917256",
       "files": [
         {
           "path": "skills/aws/aws-iac-change-safety-review/SKILL.md",
-          "sha256": "628e07e512bf8f43d47137a304702084db6c3e3b8ed7c795324961dc2f4f8c41",
-          "bytes": 2742
+          "sha256": "53922959e98e016f8d2a88d7187a5fe1bc4cfab9ea4f23679a66f0bd316427e9",
+          "bytes": 2772
         },
         {
           "path": "skills/aws/aws-iac-change-safety-review/metadata.json",
@@ -720,12 +720,12 @@
     {
       "id": "aws-iac-patch-executor",
       "path": "skills/aws/aws-iac-patch-executor",
-      "aggregate_sha256": "f67e93b4220ca4e917e6c3aa864ba2f26dc0038f9c5b8d081dc69d94c2eeee91",
+      "aggregate_sha256": "66a854a3dd167dc4cf13e718c5d489c9e2853b3c4622e83b700982613ddd8e07",
       "files": [
         {
           "path": "skills/aws/aws-iac-patch-executor/SKILL.md",
-          "sha256": "12816c7f1c1a61582da962ec0e532c42d948b8f01d51e94dcf564db34e4ffcee",
-          "bytes": 2648
+          "sha256": "8a1f06aa97376996e4684f7de250ec57f6137118709651a6335881bb4dcb0718",
+          "bytes": 2699
         },
         {
           "path": "skills/aws/aws-iac-patch-executor/metadata.json",
@@ -752,12 +752,12 @@
     {
       "id": "aws-iam-least-privilege-review",
       "path": "skills/aws/aws-iam-least-privilege-review",
-      "aggregate_sha256": "6b73eb0ecf7e6524f3b5887c8bc1efbff3bc43dd037a20951018e4944820ca44",
+      "aggregate_sha256": "36f2d5008c0e25161c446d2fa1205d39212b98614c2aaf79c97b944c467061e6",
       "files": [
         {
           "path": "skills/aws/aws-iam-least-privilege-review/SKILL.md",
-          "sha256": "053e58d494389ca173201c730b5975a0de6dd863a7e7b108921b586ce76859e0",
-          "bytes": 2702
+          "sha256": "d3b651d19d028539203b6237c4c406743d913e3ab67cb67dd542d117c094917c",
+          "bytes": 2732
         },
         {
           "path": "skills/aws/aws-iam-least-privilege-review/metadata.json",
@@ -784,12 +784,12 @@
     {
       "id": "aws-kms-secrets-lifecycle-steward",
       "path": "skills/aws/aws-kms-secrets-lifecycle-steward",
-      "aggregate_sha256": "94d7b6fb466f1d4615c1765e6c45fba23eb9e14a7158fd438c6856c43861b4b4",
+      "aggregate_sha256": "b2147378e1bad43f4da71fd850a40966e98a1cc278dd301d083ced7e7842d79c",
       "files": [
         {
           "path": "skills/aws/aws-kms-secrets-lifecycle-steward/SKILL.md",
-          "sha256": "6402fb64629a4887c2a578b0cea4c9b7db518c5fe8be63667248fd7c898737a6",
-          "bytes": 2796
+          "sha256": "8c54118ae1d561fa609a2bd1587eea98a4e5d03a2d42045197bf1fc181e9cb2f",
+          "bytes": 2826
         },
         {
           "path": "skills/aws/aws-kms-secrets-lifecycle-steward/metadata.json",
@@ -816,12 +816,12 @@
     {
       "id": "aws-landing-zone-governor",
       "path": "skills/aws/aws-landing-zone-governor",
-      "aggregate_sha256": "632066902af013a1c6ea10a5d2a2c1f6500425c8711a5d440d7d79937e9bf8cc",
+      "aggregate_sha256": "30bb7dc0f500660bf079c13307fd4e7e80431d35846666391e3e15a2982ec7b1",
       "files": [
         {
           "path": "skills/aws/aws-landing-zone-governor/SKILL.md",
-          "sha256": "949c1b4b8fb14bd697913dd5130fefd1165dea89e49866ee7221c7684ba24950",
-          "bytes": 2516
+          "sha256": "3c833a88ed1b36a4d707d9a107c5560ae987d7b674abedcb6a95cf9ae3f6dace",
+          "bytes": 2546
         },
         {
           "path": "skills/aws/aws-landing-zone-governor/metadata.json",
@@ -848,12 +848,12 @@
     {
       "id": "aws-live-deployment-guarded-operator",
       "path": "skills/aws/aws-live-deployment-guarded-operator",
-      "aggregate_sha256": "15c49db64e19abad8bfe9d71e1211de3586897f8a2924d7b620ec8695d18d536",
+      "aggregate_sha256": "e7756df4befb45d7c40e3fa05258c3838f5b0b5611696cdf5ca4de01adcbeed1",
       "files": [
         {
           "path": "skills/aws/aws-live-deployment-guarded-operator/SKILL.md",
-          "sha256": "b13dfea14514635648aa3ac786a3b89a72e8d8e2839e468f924f133d1e55420f",
-          "bytes": 3219
+          "sha256": "99740298bd4418a9c1617f68b58592192f20376618fa717d9e31ccd90e66d8f6",
+          "bytes": 3249
         },
         {
           "path": "skills/aws/aws-live-deployment-guarded-operator/metadata.json",
@@ -885,12 +885,12 @@
     {
       "id": "aws-live-ecs-rollout-guard",
       "path": "skills/aws/aws-live-ecs-rollout-guard",
-      "aggregate_sha256": "0d97ae9bfe32bb2548f213046bafffbea1abe2aa70d6f9f2047f8c5f61769b01",
+      "aggregate_sha256": "5eab8fe4fa6891440e8f5a3a5088aeba39b1ca43ca779d18484ae24a9d471a70",
       "files": [
         {
           "path": "skills/aws/aws-live-ecs-rollout-guard/SKILL.md",
-          "sha256": "6a371914f745f82d98331b1a2c04dcb3327088848bd7c5360dad7adf0f99888f",
-          "bytes": 2800
+          "sha256": "a1baffc2c7a9ef226fc6cb127e33c72f41e49bd5454998078866e0087d45af0d",
+          "bytes": 2839
         },
         {
           "path": "skills/aws/aws-live-ecs-rollout-guard/metadata.json",
@@ -922,12 +922,12 @@
     {
       "id": "aws-live-iac-change-guard",
       "path": "skills/aws/aws-live-iac-change-guard",
-      "aggregate_sha256": "42dd9e12b2ed4c91c02aad47fd76db8034777109fdd5e9c485106b8b410430fe",
+      "aggregate_sha256": "80e48bdb5b61f4b2f4c48a4f612a663ab8114b4e551cb7577eb7125e8ab2ec71",
       "files": [
         {
           "path": "skills/aws/aws-live-iac-change-guard/SKILL.md",
-          "sha256": "d592d15c092809398db1efc05e9eb61e066d2c1fdb958f2aa5a4f3e72a64c400",
-          "bytes": 2877
+          "sha256": "7230c2c98dc37d0fdd9bd214fae39bc1124b2a18befa3890acb00daacf7df483",
+          "bytes": 2916
         },
         {
           "path": "skills/aws/aws-live-iac-change-guard/metadata.json",
@@ -959,12 +959,12 @@
     {
       "id": "aws-live-pipeline-approval-operator",
       "path": "skills/aws/aws-live-pipeline-approval-operator",
-      "aggregate_sha256": "27e6dabbbf6d0b513e6cb417274db622107aaf8d3b8e1140057d8a9397b19b87",
+      "aggregate_sha256": "a10d1576bed0a15330d4ba77f29b5012aab9c8a213157a77af077f1387a91310",
       "files": [
         {
           "path": "skills/aws/aws-live-pipeline-approval-operator/SKILL.md",
-          "sha256": "e60aad22e24b76e74e4cb411680e702fd2fb5958adac9416187083a0f5d374cf",
-          "bytes": 2850
+          "sha256": "6ce4cde3b4ae32c31c7ce10b8c049d8b50d40de75b6b7268aa08dd859759879c",
+          "bytes": 2880
         },
         {
           "path": "skills/aws/aws-live-pipeline-approval-operator/metadata.json",
@@ -996,12 +996,12 @@
     {
       "id": "aws-live-serverless-release-guard",
       "path": "skills/aws/aws-live-serverless-release-guard",
-      "aggregate_sha256": "868b78816fbf4d8fa529973c3a7ed27f4ace1d3805ace1b3d41dfc29baa4c188",
+      "aggregate_sha256": "3c2851ad13531a5b2e0f32af38dfd520adfaad83c4bce1b3cbf6215cb20435d6",
       "files": [
         {
           "path": "skills/aws/aws-live-serverless-release-guard/SKILL.md",
-          "sha256": "02d0c81e9efb120d19bf68504a8a4862fede5d3ebeeed6bed176ea34504f2b13",
-          "bytes": 2936
+          "sha256": "ce09586ef9e5446bf5c1130bdf2fdd90880c9dfd529e6a69c5b8e3a526ece16f",
+          "bytes": 2975
         },
         {
           "path": "skills/aws/aws-live-serverless-release-guard/metadata.json",
@@ -1033,12 +1033,12 @@
     {
       "id": "aws-maestro",
       "path": "skills/aws/aws-maestro",
-      "aggregate_sha256": "4443e812046b318de873b8ddf19fd4a397f00ae02b536a78f95f1485e6d2dd35",
+      "aggregate_sha256": "0066b101edcdbf05808fad3efb4b50c70c61c9398e25a0fa63feadff13ed5e93",
       "files": [
         {
           "path": "skills/aws/aws-maestro/SKILL.md",
-          "sha256": "bfb517d91fbfa222d5cfa6afa2e5218e37a80419c961f37166a7abd3e16097ec",
-          "bytes": 3150
+          "sha256": "8d8bc4df5505b6a21f49315c8690b5eb532b10df87376c0395d59817ac9ecee3",
+          "bytes": 3192
         },
         {
           "path": "skills/aws/aws-maestro/metadata.json",
@@ -1065,12 +1065,12 @@
     {
       "id": "aws-migration-cutover-architect",
       "path": "skills/aws/aws-migration-cutover-architect",
-      "aggregate_sha256": "92ecd54ecefc0267890c4c963a43786c2d88f9618fded1501991432ba7b603f5",
+      "aggregate_sha256": "8630319a2d6d835b7273b327f202c0235d58459da925324d0c02376ea1170197",
       "files": [
         {
           "path": "skills/aws/aws-migration-cutover-architect/SKILL.md",
-          "sha256": "623d81d3b59041a8ca30a227114e65803485923be649c5e81d3a43037835d9e9",
-          "bytes": 2603
+          "sha256": "5c55b80735dd8e1fe4cac551340bb81c7493fa84aeb916ed034ae89efd111043",
+          "bytes": 2633
         },
         {
           "path": "skills/aws/aws-migration-cutover-architect/metadata.json",
@@ -1097,12 +1097,12 @@
     {
       "id": "aws-network-architect",
       "path": "skills/aws/aws-network-architect",
-      "aggregate_sha256": "a21e64c2c97f4fec69b06e970b6faf15cb0cb29583a24618e21136ebdd868ef2",
+      "aggregate_sha256": "3d57397dc67eae6ab6bd98958a2c0d930b3a99515aab2c7f5e86138183625a67",
       "files": [
         {
           "path": "skills/aws/aws-network-architect/SKILL.md",
-          "sha256": "182306c85358f8f59d4c15fcb200d0d1ce9a3059c3474569dd9a2852a127a736",
-          "bytes": 2649
+          "sha256": "22ac412c5c36d3845870ba6ccea3fa01ab73a64b1c1c74b6f07f36d4e6dea838",
+          "bytes": 2679
         },
         {
           "path": "skills/aws/aws-network-architect/metadata.json",
@@ -1129,12 +1129,12 @@
     {
       "id": "aws-non-destructive-task-automation-advisor",
       "path": "skills/aws/aws-non-destructive-task-automation-advisor",
-      "aggregate_sha256": "e854dcc227e25230ba55031a0547791ce463288a8c163768c52700083359cf20",
+      "aggregate_sha256": "bf0c164de8df8ee1f9b913aa72a40164669a85ad8644963e46b24d2a4953b4c1",
       "files": [
         {
           "path": "skills/aws/aws-non-destructive-task-automation-advisor/SKILL.md",
-          "sha256": "9321249d83750b3f0b97323ff7fb03139a32d9a86ab850e7cc45c8a49ed9e7be",
-          "bytes": 2813
+          "sha256": "8696b2acad1db090ab723d4cab1bac11b4bd56ca1e984e239ea83d44ded7434e",
+          "bytes": 2852
         },
         {
           "path": "skills/aws/aws-non-destructive-task-automation-advisor/metadata.json",
@@ -1161,12 +1161,12 @@
     {
       "id": "aws-observability-incident-responder",
       "path": "skills/aws/aws-observability-incident-responder",
-      "aggregate_sha256": "90db47ffb378bdb3a5d0a996f4464af61c32584484793bcb06afe857995aaef2",
+      "aggregate_sha256": "cb1b19c4aea204251a4decb73c22f2c3fb50279dda286f047e36018fb9d35940",
       "files": [
         {
           "path": "skills/aws/aws-observability-incident-responder/SKILL.md",
-          "sha256": "66df334be8dbe6af6ba9e7903022f9e74d7bd4e1e85735db113e93de6f3607da",
-          "bytes": 2604
+          "sha256": "bbd4dcab6a455915563ae5903846a947abdc07f66706d8fd7ca1e739bc3bc73a",
+          "bytes": 2643
         },
         {
           "path": "skills/aws/aws-observability-incident-responder/metadata.json",
@@ -1193,12 +1193,12 @@
     {
       "id": "aws-pipeline-fix-operator",
       "path": "skills/aws/aws-pipeline-fix-operator",
-      "aggregate_sha256": "1175a89d91353099dc368ce739138bc679adb370bffd9d94c8614f270b2529b0",
+      "aggregate_sha256": "759dbd8bc283d46fbe07c325ab2fe6665e8a5bf985705face6c20236b30af452",
       "files": [
         {
           "path": "skills/aws/aws-pipeline-fix-operator/SKILL.md",
-          "sha256": "75b2912b42d5e9a6b594690319a9e5e3ed1768b72ed92887d9b10ed52a19e411",
-          "bytes": 2666
+          "sha256": "8ffe8c6b027ef3461c976469d8edb0f97894f86df2ee745263c6309add65dbdc",
+          "bytes": 2717
         },
         {
           "path": "skills/aws/aws-pipeline-fix-operator/metadata.json",
@@ -1225,12 +1225,12 @@
     {
       "id": "aws-private-ca-issuer-review",
       "path": "skills/aws/aws-private-ca-issuer-review",
-      "aggregate_sha256": "91b7b622f188d03433b15b0947d03df072590484c59c4a3a4fe2d293237218e6",
+      "aggregate_sha256": "9e6b0d25c14574c0d869b73242ebc8b27a98a8f5be2a2fdafa8469077ff101cf",
       "files": [
         {
           "path": "skills/aws/aws-private-ca-issuer-review/SKILL.md",
-          "sha256": "dcda777a598f87015860a10b1f34ee5b252c39c06c11c8e15e6d9168e78c31ae",
-          "bytes": 2246
+          "sha256": "2bf5d2ab8865a2b460fd638e1c934bd465b12e37fc7d5aa79bcd9066591e1e33",
+          "bytes": 2276
         },
         {
           "path": "skills/aws/aws-private-ca-issuer-review/metadata.json",
@@ -1257,12 +1257,12 @@
     {
       "id": "aws-rds-aurora-performance-investigator",
       "path": "skills/aws/aws-rds-aurora-performance-investigator",
-      "aggregate_sha256": "b7c1bd0b3181f2393e4047afd2c7153866bf7afb99627faaec8d3fcee16b66e5",
+      "aggregate_sha256": "25b7d1099a9b4ca8df026a3d4ef07eff85b77e5a64da059327bcfb7b66519355",
       "files": [
         {
           "path": "skills/aws/aws-rds-aurora-performance-investigator/SKILL.md",
-          "sha256": "128bd1519a66198983a3107313a5374c94f254050aae43aaf7091a65b79039fc",
-          "bytes": 2663
+          "sha256": "80436ec945c066312b4fcbe9149987b6fad7ce25e6ec35b783177817dff3649e",
+          "bytes": 2702
         },
         {
           "path": "skills/aws/aws-rds-aurora-performance-investigator/metadata.json",
@@ -1289,12 +1289,12 @@
     {
       "id": "aws-resilience-bcdr-review",
       "path": "skills/aws/aws-resilience-bcdr-review",
-      "aggregate_sha256": "ecb488ff555b122522fb1b4d6293596db0065ed7ad73f0e5bfc6d3e78df9847d",
+      "aggregate_sha256": "7be25c64c62fb55d29c86374e5c2cb5ed3e39dcf07c93a219dc38980c1c7e48d",
       "files": [
         {
           "path": "skills/aws/aws-resilience-bcdr-review/SKILL.md",
-          "sha256": "4acdd6b4c1b244aaac078a59b69f74c4cd2246e153d7a65e6071bafe507c6d07",
-          "bytes": 2421
+          "sha256": "548aa44d24fe81157a9af26d273968944ac413cc36a865a3f10a68d704ea044e",
+          "bytes": 2451
         },
         {
           "path": "skills/aws/aws-resilience-bcdr-review/metadata.json",
@@ -1321,12 +1321,12 @@
     {
       "id": "aws-s3-data-perimeter-governor",
       "path": "skills/aws/aws-s3-data-perimeter-governor",
-      "aggregate_sha256": "75fdfb808bbd821df2bb0f4e175787618df72e1a3d977a59da47da5f699cc680",
+      "aggregate_sha256": "d8e2c50fedc03d63fcf3ed47d9c925c5eb3012a3b0cb489780a39007bd0103f0",
       "files": [
         {
           "path": "skills/aws/aws-s3-data-perimeter-governor/SKILL.md",
-          "sha256": "7480a0d4b87729a1a4ec6d5111554bf8737edfe1d504fbc3b8a913398253d189",
-          "bytes": 2719
+          "sha256": "b4e25c4417adbe86534dd40d2d88ac8fb4154ca6c42e34f80406f4060b0306cc",
+          "bytes": 2749
         },
         {
           "path": "skills/aws/aws-s3-data-perimeter-governor/metadata.json",
@@ -1353,12 +1353,12 @@
     {
       "id": "aws-security-posture-hardening",
       "path": "skills/aws/aws-security-posture-hardening",
-      "aggregate_sha256": "4f1979efc16854fc579ea3266fbd590e43f5cfd86b85cacf0ac42a9e121a1455",
+      "aggregate_sha256": "691d58690c802b039f42527012563f3740a8cb9c56c35ebf24ec53c693ae8cd4",
       "files": [
         {
           "path": "skills/aws/aws-security-posture-hardening/SKILL.md",
-          "sha256": "c0e8c79d71c04bd7b72938e27eb1d9e3d528b8b0430a94cb557931029362f8f5",
-          "bytes": 2701
+          "sha256": "4a262420de7a9877d4c3916f23215cfe465988fc0c9dad32d7623f4d304d16b8",
+          "bytes": 2731
         },
         {
           "path": "skills/aws/aws-security-posture-hardening/metadata.json",
@@ -1385,12 +1385,12 @@
     {
       "id": "aws-serverless-production-readiness",
       "path": "skills/aws/aws-serverless-production-readiness",
-      "aggregate_sha256": "c38d392c9a9686fbfc3cd3b9785206d1cf53d0875a2c5b091957d946ef2a89aa",
+      "aggregate_sha256": "de79fe8360e707cb7b496c64c9abe50f909462ed89029aee5cf90a76f9e7369e",
       "files": [
         {
           "path": "skills/aws/aws-serverless-production-readiness/SKILL.md",
-          "sha256": "764254c13fbe23122ebee3f31dfbe5fad50bfa5fb619cd23cfd0cf1cc82fcfce",
-          "bytes": 2663
+          "sha256": "8e26e68dda7ecfb3200f32c1afbdae5daf220e20f1d5fa023631292ed880c468",
+          "bytes": 2693
         },
         {
           "path": "skills/aws/aws-serverless-production-readiness/metadata.json",
@@ -1417,12 +1417,12 @@
     {
       "id": "aws-serverless-rollout-corrector",
       "path": "skills/aws/aws-serverless-rollout-corrector",
-      "aggregate_sha256": "e3ae14b7ebc90ee4eb217f75a98b91522abc3fe3e2bc76555e5bbc6f650209e0",
+      "aggregate_sha256": "07b26f916e2ba8906df333356c37c8c6f21d8434e9d16d5da6ed347001157bc3",
       "files": [
         {
           "path": "skills/aws/aws-serverless-rollout-corrector/SKILL.md",
-          "sha256": "403b9d22b089309a0ad91dd4bf815d0470b602b69ff41484f170b4d1175a327d",
-          "bytes": 2671
+          "sha256": "55e3b3013b098d64e3ca693aeea74da92d4c919bd7e8d04e89d5675fed6b8f9b",
+          "bytes": 2722
         },
         {
           "path": "skills/aws/aws-serverless-rollout-corrector/metadata.json",
@@ -1449,12 +1449,12 @@
     {
       "id": "aws-solution-architect",
       "path": "skills/aws/aws-solution-architect",
-      "aggregate_sha256": "527412b2afe7efa3ec7614609a25ff712510d791d0030257db6c2d53fdae0b46",
+      "aggregate_sha256": "dc61933cab7d1381996d81ed68af3a3762e64ac28d2d201435182224b82a50e2",
       "files": [
         {
           "path": "skills/aws/aws-solution-architect/SKILL.md",
-          "sha256": "ca9a310cf075d97136be5c4c549b2fbf7e03c5a84264d1c704382e959a814667",
-          "bytes": 2544
+          "sha256": "0d1dafba85fc4728f5425717ec4f183262ecbafb219753ed995624f32fc41ea6",
+          "bytes": 2574
         },
         {
           "path": "skills/aws/aws-solution-architect/metadata.json",
@@ -1481,12 +1481,12 @@
     {
       "id": "aws-ticket-triage-escalation-coordinator",
       "path": "skills/aws/aws-ticket-triage-escalation-coordinator",
-      "aggregate_sha256": "3839c6debdd918580a0156932b0424af9af8a78fd4a518173be846fdaf5e8f60",
+      "aggregate_sha256": "bb69f155650a405b90e1b058cb3a199f9a30acf91457c044d96f09b3d81c5028",
       "files": [
         {
           "path": "skills/aws/aws-ticket-triage-escalation-coordinator/SKILL.md",
-          "sha256": "d60385734507450b8fb6b31e46bea95c2f16408b53e859eb99c4547d6efdb9dd",
-          "bytes": 2714
+          "sha256": "670993e15f9a63ba1c2daeafd1b6516739e13e1e0a9908183f2a3e67dd80c6d5",
+          "bytes": 2753
         },
         {
           "path": "skills/aws/aws-ticket-triage-escalation-coordinator/metadata.json",
@@ -1513,12 +1513,12 @@
     {
       "id": "azure-ai-foundry-ops-governor",
       "path": "skills/azure/azure-ai-foundry-ops-governor",
-      "aggregate_sha256": "42639f500102205608c3af43ec3135f305fbb87a5393078c3bf2721103a93bca",
+      "aggregate_sha256": "8581e1de41872dd4154956d2e7f820623e45a2448ad366c4ad354e774eaae061",
       "files": [
         {
           "path": "skills/azure/azure-ai-foundry-ops-governor/SKILL.md",
-          "sha256": "ea1026ed78ef4480672a3f4ac64c0c299fd64a1259f9e72042faf95a7943e64a",
-          "bytes": 2928
+          "sha256": "347bfc7956d01c7110e2d1e248295e9ffa1acd577709c2f277df1c6bb1cbd0ee",
+          "bytes": 2958
         },
         {
           "path": "skills/azure/azure-ai-foundry-ops-governor/metadata.json",
@@ -1545,12 +1545,12 @@
     {
       "id": "azure-aks-platform-operator",
       "path": "skills/azure/azure-aks-platform-operator",
-      "aggregate_sha256": "a29ba17c35f7ae74b90f5e9a8dd7d8ead0ca4fa2aba584b59b52111914d88ab8",
+      "aggregate_sha256": "84d8f0a2c244c6c9306f8048787d3ff7a7006285121c8b235d1f4474137dcee6",
       "files": [
         {
           "path": "skills/azure/azure-aks-platform-operator/SKILL.md",
-          "sha256": "79c35340116652e4078486b0bd16eedf1b1b70cbec509a564b67e447746f365a",
-          "bytes": 3117
+          "sha256": "eed5d81e6110f6588b31420e46588c86d8c3827017d15f7040ca679e53543aba",
+          "bytes": 3147
         },
         {
           "path": "skills/azure/azure-aks-platform-operator/metadata.json",
@@ -1577,12 +1577,12 @@
     {
       "id": "azure-app-service-production-readiness",
       "path": "skills/azure/azure-app-service-production-readiness",
-      "aggregate_sha256": "4664adbdce1f08fc5a8725ad8c4f30235028e00d3ca31af9eeb9e18c03497ec0",
+      "aggregate_sha256": "1bfe8bb696ca26543901a1c9dc2028904600f076437b92580a19ba2722a7824f",
       "files": [
         {
           "path": "skills/azure/azure-app-service-production-readiness/SKILL.md",
-          "sha256": "25b41e2afdaea8f66166a5f44c7f6d880d0b28c2d986a7d54cd90b47b7b2b77a",
-          "bytes": 4063
+          "sha256": "58ab91c3d69c228edc6f8b741c4a6721498f3fbcd9a491f9db40e57c3f74acb5",
+          "bytes": 4093
         },
         {
           "path": "skills/azure/azure-app-service-production-readiness/metadata.json",
@@ -1609,12 +1609,12 @@
     {
       "id": "azure-cosmosdb-application-developer",
       "path": "skills/azure/azure-cosmosdb-application-developer",
-      "aggregate_sha256": "13cb9d9b3aed9ec82c92cb71cba5930b732a119982ee0bc8c59f18e26264f5ef",
+      "aggregate_sha256": "caa872e5cafe98f50b93e44e8738ab4bd0113f0b4715f23b782a5f10d846f970",
       "files": [
         {
           "path": "skills/azure/azure-cosmosdb-application-developer/SKILL.md",
-          "sha256": "f272258c512fac2391353101cd3041ab96e0e350ec18c3739297270fb23a22b2",
-          "bytes": 2611
+          "sha256": "184be2ddf40cddbf95e3ed8540cd597e4b263f3170f685cd56e3d9d80810f2c0",
+          "bytes": 2667
         },
         {
           "path": "skills/azure/azure-cosmosdb-application-developer/metadata.json",
@@ -1641,12 +1641,12 @@
     {
       "id": "azure-cosmosdb-performance-investigator",
       "path": "skills/azure/azure-cosmosdb-performance-investigator",
-      "aggregate_sha256": "e6c40b6eb0d65d0feaa1a324a81a2a1777505e3fd872fa147b41392591a1a678",
+      "aggregate_sha256": "1be7f4aec10cfc285777d6295ec2a8517d90d0fd0a41e348b7ead64fd8563d03",
       "files": [
         {
           "path": "skills/azure/azure-cosmosdb-performance-investigator/SKILL.md",
-          "sha256": "e1c92b8b1802699e9b0b17fbbe73f8991e8fde11cc8c460755bc83e65ffe0e5c",
-          "bytes": 3077
+          "sha256": "52fdca0af07a2e83791e74ed0eb76e9971418f9a4992fd96a150aed7f815e86d",
+          "bytes": 3116
         },
         {
           "path": "skills/azure/azure-cosmosdb-performance-investigator/metadata.json",
@@ -1678,12 +1678,12 @@
     {
       "id": "azure-cosmosdb-platform-operator",
       "path": "skills/azure/azure-cosmosdb-platform-operator",
-      "aggregate_sha256": "1b8f1205ab7627d9edbc54ed8f5ec0a77eafeb32babbba2c24f4259a4ec6d5c0",
+      "aggregate_sha256": "e1630e6dd1404c041ce5326890e42f4b2514d0f9dfedeb2db8c4fbb61486b555",
       "files": [
         {
           "path": "skills/azure/azure-cosmosdb-platform-operator/SKILL.md",
-          "sha256": "b40e613b2bbff8bb6a4be6dc1f0400fc23445980b608bc9ae7b052e79fccfd72",
-          "bytes": 2591
+          "sha256": "d0d09912675f2144283c7e3a653105aede0346ee0d7ee31962872787157c9494",
+          "bytes": 2621
         },
         {
           "path": "skills/azure/azure-cosmosdb-platform-operator/metadata.json",
@@ -1710,12 +1710,12 @@
     {
       "id": "azure-cost-estimation-review",
       "path": "skills/azure/azure-cost-estimation-review",
-      "aggregate_sha256": "00a44230fa934221e0a363d51f4fed645b333592455a7ccc006a8a387ca4f572",
+      "aggregate_sha256": "430ffd5ef9e4954358b048c60a783c70758e52ae3941fe4aeb886abda63bdce4",
       "files": [
         {
           "path": "skills/azure/azure-cost-estimation-review/SKILL.md",
-          "sha256": "76756f0804f3ad57e035d411237f03e5e5b6089b8556accde5d1d9b110db35da",
-          "bytes": 2968
+          "sha256": "3c82bd37bf098fca9a4e79831dded38f2b09e09b03f50be6883788235868ffa7",
+          "bytes": 2998
         },
         {
           "path": "skills/azure/azure-cost-estimation-review/metadata.json",
@@ -1742,12 +1742,12 @@
     {
       "id": "azure-cost-optimization-governor",
       "path": "skills/azure/azure-cost-optimization-governor",
-      "aggregate_sha256": "b9f6165764e37c6220e724a8a3fe5dd228f3f2f2395d4c91b783a1b324e09809",
+      "aggregate_sha256": "d357e62f530677f618edc5a92ad9c2fba3d2a4814062a659d1c8155b0b32cc16",
       "files": [
         {
           "path": "skills/azure/azure-cost-optimization-governor/SKILL.md",
-          "sha256": "94d88f31939c5eddc138d5a9c6d59a6582dec134da440a189ce99de06d5fe2da",
-          "bytes": 3195
+          "sha256": "e367ca74be3250ce5e6c16093d8cd7e45d6665e0633385a8875bea1474feb91f",
+          "bytes": 3225
         },
         {
           "path": "skills/azure/azure-cost-optimization-governor/metadata.json",
@@ -1774,12 +1774,12 @@
     {
       "id": "azure-entra-id-specialist",
       "path": "skills/azure/azure-entra-id-specialist",
-      "aggregate_sha256": "695ec54922f45736131867506e41bc5aceb21f222bce0019aa0f69ebe2182127",
+      "aggregate_sha256": "668cd0a617ed7a22cf3f60efd979222b18806c51cb105fcdb2fa32cc57a9233b",
       "files": [
         {
           "path": "skills/azure/azure-entra-id-specialist/SKILL.md",
-          "sha256": "43b89bc58003aed6a5703755d004edf16bb750ccb234636348dc966f8d73c862",
-          "bytes": 4725
+          "sha256": "7343d9113c70def5adfdcb715c1c6b12522ade42aef234b330d28cae2e312c67",
+          "bytes": 4755
         },
         {
           "path": "skills/azure/azure-entra-id-specialist/metadata.json",
@@ -1816,12 +1816,12 @@
     {
       "id": "azure-governance-policy-guardrails",
       "path": "skills/azure/azure-governance-policy-guardrails",
-      "aggregate_sha256": "fd5908c7a0c72259b6f07cca2f7f8acb4e4f59d24a1dd22a84bcbc28e2ab7e6d",
+      "aggregate_sha256": "88b83963fbac8033e6eeddb114c2afe1af6ff65ce16153f2326256ec39d44734",
       "files": [
         {
           "path": "skills/azure/azure-governance-policy-guardrails/SKILL.md",
-          "sha256": "506860eaafc6b9bfb25db681a75ab0169c29b3f8d14b3a8eaab003a39b8fbfbe",
-          "bytes": 2260
+          "sha256": "295bb1b41f3eb63b423b258f8c01db0075636ebfcb0db1b3833180f03cd78410",
+          "bytes": 2290
         },
         {
           "path": "skills/azure/azure-governance-policy-guardrails/metadata.json",
@@ -1848,12 +1848,12 @@
     {
       "id": "azure-identity-governance-review",
       "path": "skills/azure/azure-identity-governance-review",
-      "aggregate_sha256": "38b4cf81b58a784e67a73b6768772688808bd7a4db292b3185d1402f1a08eea0",
+      "aggregate_sha256": "a5e4c3b590fd19a7abfcc5dc04edc904d74ebba147f831d169716f5087e1c525",
       "files": [
         {
           "path": "skills/azure/azure-identity-governance-review/SKILL.md",
-          "sha256": "1f3039610fe0113537f3422c5794c1e0805f754cad7952daf99b5bb6127c814a",
-          "bytes": 3188
+          "sha256": "eac49e3e235ce16889c317323172aaed9524e79326ea450395c37320169b6000",
+          "bytes": 3218
         },
         {
           "path": "skills/azure/azure-identity-governance-review/metadata.json",
@@ -1880,12 +1880,12 @@
     {
       "id": "azure-key-vault-secret-lifecycle-auditor",
       "path": "skills/azure/azure-key-vault-secret-lifecycle-auditor",
-      "aggregate_sha256": "0c9f18b75bccb8e0d6795700c4ef2b411d8c1f01bf2677a0f11ab8eac462d11d",
+      "aggregate_sha256": "d83c479e87126d4119d201adf27d33c780404b8e34b414fea507bfee7aa93a24",
       "files": [
         {
           "path": "skills/azure/azure-key-vault-secret-lifecycle-auditor/SKILL.md",
-          "sha256": "11e1235f53943fd9f1c82cec78effe053d20e4d4b849e4e309ff97b6deb5580d",
-          "bytes": 3134
+          "sha256": "43ea638ca2a19e89ba8b034eb148c89e4736b7efcafc46c0be92ee1d56954d54",
+          "bytes": 3164
         },
         {
           "path": "skills/azure/azure-key-vault-secret-lifecycle-auditor/metadata.json",
@@ -1912,12 +1912,12 @@
     {
       "id": "azure-keyvault-certificate-issuer-review",
       "path": "skills/azure/azure-keyvault-certificate-issuer-review",
-      "aggregate_sha256": "f3bc515cddfbb21723eba6a50a1d67800d7b38268a47bf01ad70225358e81db5",
+      "aggregate_sha256": "3a1e9dbb4ee001c84f4a9bc8fed92f43227bfe24187254aba15cdd4dd2a5e3d2",
       "files": [
         {
           "path": "skills/azure/azure-keyvault-certificate-issuer-review/SKILL.md",
-          "sha256": "d133973751feb58cce073f8e4f759069464a4b428e71aaefec0e30dcd5c40e61",
-          "bytes": 2814
+          "sha256": "d64c972d306ddfda7cccdc28f3ae3fcc204d7ba85e24916e8a0db49f062d21a1",
+          "bytes": 2844
         },
         {
           "path": "skills/azure/azure-keyvault-certificate-issuer-review/metadata.json",
@@ -1934,12 +1934,12 @@
     {
       "id": "azure-landing-zone-architect",
       "path": "skills/azure/azure-landing-zone-architect",
-      "aggregate_sha256": "60c77c5c6499a752a93cd2faab7f9b35e3852416e7ca16f4b5a45ec2e7b2d6c3",
+      "aggregate_sha256": "439af2d57f24904f44588315f765334ab3b8a708dc24bcb3bed69975ce6d7330",
       "files": [
         {
           "path": "skills/azure/azure-landing-zone-architect/SKILL.md",
-          "sha256": "69865a1fcb1e3232fbe4bff5c7e3b8c1a64aedc9ef47bfed87f740a1b4cf6e25",
-          "bytes": 2794
+          "sha256": "4736a436501771ab07ba4d03bcce8f75420a1b05df071e7fded76858862872dc",
+          "bytes": 2824
         },
         {
           "path": "skills/azure/azure-landing-zone-architect/metadata.json",
@@ -1966,12 +1966,12 @@
     {
       "id": "azure-live-aks-rollout-guard",
       "path": "skills/azure/azure-live-aks-rollout-guard",
-      "aggregate_sha256": "7b2e98490e6254530c986cff0b13086e40e7bea304c2e8604e24d8f13b45e010",
+      "aggregate_sha256": "b49d9076d4e3a512114acc6c0fe499d3cb727d0bf3556cb71f009ea35228fcec",
       "files": [
         {
           "path": "skills/azure/azure-live-aks-rollout-guard/SKILL.md",
-          "sha256": "5a87aa375e2085e829e9f7ace47d80bb2d2f4be42977a175de6aa9807cfe9bbc",
-          "bytes": 2166
+          "sha256": "9c760020e6ceb0fab14e5b5d0a85f8e043b651bc98b57f7383ea86789bc684fb",
+          "bytes": 2205
         },
         {
           "path": "skills/azure/azure-live-aks-rollout-guard/metadata.json",
@@ -2003,12 +2003,12 @@
     {
       "id": "azure-live-app-service-slot-swap-guard",
       "path": "skills/azure/azure-live-app-service-slot-swap-guard",
-      "aggregate_sha256": "f1ded001400c62100ae0c007cc69a771d955a3b0c7a12959ab1638e11d7da72a",
+      "aggregate_sha256": "26e0258b56605c4334b4a59a145ad1e13019c54c980edcf359695b4e8d86c192",
       "files": [
         {
           "path": "skills/azure/azure-live-app-service-slot-swap-guard/SKILL.md",
-          "sha256": "b0c7b4e4b0169e63a6af0a6c4992655ee711d1fa54b8cc1aa230d23c24217956",
-          "bytes": 2236
+          "sha256": "5ab5dfc272ed707e046814e3bff6b98f8f7f034aec85c9563aa707c4fbedd68c",
+          "bytes": 2275
         },
         {
           "path": "skills/azure/azure-live-app-service-slot-swap-guard/metadata.json",
@@ -2040,12 +2040,12 @@
     {
       "id": "azure-live-arm-deployment-stack-guard",
       "path": "skills/azure/azure-live-arm-deployment-stack-guard",
-      "aggregate_sha256": "ca6a65f3dd11e3050f5002beadc64ad09bb599d4cce708ac032c3231299e1c33",
+      "aggregate_sha256": "35534546e44f7f88f0744d004a15fc85588ba73f8e6ff64be63a1e4310260254",
       "files": [
         {
           "path": "skills/azure/azure-live-arm-deployment-stack-guard/SKILL.md",
-          "sha256": "725829d8ae934825dab7f87093a67b84e1f63af70e66996a31407a3c3b578205",
-          "bytes": 2223
+          "sha256": "52933869d0b4b876129cf4385e3691f4e11082c2eb63e5e69b3663dec843f252",
+          "bytes": 2262
         },
         {
           "path": "skills/azure/azure-live-arm-deployment-stack-guard/metadata.json",
@@ -2077,12 +2077,12 @@
     {
       "id": "azure-live-cost-budget-action-guard",
       "path": "skills/azure/azure-live-cost-budget-action-guard",
-      "aggregate_sha256": "fb897ff5dc4baa7a2f19c52020ab2b645a5edeb32b01a9838151608880984616",
+      "aggregate_sha256": "6be302bbedf3f4533c004c66d74199ac1f4e7bb2f90f9b710e4a785df81b863a",
       "files": [
         {
           "path": "skills/azure/azure-live-cost-budget-action-guard/SKILL.md",
-          "sha256": "ace2d50fbf78779cb3d811bebf3d9429de7db44383c4647104c59102ab407c01",
-          "bytes": 2223
+          "sha256": "aca60ff19307224e1823153569064339a5605bb280ec776448a4573d89b5fb3b",
+          "bytes": 2262
         },
         {
           "path": "skills/azure/azure-live-cost-budget-action-guard/metadata.json",
@@ -2114,12 +2114,12 @@
     {
       "id": "azure-live-entra-role-assignment-guard",
       "path": "skills/azure/azure-live-entra-role-assignment-guard",
-      "aggregate_sha256": "0e19748c3c042caf393c2010618696fc5d765ce47356cef633d27d2dcf12f5d1",
+      "aggregate_sha256": "8fe1476d6c8e036b1bca56255abb241b351161aaf6c1f505f6e113805f950450",
       "files": [
         {
           "path": "skills/azure/azure-live-entra-role-assignment-guard/SKILL.md",
-          "sha256": "ff6214a6e6fe6783c5d504b5923c397d2c8b3dbfb4eef569be57cfc75fcb330e",
-          "bytes": 3486
+          "sha256": "01e5912893a6408ac211a6e9dd786bf9dc94c13c00679a0389d4457e8a065d42",
+          "bytes": 3525
         },
         {
           "path": "skills/azure/azure-live-entra-role-assignment-guard/metadata.json",
@@ -2151,12 +2151,12 @@
     {
       "id": "azure-live-keyvault-rotation-purge-guard",
       "path": "skills/azure/azure-live-keyvault-rotation-purge-guard",
-      "aggregate_sha256": "d51904de4190032ecec54887758ac3f25a32e90fede361be52533e65833d02c1",
+      "aggregate_sha256": "569aec5d168e455c6947c0a54e70dde286a3edbbf1e9963d92ca426963e1d7b8",
       "files": [
         {
           "path": "skills/azure/azure-live-keyvault-rotation-purge-guard/SKILL.md",
-          "sha256": "56733e2b0a57f0083c85fa10c6373ab1809782cc25659777c18fe3181605f3b6",
-          "bytes": 2238
+          "sha256": "8fab7759f8dc67f03eb82aac0f93bb3c1be1c6bb9c3404312232dde4eb720cd3",
+          "bytes": 2277
         },
         {
           "path": "skills/azure/azure-live-keyvault-rotation-purge-guard/metadata.json",
@@ -2188,12 +2188,12 @@
     {
       "id": "azure-live-pim-jit-activation-guard",
       "path": "skills/azure/azure-live-pim-jit-activation-guard",
-      "aggregate_sha256": "84849b594d3a996172d036bbccfb5ed2abe828e672319dc1dc6257a08c619220",
+      "aggregate_sha256": "c42e3af7e62d65c09f53bec806fae95e58025e3f80ae06ca36019160f1aa53c3",
       "files": [
         {
           "path": "skills/azure/azure-live-pim-jit-activation-guard/SKILL.md",
-          "sha256": "9bfb0625840d9d6de3e49ac5d58afc6ec52d2e38633f049344c47aa4ab43084d",
-          "bytes": 2231
+          "sha256": "9d8d68ef5540607d7fa4e9686af0bca80d924e10493bdc8fd298a1d0a02afb2f",
+          "bytes": 2270
         },
         {
           "path": "skills/azure/azure-live-pim-jit-activation-guard/metadata.json",
@@ -2225,12 +2225,12 @@
     {
       "id": "azure-maestro",
       "path": "skills/azure/azure-maestro",
-      "aggregate_sha256": "20875fd3bd092bef6f907cbd59523b18c38b0e4acc48fbd39db4d3727f9ac654",
+      "aggregate_sha256": "9d14316c1df264916a92445d50eeb6fd7071a822a893746ec612f7d9595c3859",
       "files": [
         {
           "path": "skills/azure/azure-maestro/SKILL.md",
-          "sha256": "9340de10baacd355d3a6eb8a05160519129e9e473d8f8b36b82abe00fc1934cd",
-          "bytes": 11475
+          "sha256": "49e6b6f691461366587fb8b3c053a7d2158308182ae9cc86c375b84271ba1f0b",
+          "bytes": 11517
         },
         {
           "path": "skills/azure/azure-maestro/metadata.json",
@@ -2242,12 +2242,12 @@
     {
       "id": "azure-migrate-landing-zone-cutover",
       "path": "skills/azure/azure-migrate-landing-zone-cutover",
-      "aggregate_sha256": "20bc6b78fe5ab52c37cc6beda7016f1690c26bebadd457f1078aabd8ce5363af",
+      "aggregate_sha256": "fb4d1ecad30051be78fddb97800634de9786362ec7774877af3992eb3a9c8791",
       "files": [
         {
           "path": "skills/azure/azure-migrate-landing-zone-cutover/SKILL.md",
-          "sha256": "db38963f358d9e863d10d49774c083480ffc93bc47436011617cdf8e3f651f24",
-          "bytes": 2931
+          "sha256": "9f9027943e9a3b6a6934c84b0851bc04af660917e8ba9e5006041771508c476a",
+          "bytes": 2961
         },
         {
           "path": "skills/azure/azure-migrate-landing-zone-cutover/metadata.json",
@@ -2274,12 +2274,12 @@
     {
       "id": "azure-network-topology-review",
       "path": "skills/azure/azure-network-topology-review",
-      "aggregate_sha256": "a030071db8bf94ceadeed30c6a0793b3bf346ef9c3407fb8cefa6ed8998c6775",
+      "aggregate_sha256": "02af38822d0ebba790d8f3ac05521a7e92fd6990b1bc5dd75fa0c08ff15658ca",
       "files": [
         {
           "path": "skills/azure/azure-network-topology-review/SKILL.md",
-          "sha256": "c35eb7c29b75c21457500b65c6050f304b1a21447d5196d6b9fb834ecd84124b",
-          "bytes": 3164
+          "sha256": "61a52ea29db4094141ddc4cb2f40e0b8aa407a4ef6592cd218548e6967788ef5",
+          "bytes": 3194
         },
         {
           "path": "skills/azure/azure-network-topology-review/metadata.json",
@@ -2306,12 +2306,12 @@
     {
       "id": "azure-observability-investigator",
       "path": "skills/azure/azure-observability-investigator",
-      "aggregate_sha256": "1db51941aaad7f2674a3c90a28b353095fae34a25affbc65654642af3fd1c6f5",
+      "aggregate_sha256": "65670ebd4d125606833fa27e80c11493ed0a229f3b9e6fafe9a11cba322eb577",
       "files": [
         {
           "path": "skills/azure/azure-observability-investigator/SKILL.md",
-          "sha256": "0eab0c95365b399b156be7df087532f83a0b810dba498935e5d5d59da3616951",
-          "bytes": 2844
+          "sha256": "e308137ced314347cfe0276acbc4adc5ded82a78d36198172a14ce95331ff63f",
+          "bytes": 2883
         },
         {
           "path": "skills/azure/azure-observability-investigator/metadata.json",
@@ -2338,12 +2338,12 @@
     {
       "id": "azure-platform-automation-devops",
       "path": "skills/azure/azure-platform-automation-devops",
-      "aggregate_sha256": "8fee21b12a3538d4490d223cbe2ebd15c3abb29059aa67c9cdf7c8d574785e2f",
+      "aggregate_sha256": "38939919ff80e94d846450f4f78d7854ae177295a08980c9255f574a1b245c96",
       "files": [
         {
           "path": "skills/azure/azure-platform-automation-devops/SKILL.md",
-          "sha256": "8b94a2521f19077b5b13f10d09e8e038d7054bac467dbc30c94be7c660110a77",
-          "bytes": 3526
+          "sha256": "e997571a2341d77c4e66e9b51a64fa320402fb66d5414afb0d98ca8ec6735015",
+          "bytes": 3556
         },
         {
           "path": "skills/azure/azure-platform-automation-devops/metadata.json",
@@ -2370,12 +2370,12 @@
     {
       "id": "azure-private-endpoint-adoption-planner",
       "path": "skills/azure/azure-private-endpoint-adoption-planner",
-      "aggregate_sha256": "bae893e046f4192e6162b986dfdab45c4ea6a44f01e01391c6aa5b4addf6f909",
+      "aggregate_sha256": "3abc1e8c1b235ae5d8fb28fca1d68d7ae9b10c97a4d6bb0f187d34a1c09d45d7",
       "files": [
         {
           "path": "skills/azure/azure-private-endpoint-adoption-planner/SKILL.md",
-          "sha256": "2fc5341ee53bbe86eac3a4457d03a854a28ac899551e3a6630c4a9b6621dff2d",
-          "bytes": 3379
+          "sha256": "6b4715cea7d22976489a973894bc25a2761f8c05f58d7d0ff8b1b923b2f4fbb3",
+          "bytes": 3418
         },
         {
           "path": "skills/azure/azure-private-endpoint-adoption-planner/metadata.json",
@@ -2402,12 +2402,12 @@
     {
       "id": "azure-rbac-review",
       "path": "skills/azure/azure-rbac-review",
-      "aggregate_sha256": "f963bbf1e0a24f693e13b0980622d51eeb07a0537950f52505e4eaeef350fbc7",
+      "aggregate_sha256": "af1066cc3ffe5626344e576e69c5e1a9c2c419c821712f697c8c8b628b00344f",
       "files": [
         {
           "path": "skills/azure/azure-rbac-review/SKILL.md",
-          "sha256": "bc3823971329200aa337a84f14bea5b95423a8f326d62a69017704abc431296c",
-          "bytes": 1663
+          "sha256": "ae150f3070ae5d1a3f7f20660f63fc3652382cc2c346a187931797a5d2cb6235",
+          "bytes": 1693
         },
         {
           "path": "skills/azure/azure-rbac-review/metadata.json",
@@ -2434,12 +2434,12 @@
     {
       "id": "azure-resilience-bcdr-review",
       "path": "skills/azure/azure-resilience-bcdr-review",
-      "aggregate_sha256": "e60b339a16de1404db03bdf6d2a59df0cd6756d8ba46e872ea50360baaf7ce61",
+      "aggregate_sha256": "25397c8b82dfe15dd854bc7b2dab4f40dc6df6a41b868848c6e3bf54b280c1e4",
       "files": [
         {
           "path": "skills/azure/azure-resilience-bcdr-review/SKILL.md",
-          "sha256": "80a1ce99a7281d6ad95f0ebe38456d2e1774aa8c6edccaf8aa925cfc171859a1",
-          "bytes": 3072
+          "sha256": "59b8d4a58ba159eca5d21a28da5bc81cdcd693de970859f97c7d52a2b33c7a6a",
+          "bytes": 3102
         },
         {
           "path": "skills/azure/azure-resilience-bcdr-review/metadata.json",
@@ -2466,12 +2466,12 @@
     {
       "id": "azure-resource-health-incident-triage",
       "path": "skills/azure/azure-resource-health-incident-triage",
-      "aggregate_sha256": "094cd2c9df4b6d2ba9c9ab79f0198a0d3e256ac1b35100972bd2a81f9a2c745a",
+      "aggregate_sha256": "a7bdbdad84fe85619c78cbcdf7c11879f68c3d54df5de180263c275f20603136",
       "files": [
         {
           "path": "skills/azure/azure-resource-health-incident-triage/SKILL.md",
-          "sha256": "9f6f87fbbea6bcde856b5fff1858eb9f35bc48bec4cdb91b3cac9c83a5ea2476",
-          "bytes": 3303
+          "sha256": "f562ba194b299ca71cc639f65b634bc1c44903d32a833b9f1e0a683b3c001b02",
+          "bytes": 3333
         },
         {
           "path": "skills/azure/azure-resource-health-incident-triage/metadata.json",
@@ -2498,12 +2498,12 @@
     {
       "id": "azure-role-selector",
       "path": "skills/azure/azure-role-selector",
-      "aggregate_sha256": "33104a629c2b8f2695452edc90d7dbccccb68849c00a73308ede6b958b778393",
+      "aggregate_sha256": "ac803186743642275215508ff70a44ddbe3addeeb2c0be9e7ef646fdc21b41c9",
       "files": [
         {
           "path": "skills/azure/azure-role-selector/SKILL.md",
-          "sha256": "d8981cc6abd30eae03ff52c7f5a3b4c427ccb7e7da4e67f8cb795f09a8b07f58",
-          "bytes": 2231
+          "sha256": "afbe39cd784ef2eb1c9732c32559d4950f7409595924d8a56989b24965bdecf2",
+          "bytes": 2261
         },
         {
           "path": "skills/azure/azure-role-selector/metadata.json",
@@ -2530,12 +2530,12 @@
     {
       "id": "azure-security-posture-hardening",
       "path": "skills/azure/azure-security-posture-hardening",
-      "aggregate_sha256": "46bbe27fdc1aa41ad67b8e7008417b113e0042f52e320091b25c7a5da078ad85",
+      "aggregate_sha256": "915734d79aa93cf16e962d13a44c04bf2f7497cb4b9e812032e275f13dea02ba",
       "files": [
         {
           "path": "skills/azure/azure-security-posture-hardening/SKILL.md",
-          "sha256": "691b68fa5f849aa5bd63b321c433652a0ac66e827d01a4f9078db1084fefecdd",
-          "bytes": 2594
+          "sha256": "c37566cda5d06c2661563eb22234235168064b1d2f078f3de6b2dfe8f2478045",
+          "bytes": 2624
         },
         {
           "path": "skills/azure/azure-security-posture-hardening/metadata.json",
@@ -2562,12 +2562,12 @@
     {
       "id": "azure-subscription-resource-organization",
       "path": "skills/azure/azure-subscription-resource-organization",
-      "aggregate_sha256": "8a6f0adbae807f0d41445a464fcc280436cf50e45b314fa2933fab1bc8719aa0",
+      "aggregate_sha256": "209076d16e9abfdf1fffd5033404df411ad398aa3e4ee0a200a8e214d695523d",
       "files": [
         {
           "path": "skills/azure/azure-subscription-resource-organization/SKILL.md",
-          "sha256": "71ba6f22ba05dbd37c5cbdab33f3f6d3589ae88015b58f65b8062679484fb3bf",
-          "bytes": 3285
+          "sha256": "3cf1d188e2608e7f1a681fb5fbb8380e1b3e708d364c06bb7991cfda03ea0fcd",
+          "bytes": 3315
         },
         {
           "path": "skills/azure/azure-subscription-resource-organization/metadata.json",
@@ -2594,12 +2594,12 @@
     {
       "id": "backstage-scaffolder-template-review",
       "path": "skills/backstage/backstage-scaffolder-template-review",
-      "aggregate_sha256": "892d7c76026e937a9fedcf50c71574f9ceeb52d768f9553b5f7cc93dd86b6f76",
+      "aggregate_sha256": "c72a70f4b16ac6f0ccddfb6477f06c8cb943c582bbd29467310ff80bb4899c31",
       "files": [
         {
           "path": "skills/backstage/backstage-scaffolder-template-review/SKILL.md",
-          "sha256": "f7eaa2137059d65b8c7c974bc7d676fe8aa88d0f385e95bc3c299be780da32a9",
-          "bytes": 2842
+          "sha256": "6277080a4cb978e0663b62a0bd32a310a9bc1201ea46469331a6e815f950bb82",
+          "bytes": 2872
         },
         {
           "path": "skills/backstage/backstage-scaffolder-template-review/metadata.json",
@@ -2616,12 +2616,12 @@
     {
       "id": "cert-manager-issuer-trust-review",
       "path": "skills/cert-manager/cert-manager-issuer-trust-review",
-      "aggregate_sha256": "7519e8dc031609d96c3a4f1d033ba869b446ecb08bdec24f86db09a736bf0aca",
+      "aggregate_sha256": "1d664f73b6fd2e969481d2fbac3a5818a122388bb5670c06b576ba9290ecebbd",
       "files": [
         {
           "path": "skills/cert-manager/cert-manager-issuer-trust-review/SKILL.md",
-          "sha256": "84d6d4a4f5ab87b82a0423e68403ea258c6ae195fc620094d2c733a4a0336a7c",
-          "bytes": 3188
+          "sha256": "b1feedf897a808c1811954f9f6c793de62bbbc3df9bf656a3f9b6e650bd0d73e",
+          "bytes": 3218
         },
         {
           "path": "skills/cert-manager/cert-manager-issuer-trust-review/metadata.json",
@@ -2638,12 +2638,12 @@
     {
       "id": "cilium-network-policy-review",
       "path": "skills/cilium/cilium-network-policy-review",
-      "aggregate_sha256": "126620084f05e0a65dd9d1382dfc8de2f5be3b35f83b173af609e8f9c46fe156",
+      "aggregate_sha256": "1261cc74641b9a63b0a9352a5b26760c5f528a7b88ceba919b7005db35bcfd17",
       "files": [
         {
           "path": "skills/cilium/cilium-network-policy-review/SKILL.md",
-          "sha256": "77a55c4901a0dcb42912cfe7b40afd29ccb703759cfd231bd679d206cf78bec3",
-          "bytes": 3847
+          "sha256": "413ee8304aa581f6aaf6aad0f9e4216e9143ce8828ed0ddd73bf22b18bb1cbcd",
+          "bytes": 3877
         },
         {
           "path": "skills/cilium/cilium-network-policy-review/metadata.json",
@@ -2670,12 +2670,12 @@
     {
       "id": "external-secrets-operator-review",
       "path": "skills/kubernetes/external-secrets-operator-review",
-      "aggregate_sha256": "ae87b69885abc1d23f2266aa4daa5083fe9f42c7e266c5c351d132e505d35d9f",
+      "aggregate_sha256": "8af500b390ea7f898d816d4481548cdb30f0745389b980f2b1176babb0c6a51b",
       "files": [
         {
           "path": "skills/kubernetes/external-secrets-operator-review/SKILL.md",
-          "sha256": "859b260c80fe74c09d8f92b8d75f83674a8578a8423ff153d91022483faa70ac",
-          "bytes": 3565
+          "sha256": "ab28ffbf928a7bf349477cd6c0505ef363727859d7990b6028ce0579df001831",
+          "bytes": 3595
         },
         {
           "path": "skills/kubernetes/external-secrets-operator-review/metadata.json",
@@ -2692,12 +2692,12 @@
     {
       "id": "falco-runtime-threat-rules-review",
       "path": "skills/falco/falco-runtime-threat-rules-review",
-      "aggregate_sha256": "8e1a8258caf3450fa39ca615c8f5c150e8863085b459193da922e74f7ed130bf",
+      "aggregate_sha256": "e63728511049c6b49d9bb3e58605084b65ce488cb69ba4b589acd79b15bbe2f5",
       "files": [
         {
           "path": "skills/falco/falco-runtime-threat-rules-review/SKILL.md",
-          "sha256": "2131447590781bf510b87ac076668b6442ddf1057b55498e911492afd451ec41",
-          "bytes": 3257
+          "sha256": "a3f82f37b9e43dd52b2feb7dabc852d1c8c7d4cd5b45684806dea952ef33c4e4",
+          "bytes": 3287
         },
         {
           "path": "skills/falco/falco-runtime-threat-rules-review/metadata.json",
@@ -2714,12 +2714,12 @@
     {
       "id": "finops-cloud-price-advisor",
       "path": "skills/finops/finops-cloud-price-advisor",
-      "aggregate_sha256": "d8ab8926653b171da6dedfa41ea4bfd0a55e25c63ddbed9b561dc2db6a7e9172",
+      "aggregate_sha256": "1865d7e1309f883403d1d7bac9922e38bd340199cc71551f8ac5c051d75afbdf",
       "files": [
         {
           "path": "skills/finops/finops-cloud-price-advisor/SKILL.md",
-          "sha256": "8481de51958f204cb3dbf91b5079fb66517bb3645d9b64550cfafb5700216228",
-          "bytes": 3684
+          "sha256": "af5b9e6f66d89adff1b70ad6cc2159928d7233fe128f4f65f810ebc94bf31f22",
+          "bytes": 3723
         },
         {
           "path": "skills/finops/finops-cloud-price-advisor/metadata.json",
@@ -2751,12 +2751,12 @@
     {
       "id": "fluxcd-kustomization-helmrelease-review",
       "path": "skills/fluxcd/fluxcd-kustomization-helmrelease-review",
-      "aggregate_sha256": "d38f19fb8940e46c6573ffc99536efd97e50915336dd1e9de88dcbe195cbbdcb",
+      "aggregate_sha256": "3ec3410a10f6f893ddc31d73a76010e6c72ed33fe8b4fe8f5a3c1f4335b3c5a8",
       "files": [
         {
           "path": "skills/fluxcd/fluxcd-kustomization-helmrelease-review/SKILL.md",
-          "sha256": "ba5f9d9a9386363010299d6e8f04795826c4a5ca16b1f87cd5467ef73b709fa8",
-          "bytes": 3120
+          "sha256": "5bf8fbac170a9c6aed465b7a3916ec00813fc3d0df7929521f1aae6999289a7f",
+          "bytes": 3150
         },
         {
           "path": "skills/fluxcd/fluxcd-kustomization-helmrelease-review/metadata.json",
@@ -2773,12 +2773,12 @@
     {
       "id": "istio-ambient-mesh-review",
       "path": "skills/istio/istio-ambient-mesh-review",
-      "aggregate_sha256": "f5ba5707a7b2b58141308e26252ed27a2fc9720695279e9f4b65bdc17bb87b1c",
+      "aggregate_sha256": "aa16a16d37a98ae8e9e2c06b8cc5ccf8e21e0034d4a15f733790acdfb8fdb709",
       "files": [
         {
           "path": "skills/istio/istio-ambient-mesh-review/SKILL.md",
-          "sha256": "7aec0daf9c7926858f61b0f845c4cb4b50b2f75e0c6c7f5e888210a11960c627",
-          "bytes": 3633
+          "sha256": "71ba2d816f32e2da7cba16e92162ac031be24a5db7172af0999d56b4c23441e4",
+          "bytes": 3663
         },
         {
           "path": "skills/istio/istio-ambient-mesh-review/metadata.json",
@@ -2805,12 +2805,12 @@
     {
       "id": "kubecost-chargeback-allocation-review",
       "path": "skills/kubernetes/kubecost-chargeback-allocation-review",
-      "aggregate_sha256": "71018e6509baf478fef056cacb7a2cabf3703b0386dc1ccc572f5c516c8bfd36",
+      "aggregate_sha256": "eff917c1aa21ba572f10c8b14ebba15d42ded272688ef020520dbf2f1788643d",
       "files": [
         {
           "path": "skills/kubernetes/kubecost-chargeback-allocation-review/SKILL.md",
-          "sha256": "06e9781640a8f662360fbaa138f2e7bc850d1ff74b0075cb60fb30573c017cfc",
-          "bytes": 2962
+          "sha256": "b25e38dacfdd4895c3a9a1bb705ae6d3ade1f1397232fc6afbec78b1a1cab012",
+          "bytes": 2992
         },
         {
           "path": "skills/kubernetes/kubecost-chargeback-allocation-review/metadata.json",
@@ -2827,12 +2827,12 @@
     {
       "id": "kubernetes-live-rbac-mutation-guard",
       "path": "skills/kubernetes/kubernetes-live-rbac-mutation-guard",
-      "aggregate_sha256": "d30fe5bced7d4fcfeea5b4a9bbd05e1a3db49b77d0c50c43ec079439bdd92946",
+      "aggregate_sha256": "f2c6f24e9dd9ebd87ce6f9f0ff181fb50a043f96e2385eb096ea5a871a486e90",
       "files": [
         {
           "path": "skills/kubernetes/kubernetes-live-rbac-mutation-guard/SKILL.md",
-          "sha256": "2e94c31d0a992dc998bcf296bdc10db7dfd46e3464220e2456186edead48c525",
-          "bytes": 3797
+          "sha256": "9dbf05f8bf53aebccd837dc7fedd5b8aafa76f701ec9bd1903fd7c691b567815",
+          "bytes": 3836
         },
         {
           "path": "skills/kubernetes/kubernetes-live-rbac-mutation-guard/metadata.json",
@@ -2864,12 +2864,12 @@
     {
       "id": "kubernetes-maestro",
       "path": "skills/kubernetes/kubernetes-maestro",
-      "aggregate_sha256": "75b2b8eacff77b20602a518c79ec72d32a5c39c5094f72d34f7316145d9f5ab4",
+      "aggregate_sha256": "20c8ac391350826e2195fcf0096fbf2c3448c8f6469de3409a15b120ac857cd3",
       "files": [
         {
           "path": "skills/kubernetes/kubernetes-maestro/SKILL.md",
-          "sha256": "dccafcb3c855955546b256e55faaad9bfa8f5cc1ae84d4cc6e53cdd355a55af9",
-          "bytes": 2577
+          "sha256": "1141ffc5f4d55ab44a3d46fa1c2c7414a76d6ba20fc0a2123af75ff4fc1eb194",
+          "bytes": 2619
         },
         {
           "path": "skills/kubernetes/kubernetes-maestro/metadata.json",
@@ -2891,12 +2891,12 @@
     {
       "id": "kubernetes-pod-security-admission-review",
       "path": "skills/kubernetes/kubernetes-pod-security-admission-review",
-      "aggregate_sha256": "fb2a0affd9783a7d7c821a69d14e938076ed1169b09b06d2491a563d810053c4",
+      "aggregate_sha256": "1ec2b952b954e25d878e2d640555fe609ed1914f3b00c748990d4869d20a9e15",
       "files": [
         {
           "path": "skills/kubernetes/kubernetes-pod-security-admission-review/SKILL.md",
-          "sha256": "ef39409ba93bec4a21a873d96943be19fcde5f7b6786aa4e41003b3e4b167ca0",
-          "bytes": 3523
+          "sha256": "45bf8f64bfa36a2d4b54e42c47efd311f3eda8576fbe5eff7308c54ecd35187d",
+          "bytes": 3553
         },
         {
           "path": "skills/kubernetes/kubernetes-pod-security-admission-review/metadata.json",
@@ -2923,12 +2923,12 @@
     {
       "id": "kubernetes-pod-spec-review",
       "path": "skills/kubernetes/kubernetes-pod-spec-review",
-      "aggregate_sha256": "dbb43082ff01f0f504f37c8c8258693ee85055dacc209f9b6bafda95bc4e8657",
+      "aggregate_sha256": "4312cd67dcb40ae0e28c4695c1bcb09230a956c2b2b0591978047207c9351a58",
       "files": [
         {
           "path": "skills/kubernetes/kubernetes-pod-spec-review/SKILL.md",
-          "sha256": "6babd07bba88c384e70df7cfa7c682a3a487c8cccb16dfb6b23c221f7fe9eca5",
-          "bytes": 2425
+          "sha256": "c3e13b5bd41132c9a87531ca2605eff8633e2453f99e3e9398b49124d5d24cfe",
+          "bytes": 2455
         },
         {
           "path": "skills/kubernetes/kubernetes-pod-spec-review/metadata.json",
@@ -2945,12 +2945,12 @@
     {
       "id": "kubernetes-rbac-review",
       "path": "skills/kubernetes/kubernetes-rbac-review",
-      "aggregate_sha256": "c80216d93bec97862b53c7df20624ab73bdc6cb1a3fd622b5ff2fbc59a590f13",
+      "aggregate_sha256": "1848b4124db3035ec3adbbbabd19426ae43135b3713a2a256e60f1756bad2352",
       "files": [
         {
           "path": "skills/kubernetes/kubernetes-rbac-review/SKILL.md",
-          "sha256": "51c178e867a6113f1c0b2dbe452cd8ba2a8bc72b6c3c87d28d2c93c79f3fa3f6",
-          "bytes": 1986
+          "sha256": "fa2f4f99c7419e70899cd84e4d3dfa4e907452be7f4a81d7d3150b426f30c148",
+          "bytes": 2016
         },
         {
           "path": "skills/kubernetes/kubernetes-rbac-review/metadata.json",
@@ -2977,12 +2977,12 @@
     {
       "id": "kubernetes-workload-identity-review",
       "path": "skills/kubernetes/kubernetes-workload-identity-review",
-      "aggregate_sha256": "b58432f005b6d0f1716ddf0cb375be9dfced5d53420e554f6889d00420739f2a",
+      "aggregate_sha256": "594d9fc8fd92ad8bada4f0a1b2ff45dbde7e4fc6cd6b6cba8d281edab4349f0a",
       "files": [
         {
           "path": "skills/kubernetes/kubernetes-workload-identity-review/SKILL.md",
-          "sha256": "bf5fd40681a1efca2e04c5b089d3cfd988d7f3342c9cc663cfaa0666ce7aa198",
-          "bytes": 3719
+          "sha256": "0abc6e3b087469ebe42fdd339d576c3dfabc9d04afc9974ecf405e23383bf0b2",
+          "bytes": 3749
         },
         {
           "path": "skills/kubernetes/kubernetes-workload-identity-review/metadata.json",
@@ -3009,12 +3009,12 @@
     {
       "id": "kyverno-policy-review",
       "path": "skills/kyverno/kyverno-policy-review",
-      "aggregate_sha256": "c2f048269493519fe266880900459dc470072fe6518f8a7022bc7fc5a9efd40b",
+      "aggregate_sha256": "a4bc7c5b07e71c342081f7c2cfff9a737e1ab0d8f55e77261cf210a49f914921",
       "files": [
         {
           "path": "skills/kyverno/kyverno-policy-review/SKILL.md",
-          "sha256": "0b645042adf772eac32f4dfc6190c2df882de71b22e5c57a82a7eb48366a60f7",
-          "bytes": 3510
+          "sha256": "5eb1b1503c57d899a650c556cc109f5018293b2620970189f1d0620c70ab24c8",
+          "bytes": 3540
         },
         {
           "path": "skills/kyverno/kyverno-policy-review/metadata.json",
@@ -3041,12 +3041,12 @@
     {
       "id": "oci-autonomous-database-architect",
       "path": "skills/oci/oci-autonomous-database-architect",
-      "aggregate_sha256": "b91446c2a0ea23ec9915101b04a33b02b979bbd36a359ef13af9a45945825674",
+      "aggregate_sha256": "1f999f351c946767a44cfa87c73426aa07e3b019e64c9650fb8abfdc790d678c",
       "files": [
         {
           "path": "skills/oci/oci-autonomous-database-architect/SKILL.md",
-          "sha256": "fc60b3228f215490fcc032f1fed10c7d32b9e2449a5c62d0a2de35865cd4820f",
-          "bytes": 8670
+          "sha256": "62c21de12694dd7eb1fb5e16ed0c6fc3628f4aff44ce352b5ff37a1eb6064d1e",
+          "bytes": 8700
         },
         {
           "path": "skills/oci/oci-autonomous-database-architect/metadata.json",
@@ -3083,12 +3083,12 @@
     {
       "id": "oci-certificates-issuer-review",
       "path": "skills/oci/oci-certificates-issuer-review",
-      "aggregate_sha256": "5b7f7ef4ea7764b384cb5e5ad3e8f92d53da651373222961efcf915c0d64c611",
+      "aggregate_sha256": "eb4e8b8f56912f105b50db9478d0d656c95f4b2a244cfdf209241dff66a01b87",
       "files": [
         {
           "path": "skills/oci/oci-certificates-issuer-review/SKILL.md",
-          "sha256": "94f3f2d1674f17cab7fc61386e8f687721611eba640c7234f13c583b81befb8f",
-          "bytes": 2669
+          "sha256": "c315ba57c9dbac4896edd5262073aa7527e692e937caa831e454d6595b4fcd09",
+          "bytes": 2699
         },
         {
           "path": "skills/oci/oci-certificates-issuer-review/metadata.json",
@@ -3105,12 +3105,12 @@
     {
       "id": "oci-cloud-guard-responder",
       "path": "skills/oci/oci-cloud-guard-responder",
-      "aggregate_sha256": "0abb87aec32ecadad179fe33975d2a793986d7ea67ad08714cf0b36ad8d5e8b8",
+      "aggregate_sha256": "042f1f482c0c5696e29f4400897d3028de8a641ec4787c91a56f0be0e66b3068",
       "files": [
         {
           "path": "skills/oci/oci-cloud-guard-responder/SKILL.md",
-          "sha256": "7413c16349b7a1b969c655ca0acef342f7fa8925270a839e6c44d80819da73bf",
-          "bytes": 5615
+          "sha256": "58d1cb551e25aa733f2712e2186282b8b24704425511f3dd1fae6a685d7bc3de",
+          "bytes": 5654
         },
         {
           "path": "skills/oci/oci-cloud-guard-responder/metadata.json",
@@ -3137,12 +3137,12 @@
     {
       "id": "oci-compute-instance-agent-operator",
       "path": "skills/oci/oci-compute-instance-agent-operator",
-      "aggregate_sha256": "8efd4d0f94cba7203ef396526cb7f185595b669d378c7485a980784d7cec392c",
+      "aggregate_sha256": "abe4690b2b1a0a16dc87034442241245280c9d8df5dff710c1aa04cf98a2cb0f",
       "files": [
         {
           "path": "skills/oci/oci-compute-instance-agent-operator/SKILL.md",
-          "sha256": "ae0c114e958c32f585faa1e42bd39ba8b913f2c5279b32942aabcd2e3f75da69",
-          "bytes": 5529
+          "sha256": "f2988df903b7ddc16e9798449d9dd04e832dd87be6512829d437c29cd2b0dec5",
+          "bytes": 5559
         },
         {
           "path": "skills/oci/oci-compute-instance-agent-operator/metadata.json",
@@ -3169,12 +3169,12 @@
     {
       "id": "oci-compute-platform-operator",
       "path": "skills/oci/oci-compute-platform-operator",
-      "aggregate_sha256": "3cd924b2c059a32861b1a2ca857a8f83a8101c37a572e91c20f029e4d0843cbc",
+      "aggregate_sha256": "5e599367534512390339aa86d3f5a77e877435cd66ae68450d035fe7e2fc3494",
       "files": [
         {
           "path": "skills/oci/oci-compute-platform-operator/SKILL.md",
-          "sha256": "0d507a282516f122ca9c57fc1c0f30151ef6cc3c10ed38a56fdfcaa01bdd6db0",
-          "bytes": 11370
+          "sha256": "7af2510472354594603e02982f4bb411ba8cb1c4c280c525b15494da6f9b26bf",
+          "bytes": 11400
         },
         {
           "path": "skills/oci/oci-compute-platform-operator/metadata.json",
@@ -3201,12 +3201,12 @@
     {
       "id": "oci-cost-finops-analyst",
       "path": "skills/oci/oci-cost-finops-analyst",
-      "aggregate_sha256": "0048d799107effd422b1d9558842dc4870232b4d84fd0fd49454e8708e63ec07",
+      "aggregate_sha256": "5e3d1bf35ad29a287b105f6e5ca0ed1399ee5984f113b74d599eb9ef2ad8fb99",
       "files": [
         {
           "path": "skills/oci/oci-cost-finops-analyst/SKILL.md",
-          "sha256": "87680030182921390f57b6a686ad1e668a240ebea4ff15f63433676f47564025",
-          "bytes": 10854
+          "sha256": "dfbd6de8665d054ba3343efc17ac26aea3202109f51b8556fea890a5eea97769",
+          "bytes": 10893
         },
         {
           "path": "skills/oci/oci-cost-finops-analyst/metadata.json",
@@ -3233,12 +3233,12 @@
     {
       "id": "oci-database-platform-dba",
       "path": "skills/oci/oci-database-platform-dba",
-      "aggregate_sha256": "2f2cba9c717437d2b0000ba6f94cf722281575f84e159ce39f57e6135d58d022",
+      "aggregate_sha256": "272724fc1ba53e19ff66c093469c8e3e4b5377beec1e5a2c0dea37dca834e03d",
       "files": [
         {
           "path": "skills/oci/oci-database-platform-dba/SKILL.md",
-          "sha256": "76392b2a0e932cd88886dd949d51a35ca1ebf6a02acc02fff013ffd07927c293",
-          "bytes": 11679
+          "sha256": "beb78c763b21311e4fe39c44635d281321bf2926999922c6412f1cfde60ab8a3",
+          "bytes": 11709
         },
         {
           "path": "skills/oci/oci-database-platform-dba/metadata.json",
@@ -3265,12 +3265,12 @@
     {
       "id": "oci-dbtools-sql-analyst",
       "path": "skills/oci/oci-dbtools-sql-analyst",
-      "aggregate_sha256": "1ba0f1176e5e17734977709e7862c0fab88c4295416f5e5b119fcd4536a7fb7b",
+      "aggregate_sha256": "2a773a47ae41dd4cefb1d801042fce30a0ed9abe1ea33471d73d03ecd898facf",
       "files": [
         {
           "path": "skills/oci/oci-dbtools-sql-analyst/SKILL.md",
-          "sha256": "7dbe979f83a19874d591de7a1fbbeac4204fbb3425c7055d85958c2afde73f42",
-          "bytes": 5663
+          "sha256": "9777ae7014177c5bb22bc300bcc01234294de352b50cb5e5524413b0349ffab9",
+          "bytes": 5702
         },
         {
           "path": "skills/oci/oci-dbtools-sql-analyst/metadata.json",
@@ -3297,12 +3297,12 @@
     {
       "id": "oci-devops-container-platform-engineer",
       "path": "skills/oci/oci-devops-container-platform-engineer",
-      "aggregate_sha256": "d750396877490c5d0de476ff430a5a1d8607e36af514a0d110f682e32406912d",
+      "aggregate_sha256": "57b28afdb336eb717da6fb357786dc0b40ff620202b30a028453c7c172783989",
       "files": [
         {
           "path": "skills/oci/oci-devops-container-platform-engineer/SKILL.md",
-          "sha256": "756a56c2fd7bd76d5e8f7cd2ddc83df02d81c386554c897457e9caa0a9d69754",
-          "bytes": 11614
+          "sha256": "5067a20c0b0345833c046bfb2ef4f072d0a10f60fd59ad7ae2d9be164c9f07e8",
+          "bytes": 11644
         },
         {
           "path": "skills/oci/oci-devops-container-platform-engineer/metadata.json",
@@ -3329,12 +3329,12 @@
     {
       "id": "oci-exadata-database-architect",
       "path": "skills/oci/oci-exadata-database-architect",
-      "aggregate_sha256": "58d8655f3ce143f7611f25d216190c1741a64ae8f93a64656d79024c6411b8b8",
+      "aggregate_sha256": "fe30459e17e192e9c4e8b3282a3f0ea07c4612a620c658482e43e35797a97c11",
       "files": [
         {
           "path": "skills/oci/oci-exadata-database-architect/SKILL.md",
-          "sha256": "99877aa2c1321eb4fc1c8c6fe91f62cbbb3981ed8b790c66274199f4048a5d61",
-          "bytes": 11829
+          "sha256": "17d4bc92b501835064593ec13ea3a9132dc7fb87d51bbc77fb26787d2443dc90",
+          "bytes": 11859
         },
         {
           "path": "skills/oci/oci-exadata-database-architect/metadata.json",
@@ -3346,12 +3346,12 @@
     {
       "id": "oci-exadata-platform-architect",
       "path": "skills/oci/oci-exadata-platform-architect",
-      "aggregate_sha256": "7e13fc9ce3affc4e6bbda92c2251a1e7b7bb09dbf91c041189b45ada8171d587",
+      "aggregate_sha256": "0814a2621d35834ab8c7231cea0e406a1d1428c119795f4b65aaefc4e66c41df",
       "files": [
         {
           "path": "skills/oci/oci-exadata-platform-architect/SKILL.md",
-          "sha256": "2105fb6554b7c0a8cc9947caf0ddb474359b6599ef4bf931ae6e69294442ef1b",
-          "bytes": 8908
+          "sha256": "6df08e301d25af4ff9ff1901ca17f73aa1d7fec30186ea7e00f7a7662d59eedd",
+          "bytes": 8938
         },
         {
           "path": "skills/oci/oci-exadata-platform-architect/metadata.json",
@@ -3388,12 +3388,12 @@
     {
       "id": "oci-fusion-apps-environment-operator",
       "path": "skills/oci/oci-fusion-apps-environment-operator",
-      "aggregate_sha256": "7d11fc851c03e8dbb9d4160745a852094ae3b064dfd6aceaa45c39ef709e3f7f",
+      "aggregate_sha256": "9e83c1bcc275e91ad8c380aeb72d57a8ffb74f7fcc1c77e25fa3830aa6b01fbb",
       "files": [
         {
           "path": "skills/oci/oci-fusion-apps-environment-operator/SKILL.md",
-          "sha256": "cf451d2cac4e51e3431c0778109e3036b43f3b2c7ceac4beecbe6d09d155d37f",
-          "bytes": 5538
+          "sha256": "0df1a57e1c4ff343a1e4abd46e6530b7ee44c69d9724671a484414c2f822aad7",
+          "bytes": 5568
         },
         {
           "path": "skills/oci/oci-fusion-apps-environment-operator/metadata.json",
@@ -3420,12 +3420,12 @@
     {
       "id": "oci-goldengate-replication-operator",
       "path": "skills/oci/oci-goldengate-replication-operator",
-      "aggregate_sha256": "bfed30ee4953bf19f433db97e446ee641965b421ae252e000233591e1b5e56f2",
+      "aggregate_sha256": "eb9d40a2883b3fe438ba5e377c8b1410b919211349f392445f44da8d139061c9",
       "files": [
         {
           "path": "skills/oci/oci-goldengate-replication-operator/SKILL.md",
-          "sha256": "9edc95f66e6454679036e9356f406d9c9a87dffc1cbb2ad49e2e9bc39ad7c74e",
-          "bytes": 5636
+          "sha256": "45564f4b902500f62d440021d34cc20bc4d39ad6daa5e1be7e00a032a92fbd09",
+          "bytes": 5666
         },
         {
           "path": "skills/oci/oci-goldengate-replication-operator/metadata.json",
@@ -3452,12 +3452,12 @@
     {
       "id": "oci-identity-access-governor",
       "path": "skills/oci/oci-identity-access-governor",
-      "aggregate_sha256": "22ab8a8510f2c41b9aa8359691a8878ff7695476fa12973ee7f62978eb5bd220",
+      "aggregate_sha256": "5fc1caef253e99ab1f8c3151920ca11063115f88d3f171866d90786cb34e91a6",
       "files": [
         {
           "path": "skills/oci/oci-identity-access-governor/SKILL.md",
-          "sha256": "73b15ec279ab19c8f729a20e76fbf7d1edaef9d79ddcfdbb0df0659e341c3f9c",
-          "bytes": 11126
+          "sha256": "cb1b2437f33155f040389071842affdbb3c04e24bc18db066db6b1a86b58fa4b",
+          "bytes": 11156
         },
         {
           "path": "skills/oci/oci-identity-access-governor/metadata.json",
@@ -3484,12 +3484,12 @@
     {
       "id": "oci-iot-digital-twin-engineer",
       "path": "skills/oci/oci-iot-digital-twin-engineer",
-      "aggregate_sha256": "95283f3246d89fd5a69194a3a8695f0cf490949ff7a871454c8eb94433bd680b",
+      "aggregate_sha256": "e4c9f5419c87226b6be18d585bf8cbe7e7753902f69d43e0cf71ccf580593398",
       "files": [
         {
           "path": "skills/oci/oci-iot-digital-twin-engineer/SKILL.md",
-          "sha256": "fab469691721f7056096c56e59628eba2a64e1686978e6584193caf31fbb6464",
-          "bytes": 5557
+          "sha256": "9fde27a5571fceac6c709b1710004e48b3b976341babb74d15d729fea8ad7a2e",
+          "bytes": 5587
         },
         {
           "path": "skills/oci/oci-iot-digital-twin-engineer/metadata.json",
@@ -3516,12 +3516,12 @@
     {
       "id": "oci-limits-capacity-planner",
       "path": "skills/oci/oci-limits-capacity-planner",
-      "aggregate_sha256": "7f84c6c3b14ad958cf2884f5d867173bbe49348a522ca3c67536df2f4c9fbf1c",
+      "aggregate_sha256": "e0a202c9324bf43bbe07787f6c3a3cbf39e1a36da6ac5bb9ca301c1910610f97",
       "files": [
         {
           "path": "skills/oci/oci-limits-capacity-planner/SKILL.md",
-          "sha256": "67f878253a50e7b08cbe55e15759aa55b022231dd8f7e26bc03f7ec49e12ae4d",
-          "bytes": 5583
+          "sha256": "490758bb7400cefcf2c1158c25291062ba454da7e492433807f3bf8e3e2bc029",
+          "bytes": 5622
         },
         {
           "path": "skills/oci/oci-limits-capacity-planner/metadata.json",
@@ -3548,12 +3548,12 @@
     {
       "id": "oci-live-autonomous-db-lifecycle-guard",
       "path": "skills/oci/oci-live-autonomous-db-lifecycle-guard",
-      "aggregate_sha256": "afb0508bc50c511ef623b9477934b76f47e8a826ba03bf8d3631742ab52f0651",
+      "aggregate_sha256": "b0f72af80e1580954091ac00e9808dbcf06dc6de28c6be7f1beebd84890884fa",
       "files": [
         {
           "path": "skills/oci/oci-live-autonomous-db-lifecycle-guard/SKILL.md",
-          "sha256": "a03782d5eabc834d7b383fc4b7cf30f460b34a769a8eddfbe1d1449b7a37e8a7",
-          "bytes": 2310
+          "sha256": "14b6c96e01a839d6f494dc44d5cd6f425138fa914183499d32af9e645af0049c",
+          "bytes": 2349
         },
         {
           "path": "skills/oci/oci-live-autonomous-db-lifecycle-guard/metadata.json",
@@ -3585,12 +3585,12 @@
     {
       "id": "oci-live-cost-budget-runaway-guard",
       "path": "skills/oci/oci-live-cost-budget-runaway-guard",
-      "aggregate_sha256": "fc457f93798c13be8a11faf06d44bb13f6906d6103e8352e90a845352083754d",
+      "aggregate_sha256": "b82d73d1204d2455b0b26e8e1e7f6014ad1121e52a2d1c81b07318895a6c2ebb",
       "files": [
         {
           "path": "skills/oci/oci-live-cost-budget-runaway-guard/SKILL.md",
-          "sha256": "1fc554734026cf2b5c28ce5a94ecf9bdb63523cd5683099e911875f56809f3e4",
-          "bytes": 2225
+          "sha256": "3be50a9d4dbd43622f399e34c81d3f779ba3f3362e6bdc8251f47f99638a3c43",
+          "bytes": 2264
         },
         {
           "path": "skills/oci/oci-live-cost-budget-runaway-guard/metadata.json",
@@ -3622,12 +3622,12 @@
     {
       "id": "oci-live-iam-policy-compartment-guard",
       "path": "skills/oci/oci-live-iam-policy-compartment-guard",
-      "aggregate_sha256": "d7f40efbb5c3efed9b928dfac4a49bd2ce4e5985dbbc828659920f89ed3ba25b",
+      "aggregate_sha256": "15c865b28c4eee67dd5fa704c6a9263a0a72ba3fcdabbe9b9f22afd9bb6ff781",
       "files": [
         {
           "path": "skills/oci/oci-live-iam-policy-compartment-guard/SKILL.md",
-          "sha256": "12891530d066d5bc9bbd8aab0fc680424bfea7b354602f3a1629f240cc2eb525",
-          "bytes": 2261
+          "sha256": "00f446bb6ff99f87e8fba845585e068cbe745b8c7bcdf21ab85783e64f86c554",
+          "bytes": 2300
         },
         {
           "path": "skills/oci/oci-live-iam-policy-compartment-guard/metadata.json",
@@ -3659,12 +3659,12 @@
     {
       "id": "oci-live-network-security-rule-guard",
       "path": "skills/oci/oci-live-network-security-rule-guard",
-      "aggregate_sha256": "2ef90b2b6a9ac3d6990afa6e2a494281abec81668367c604f53633bb98543ac1",
+      "aggregate_sha256": "c0648a50cec252ad96b039d5c714955722feee10eed7475632ece691decd027c",
       "files": [
         {
           "path": "skills/oci/oci-live-network-security-rule-guard/SKILL.md",
-          "sha256": "dc9f2ce8ed139126e033b440e7676448ddf9c546223f97191f6f9d952a8314a0",
-          "bytes": 3656
+          "sha256": "4c7248b3e23e8b0da483d78cc4f470e3f252366922b0ee79874b0e562d22fb75",
+          "bytes": 3695
         },
         {
           "path": "skills/oci/oci-live-network-security-rule-guard/metadata.json",
@@ -3696,12 +3696,12 @@
     {
       "id": "oci-live-oke-rollout-guard",
       "path": "skills/oci/oci-live-oke-rollout-guard",
-      "aggregate_sha256": "a9ab93b29889238d47e33050ef7cf476881368cd50817e240af57163e4e072f4",
+      "aggregate_sha256": "81082b9f5d0088f5bbb4cd0ed9f462a512c39032cdd0438a2e16c4b9a4b40379",
       "files": [
         {
           "path": "skills/oci/oci-live-oke-rollout-guard/SKILL.md",
-          "sha256": "1625da25229bdd21af6fb8df468150e0efcb8616ef54945037547e8053d4e803",
-          "bytes": 2218
+          "sha256": "8897469933368df9a06b65bf379e7bb6a036ad2a803910f5b3f64477ad57602a",
+          "bytes": 2257
         },
         {
           "path": "skills/oci/oci-live-oke-rollout-guard/metadata.json",
@@ -3733,12 +3733,12 @@
     {
       "id": "oci-live-resource-manager-stack-guard",
       "path": "skills/oci/oci-live-resource-manager-stack-guard",
-      "aggregate_sha256": "3c9e767fe0be45091aee2f0bffef07485e62d7f8f5af8c62163670ef6f0c4c4f",
+      "aggregate_sha256": "35733182748618a81848584862d5b569245e26695ddf629163bbfc66af02496e",
       "files": [
         {
           "path": "skills/oci/oci-live-resource-manager-stack-guard/SKILL.md",
-          "sha256": "9b491d8899d7a75686bf9c02130703d1365f46cfd29c2e55bf0015d1d3422387",
-          "bytes": 2239
+          "sha256": "418d8ec0fb24be57e18285e372bab391a6ad2e2689544c55be11c3ac11f8429f",
+          "bytes": 2278
         },
         {
           "path": "skills/oci/oci-live-resource-manager-stack-guard/metadata.json",
@@ -3770,12 +3770,12 @@
     {
       "id": "oci-live-vault-key-destruction-guard",
       "path": "skills/oci/oci-live-vault-key-destruction-guard",
-      "aggregate_sha256": "670b6d694d55e73be765a3d9221ff943a564d96d18a860876bda908c1e74ae07",
+      "aggregate_sha256": "89520d7ace13b24c841af8ca9abdb99e7fa42d05a6d379bba040c13e65556af1",
       "files": [
         {
           "path": "skills/oci/oci-live-vault-key-destruction-guard/SKILL.md",
-          "sha256": "69e7c7e168c4b02610aa49932ca7900e11385938b57116b2ba82e35913962e40",
-          "bytes": 2245
+          "sha256": "32d048014ec06591609a0b74f91f954fd6b51f56ebf067c38dd19e0eaf495c4a",
+          "bytes": 2284
         },
         {
           "path": "skills/oci/oci-live-vault-key-destruction-guard/metadata.json",
@@ -3807,12 +3807,12 @@
     {
       "id": "oci-load-balancer-traffic-engineer",
       "path": "skills/oci/oci-load-balancer-traffic-engineer",
-      "aggregate_sha256": "7caaced25902c50082ca65b936c3a4482bbd8e7506a19db83590a5907bf556d1",
+      "aggregate_sha256": "35911d158facae1c33e41de7ee957de5fdf5253d0b3fc33e256cb85eda67c876",
       "files": [
         {
           "path": "skills/oci/oci-load-balancer-traffic-engineer/SKILL.md",
-          "sha256": "da9553c865eebac54f397ebea640b0c221228086969354efaabfe2d17ab65d06",
-          "bytes": 5724
+          "sha256": "1913d749160c7d5cae4e6463312b998c14ba9833508525316c3ef177bd817052",
+          "bytes": 5754
         },
         {
           "path": "skills/oci/oci-load-balancer-traffic-engineer/metadata.json",
@@ -3839,12 +3839,12 @@
     {
       "id": "oci-maestro",
       "path": "skills/oci/oci-maestro",
-      "aggregate_sha256": "9264746f0563b5975b10831a2d37954b1c107776c15855a8202f8defcf3595b4",
+      "aggregate_sha256": "8fe344ec44171bb5cced55a71d31f2613c54411d832f976dc47e1eb570b9bea4",
       "files": [
         {
           "path": "skills/oci/oci-maestro/SKILL.md",
-          "sha256": "e1b35ec3c1a4b31daab67ead568fd5561f44a6af006373d0ef0ac4d4977c3093",
-          "bytes": 13082
+          "sha256": "44860e405b9094f6c2c18fa9f805da26c102a419b08ea3574b05ea48732a8c35",
+          "bytes": 13124
         },
         {
           "path": "skills/oci/oci-maestro/metadata.json",
@@ -3856,12 +3856,12 @@
     {
       "id": "oci-migration-cutover-architect",
       "path": "skills/oci/oci-migration-cutover-architect",
-      "aggregate_sha256": "51dbb9bf273f105d98b86314fc29bb743ab8b556e348d202d667d390a25a71f8",
+      "aggregate_sha256": "27d2a3df1fa8e0662e3e31b722f140bade1442d60cf45dad8a5bba5526d6f5df",
       "files": [
         {
           "path": "skills/oci/oci-migration-cutover-architect/SKILL.md",
-          "sha256": "698b86d5f15cbe555685c64a32277f45124163ed3dda69739bba4a670cd29931",
-          "bytes": 5527
+          "sha256": "5b00c506e981380ac16749e4f2b16af7af42f517bd590d0bca2bc0188b47a7e6",
+          "bytes": 5557
         },
         {
           "path": "skills/oci/oci-migration-cutover-architect/metadata.json",
@@ -3888,12 +3888,12 @@
     {
       "id": "oci-multi-cloud-architect",
       "path": "skills/oci/oci-multi-cloud-architect",
-      "aggregate_sha256": "5f1ff759380ef7f72ea5eb2cc89df5cb21dd0af26be8d45fb4889a643a769487",
+      "aggregate_sha256": "2c9728c9ea14a83444fbf5f409a46ae916469539c4f17529a820eb2f9ede98f5",
       "files": [
         {
           "path": "skills/oci/oci-multi-cloud-architect/SKILL.md",
-          "sha256": "18902612950b5c74bb45a0528df6d32fa8b47e5a8e9bf34160d82fcf6deef492",
-          "bytes": 11970
+          "sha256": "2c3ada6d0c2cf462b8550ee6f0b61b1ee856c660a850c5060a3395a8fdbe360f",
+          "bytes": 12000
         },
         {
           "path": "skills/oci/oci-multi-cloud-architect/metadata.json",
@@ -3920,12 +3920,12 @@
     {
       "id": "oci-mysql-heatwave-ai-specialist",
       "path": "skills/oci/oci-mysql-heatwave-ai-specialist",
-      "aggregate_sha256": "f5c95b566114c6b50bdb163cba77fcf092be4dba2bfe3e74c5a5c584d7228e56",
+      "aggregate_sha256": "6e2cb358539a6371a4599a2cacffd9d10a12859909633bfe9a348b0df45712c3",
       "files": [
         {
           "path": "skills/oci/oci-mysql-heatwave-ai-specialist/SKILL.md",
-          "sha256": "d96f27dfae1806a652870f6d9c8cf5dc8b987322b935df3b843c7ac67a27858c",
-          "bytes": 5574
+          "sha256": "471b325e569f35cdb4475d5ae8c7dc835e06514f79dbc609eb3b691d1ae3d1d1",
+          "bytes": 5604
         },
         {
           "path": "skills/oci/oci-mysql-heatwave-ai-specialist/metadata.json",
@@ -3952,12 +3952,12 @@
     {
       "id": "oci-network-architect",
       "path": "skills/oci/oci-network-architect",
-      "aggregate_sha256": "be0ad4785df50f1a44dbde1136e22dda7fda9ca6cc05057513cf9729e3d762f7",
+      "aggregate_sha256": "08b9959052fffe78e9407dde34496823871d716b1b80fd98fff893f178dcefce",
       "files": [
         {
           "path": "skills/oci/oci-network-architect/SKILL.md",
-          "sha256": "8a6e8c0b84f149c8ce33c11c32dc011889408310a86b272c2c9da615edcf36bf",
-          "bytes": 10686
+          "sha256": "46687101ecb7d8553a9e5d7cb2b5887d310fa1ec8a77ec0bce4f0e1df8664716",
+          "bytes": 10716
         },
         {
           "path": "skills/oci/oci-network-architect/metadata.json",
@@ -3984,12 +3984,12 @@
     {
       "id": "oci-observability-incident-responder",
       "path": "skills/oci/oci-observability-incident-responder",
-      "aggregate_sha256": "ee1c7ab8b695cd3135932ca18211ea80b7006ece49e2e4b3f1da0db649831932",
+      "aggregate_sha256": "db2d45cc8b4d5523a965129fdb7b3bd66a31e51f4fc0f4b0a98268c1139f9cac",
       "files": [
         {
           "path": "skills/oci/oci-observability-incident-responder/SKILL.md",
-          "sha256": "f4eb23661478fa9c0c89e414012ff348d15952ebea3d6340a9ae14535ea2baff",
-          "bytes": 11062
+          "sha256": "651509f75f1faf628c06d121c010305a668990c2e5854d6e889c08cdea535920",
+          "bytes": 11101
         },
         {
           "path": "skills/oci/oci-observability-incident-responder/metadata.json",
@@ -4016,12 +4016,12 @@
     {
       "id": "oci-recovery-service-operator",
       "path": "skills/oci/oci-recovery-service-operator",
-      "aggregate_sha256": "eacf0cce446ecde3a9c41ca141f5fd4e50e9bacaa008f1e09098f3b102bde7ba",
+      "aggregate_sha256": "f48478ac18330a3fce9e4fbc8703586d34c984faad54b48dbd487b708d751fcb",
       "files": [
         {
           "path": "skills/oci/oci-recovery-service-operator/SKILL.md",
-          "sha256": "fae05d5ff9c8e5d00e313ceafa67adef4b3a76d953b7581a9d679c01f4ecaf28",
-          "bytes": 5694
+          "sha256": "38d93eceaa2b65f14e6463a437df1e3173babd4e5c25f0ede2ce4fbed557d83a",
+          "bytes": 5724
         },
         {
           "path": "skills/oci/oci-recovery-service-operator/metadata.json",
@@ -4048,12 +4048,12 @@
     {
       "id": "oci-registry-artifact-governor",
       "path": "skills/oci/oci-registry-artifact-governor",
-      "aggregate_sha256": "6f8e8ef3dc8d7a45eb623e5d3a749c8ed611fc7c990c909a5580d6c6d2e2b194",
+      "aggregate_sha256": "9c2e6c9ea0ad4ef73a2d68c446686c393dd233e49bf876ffe51940896bde254f",
       "files": [
         {
           "path": "skills/oci/oci-registry-artifact-governor/SKILL.md",
-          "sha256": "027bfc3f001702260259793a146da692897be45b66d26c517d623b3936faae1c",
-          "bytes": 5456
+          "sha256": "14efe94aaa72e4e22afbd01f1fb3d2e4ea1127f35bcfb9299a5f949133754e40",
+          "bytes": 5486
         },
         {
           "path": "skills/oci/oci-registry-artifact-governor/metadata.json",
@@ -4080,12 +4080,12 @@
     {
       "id": "oci-resource-search-inventory-analyst",
       "path": "skills/oci/oci-resource-search-inventory-analyst",
-      "aggregate_sha256": "4d1b5e0162302101a5cec1fa0db9986d1f301b79bdb7e3b3bc278d23fc1483e1",
+      "aggregate_sha256": "d00581a61457c4ffc0d7359edaa60d63b5a456603f79605ff8b1623ff1817008",
       "files": [
         {
           "path": "skills/oci/oci-resource-search-inventory-analyst/SKILL.md",
-          "sha256": "cfba46e931e3db24f7fc000fe59a68d403db258e0b2956141e12f67ef653d00f",
-          "bytes": 5595
+          "sha256": "6018964b3d7f24ee569ef62229ae64d75a8abb1cc22ab6f89e8a7577f521211b",
+          "bytes": 5634
         },
         {
           "path": "skills/oci/oci-resource-search-inventory-analyst/metadata.json",
@@ -4112,12 +4112,12 @@
     {
       "id": "oci-security-compliance-reviewer",
       "path": "skills/oci/oci-security-compliance-reviewer",
-      "aggregate_sha256": "839d0f351e41eda529f49ba086667959652b043688975935276dbf8f263333e5",
+      "aggregate_sha256": "b7f4214fd778ff0a6afaf7cc399e3877266dcd458171558ed6d11c0cdc9be14f",
       "files": [
         {
           "path": "skills/oci/oci-security-compliance-reviewer/SKILL.md",
-          "sha256": "14f608a5ab75002de7ed519b4ac5f4d4b5e1551bbb8faf364c7b3b3d2ea5f218",
-          "bytes": 11685
+          "sha256": "d04546138c21c7bb29c9ffea618809aa9bc5efa5d263567f4775d63364eed912",
+          "bytes": 11715
         },
         {
           "path": "skills/oci/oci-security-compliance-reviewer/metadata.json",
@@ -4144,12 +4144,12 @@
     {
       "id": "oci-solution-architect",
       "path": "skills/oci/oci-solution-architect",
-      "aggregate_sha256": "af4ebbbc58fe70c813449b088bb0b03c91ce9f978b8292ed61c019e13b88f78f",
+      "aggregate_sha256": "8cb00fd78ce493747936469356f1fe47e062ca78ad0061db6d428f9c72befd83",
       "files": [
         {
           "path": "skills/oci/oci-solution-architect/SKILL.md",
-          "sha256": "5d74a75cd6b579d3139064069c3e693773bddf7ddde4b00cde1f50206dda0c9b",
-          "bytes": 10545
+          "sha256": "5f7c4a632a14efd3ceb70727143648756cf78e4ebc4ed49de2c6ee1c3c950546",
+          "bytes": 10575
         },
         {
           "path": "skills/oci/oci-solution-architect/metadata.json",
@@ -4176,12 +4176,12 @@
     {
       "id": "oci-storage-backup-steward",
       "path": "skills/oci/oci-storage-backup-steward",
-      "aggregate_sha256": "2c26f4dd8d69000b90666ca0eae356a0a3db0fdb4d27e93a0873847b02e37f32",
+      "aggregate_sha256": "8efecddd8a354e465cef12ee080b2df73b95df2e513f9c809a0cad759e152821",
       "files": [
         {
           "path": "skills/oci/oci-storage-backup-steward/SKILL.md",
-          "sha256": "8c2bc39fe57af23eff601bccc9b8ca0a41911f7c9b386f54e6d18b1315a20554",
-          "bytes": 11338
+          "sha256": "4de0475010ba10012fa526d7d81f01d894cfddd0cef07db4914b8e9bd39e5296",
+          "bytes": 11368
         },
         {
           "path": "skills/oci/oci-storage-backup-steward/metadata.json",
@@ -4208,12 +4208,12 @@
     {
       "id": "oci-support-incident-coordinator",
       "path": "skills/oci/oci-support-incident-coordinator",
-      "aggregate_sha256": "0fc3fb98f1716fe14af7614307284b89641b20ffd6ab1f7d94153411d9ce1916",
+      "aggregate_sha256": "8ca985e3ddeae353d563c22a00cc7f6fc799471cd7b1552f3a6ed6633d39e1b8",
       "files": [
         {
           "path": "skills/oci/oci-support-incident-coordinator/SKILL.md",
-          "sha256": "de60dc5249e11129d783be149a90c9eebbe5e95b05433b2d993ba024339a7e80",
-          "bytes": 5491
+          "sha256": "ac3b71393981f359dfaf071c67965f2d6a4c9009b7ba677bcc9189e0783aad83",
+          "bytes": 5530
         },
         {
           "path": "skills/oci/oci-support-incident-coordinator/metadata.json",
@@ -4240,12 +4240,12 @@
     {
       "id": "opentelemetry-collector-config-review",
       "path": "skills/opentelemetry/opentelemetry-collector-config-review",
-      "aggregate_sha256": "d8d9120a2dbf253ea35268a30b3e87821e539f0c368225524fef0eceae019e30",
+      "aggregate_sha256": "09538a61ac5e6f7e09c8d464e4f23ad7c83008d7ed2c158582088dd45fb51742",
       "files": [
         {
           "path": "skills/opentelemetry/opentelemetry-collector-config-review/SKILL.md",
-          "sha256": "0a64a0ae3e86387b393b608869296ecb798b80e30765eb835df5e89c6226d8ac",
-          "bytes": 3880
+          "sha256": "a364357f1bf7742b6bde76102cf8e05dab9251d8993bcf847886137f4b690beb",
+          "bytes": 3910
         },
         {
           "path": "skills/opentelemetry/opentelemetry-collector-config-review/metadata.json",
@@ -4272,12 +4272,12 @@
     {
       "id": "oracle-oci-mcp-grounded-advisor",
       "path": "skills/oci/oracle-oci-mcp-grounded-advisor",
-      "aggregate_sha256": "b6d48bea397ab4c1d4622273a5e66953914ec35500539fa0e2073932f0d09e11",
+      "aggregate_sha256": "76f976dcb28f94d90fa2c703eb22d20d2c84b3f46e754be1769a8647063f5f71",
       "files": [
         {
           "path": "skills/oci/oracle-oci-mcp-grounded-advisor/SKILL.md",
-          "sha256": "3dd4d812652b70caf0cad7e665c83a35bbf5d8da6efecdcd28e4578b274406bd",
-          "bytes": 1366
+          "sha256": "9e29c4485ba6e9948be8bd607ee8f6ea5b88b24f9751fc4f1e8055a01aaf46dd",
+          "bytes": 1405
         },
         {
           "path": "skills/oci/oracle-oci-mcp-grounded-advisor/metadata.json",
@@ -4289,12 +4289,12 @@
     {
       "id": "prometheus-alerting-cardinality-review",
       "path": "skills/prometheus/prometheus-alerting-cardinality-review",
-      "aggregate_sha256": "191aff85643031e3a870a2d498340c3b945288bc61ff0f2d83a7ede2d4080df0",
+      "aggregate_sha256": "4081758965cd5feff572edcafce6c28874d4fa29b9465db2a2943d2e37c5b6f4",
       "files": [
         {
           "path": "skills/prometheus/prometheus-alerting-cardinality-review/SKILL.md",
-          "sha256": "0d76ca3169996c1326922026c62786566a0cabdb200e912caf444b3e0d7dae47",
-          "bytes": 2985
+          "sha256": "14bfd05fed76b7e8c97755f49ef3739618d4ae94bcf9fc54ebb6919d726580dc",
+          "bytes": 3015
         },
         {
           "path": "skills/prometheus/prometheus-alerting-cardinality-review/metadata.json",
@@ -4311,12 +4311,12 @@
     {
       "id": "sigstore-cosign-supply-chain-review",
       "path": "skills/sigstore/sigstore-cosign-supply-chain-review",
-      "aggregate_sha256": "29932631358764629bcfa68023a3140a41a4eb03aae4cb1606ae594af26f19ac",
+      "aggregate_sha256": "8269c3d5f69e37a4cd78b8c2015bfd1c34207bdc492d23306ea7dbd23b061b91",
       "files": [
         {
           "path": "skills/sigstore/sigstore-cosign-supply-chain-review/SKILL.md",
-          "sha256": "71182682d14ee4ddf29abf9f47114fad20689701034e5810255e208f3d16a051",
-          "bytes": 2953
+          "sha256": "1bc689da2591e885a6a8aa76d61f9c19371d6aafb98b92f0f7e5e926ed4955cd",
+          "bytes": 2983
         },
         {
           "path": "skills/sigstore/sigstore-cosign-supply-chain-review/metadata.json",
@@ -4333,12 +4333,12 @@
     {
       "id": "terraform-maestro",
       "path": "skills/terraform/terraform-maestro",
-      "aggregate_sha256": "283c4aeead087f1f82a1c00a01c0eccdbe6c5173ddc57bdf78c160ea62976db1",
+      "aggregate_sha256": "965993514585ba0ef19611778cc8f5a3efcd338acfa11badc524507c847b9cf4",
       "files": [
         {
           "path": "skills/terraform/terraform-maestro/SKILL.md",
-          "sha256": "ddb9278cc84e8f31d60d051287163764d70f4a4b010335dcb1de37401d23c127",
-          "bytes": 7007
+          "sha256": "2bf013670e1d74446065d209aedc2c76c05172781416d4de2286a885094f3336",
+          "bytes": 7049
         },
         {
           "path": "skills/terraform/terraform-maestro/metadata.json",
@@ -4365,12 +4365,12 @@
     {
       "id": "velero-backup-restore-guard",
       "path": "skills/velero/velero-backup-restore-guard",
-      "aggregate_sha256": "7c1d5660d03ceb497ef2d646114dc7ec1b97cbfd5e5aea95fe3ea02a4b1b0d75",
+      "aggregate_sha256": "7bc2c567ad5a645338f5838e42856c4c5bdc7bf488c4bd5825a46f3d8b913f5c",
       "files": [
         {
           "path": "skills/velero/velero-backup-restore-guard/SKILL.md",
-          "sha256": "8b6e566a3f60cad70b101462ef6660c299dbd9cd6ba11f19131bffd25b36c83b",
-          "bytes": 2509
+          "sha256": "dfdd5b510421cdab8bcaf6427e07af2ed652d548e10936356eacc8759f404273",
+          "bytes": 2548
         },
         {
           "path": "skills/velero/velero-backup-restore-guard/metadata.json",

--- a/docs/integrations/skills-cli.md
+++ b/docs/integrations/skills-cli.md
@@ -1,0 +1,154 @@
+# Skills CLI Integration Guide
+
+This document covers the three supported install paths for Vanguard Frontier Agentic content, their trust postures, and verified command syntax. It is intended for engineers who want to understand what each path fetches, from where, and with what level of integrity assurance before running anything.
+
+---
+
+## Trust matrix
+
+| Path | Source of truth | Versioning | Includes agents? | Includes skills? | Pinnable | Trust posture | Best for |
+|------|----------------|------------|-----------------|-----------------|----------|---------------|----------|
+| `npm i @raishin/vanguard-frontier-agentic` | npm registry (release pipeline) | SemVer, explicit | Yes (via exporter CLI) | Yes | Yes — lock to exact semver or lockfile | **Highest.** Published artifacts are signed via the release pipeline; you control the version in your lockfile. | Production teams, CI/CD enforcement, auditability |
+| `npx vfa-export-agents` | npm registry (same package) | SemVer, explicit | Yes | Yes (default, opt out with `--no-skills`) | Yes — pin the package version | **High.** Same artifact as above; CLI is bundled in the npm package. | Engineers who want role-based or per-platform export with a single command |
+| `npx skills add Raishin/vanguard-frontier-agentic` | GitHub raw HEAD (via `vercel-labs/skills` CLI) | None by default — fetches latest commit on the default branch | No (skills only) | Yes | Not documented — see [pinning note](#pinning-the-skills-cli-path) below | **Lower.** Third-party CLI pulls raw GitHub content without version pinning or integrity verification at install time. | Quick local exploration; not recommended for shared or CI environments |
+
+---
+
+## Path 1 — npm package (highest trust)
+
+Install the versioned npm package. The exporter CLI (`vfa-export-agents`) is bundled in the package and handles agent and skill export.
+
+```bash
+# Install a specific version
+npm install @raishin/vanguard-frontier-agentic@1.3.0
+
+# Or install latest and lock via package-lock.json / npm-shrinkwrap.json
+npm install @raishin/vanguard-frontier-agentic@latest
+```
+
+After install, run the exporter from the local package to avoid fetching a different version:
+
+```bash
+npx --no -- vfa-export-agents --platform claude-code --role cloud-security-engineer --repo .
+```
+
+See [`docs/release-versioning.md`](../release-versioning.md) for the versioning policy and the full SemVer bump table.
+
+---
+
+## Path 2 — vfa-export-agents CLI (high trust)
+
+The exporter CLI is the canonical way to install agents and skills into a project. It resolves content from the same npm package artifact.
+
+```bash
+# See all available options
+npx vfa-export-agents --help
+
+# List all agent IDs
+npx vfa-export-agents --list
+
+# List available roles
+npx vfa-export-agents --list-roles
+
+# Export agents for a job role
+npx vfa-export-agents --platform claude-code --role cloud-security-engineer --repo .
+
+# Export all agents for a platform
+npx vfa-export-agents --platform claude-code --all --repo .
+
+# Export agents without companion skills (opt out of the default skill bundle)
+npx vfa-export-agents --platform claude-code --role cloud-security-engineer --no-skills --repo .
+```
+
+The `--no-skills` flag opts out of the companion skill bundle that is included by default. See `scripts/export-marketplace-agents.mjs --help` for the full flag reference.
+
+---
+
+## Path 3 — skills CLI (lower trust, third-party)
+
+The `skills` CLI is an open-source, third-party tool maintained at [github.com/vercel-labs/skills](https://github.com/vercel-labs/skills). It pulls skill content directly from the GitHub repository at HEAD — it does not use the npm package, applies no version pin by default, and performs no integrity verification at install time.
+
+Verified flag syntax as documented at [github.com/vercel-labs/skills](https://github.com/vercel-labs/skills):
+
+| Flag | Long form | Description |
+|------|-----------|-------------|
+| `-l` | `--list` | List available skills in the source repo without installing |
+| `-s` | `--skill <skills...>` | Install one or more specific skills by name; use `'*'` to install all |
+| `-g` | `--global` | Install to user directory (`~/<agent>/skills/`) instead of project |
+| `-a` | `--agent <agents...>` | Target one or more specific agent runtimes (e.g. `claude-code`) |
+| `-y` | `--yes` | Skip confirmation prompts |
+|      | `--copy` | Copy files instead of symlinking |
+|      | `--all` | Install all skills to all agents without prompts |
+
+```bash
+# List every skill in this repo without installing
+npx skills add Raishin/vanguard-frontier-agentic --list
+
+# Install a specific skill into the current project
+npx skills add Raishin/vanguard-frontier-agentic --skill aws-iac-patch-executor
+
+# Install all skills globally for Claude Code
+npx skills add Raishin/vanguard-frontier-agentic --skill '*' --global --agent claude-code
+
+# Install all skills to all detected agents without prompts
+npx skills add Raishin/vanguard-frontier-agentic --all --yes
+```
+
+> **Note on the README's flag usage:** The README historically used `--skill` (long form) and `-a` (short form). The CLI also accepts `-s` as the short form for `--skill` and `--agent` as the long form for `-a`. Both forms are documented at [github.com/vercel-labs/skills](https://github.com/vercel-labs/skills).
+
+---
+
+## Pinning the skills CLI path
+
+The `vercel-labs/skills` CLI documentation does not describe a version-pin syntax for source repositories at install time. The tool fetches from the default branch at HEAD unless you specify a full GitHub URL pointing to a specific tree or commit, e.g.:
+
+```
+https://github.com/Raishin/vanguard-frontier-agentic/tree/<tag-or-sha>
+```
+
+Whether the CLI correctly resolves tree-scoped URLs is not confirmed in the published documentation. For environments where reproducibility matters, use Path 1 (npm) or Path 2 (vfa-export-agents) instead.
+
+---
+
+## Before you install
+
+Regardless of which path you use, inspect content before running it in a shared or production environment.
+
+### Inspect a SKILL.md frontmatter
+
+Every skill in this repo is a `SKILL.md` file with YAML frontmatter. Before installing a skill globally or into a shared project, review:
+
+1. **`name`** — the identifier the skill will be registered under.
+2. **`description`** — what the skill does and when it is invoked.
+3. **Body content** — the instructions the agent will follow. Read them as you would read a script you are about to run with elevated trust.
+
+Example of what to look for:
+
+```yaml
+---
+name: aws-iac-patch-executor
+description: Reviews and applies IaC patches for AWS resources with approval gating.
+---
+# AWS IaC Patch Executor
+...
+```
+
+Skills with `metadata.internal: true` in their frontmatter are hidden from discovery by default and only install when the `INSTALL_INTERNAL_SKILLS=1` environment variable is set.
+
+### Check the references/ directory
+
+Some skills include a `references/` subdirectory with source links, evidence templates, or supporting context. Review these before relying on a skill for compliance-sensitive work — they document the official sources the skill's guidance is based on.
+
+### Telemetry
+
+The `vercel-labs/skills` CLI collects anonymous usage data. Set `DISABLE_TELEMETRY=1` or `DO_NOT_TRACK=1` to opt out. Telemetry is automatically disabled in CI environments. This does not apply to paths 1 or 2, which do not collect telemetry.
+
+---
+
+## Choosing an install path
+
+- **CI/CD pipelines and team-shared environments:** use Path 1 or Path 2. Pin the npm version. Check the lockfile into source control.
+- **Local exploration and quick trials:** Path 3 is convenient but pulls from HEAD. Do not use it in automated pipelines.
+- **Compliance-sensitive environments:** Path 1 only. Record the exact version in your dependency manifest and validate against `catalog/skill-manifest.json` for SHA-level integrity checking.
+
+See [`docs/ci-cd-enforcement-pattern.md`](../ci-cd-enforcement-pattern.md) for CI/CD enforcement guidance.

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "validate:aws": "python3 tests/validate-aws-skill-quality.py && python3 tests/validate-aws-progressive-disclosure.py",
     "validate:catalog": "python3 tests/validate-catalog.py",
     "validate:links": "python3 tests/validate-links.py --offline",
-    "validate": "npm run validate:catalog && npm run validate:aws && npm run manifest:check && npm run validate:links"
+    "validate:allowed-tools": "python3 tests/validate-skill-allowed-tools.py",
+    "validate": "npm run validate:catalog && npm run validate:aws && npm run manifest:check && npm run validate:allowed-tools && npm run validate:links"
   },
   "devDependencies": {
     "semantic-release": "25.0.3",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "validate:catalog": "python3 tests/validate-catalog.py",
     "validate:links": "python3 tests/validate-links.py --offline",
     "validate:allowed-tools": "python3 tests/validate-skill-allowed-tools.py",
-    "validate": "npm run validate:catalog && npm run validate:aws && npm run manifest:check && npm run validate:allowed-tools && npm run validate:links"
+    "validate:skill-schema": "python3 tests/validate-skill-frontmatter-schema.py",
+    "validate": "npm run validate:catalog && npm run validate:aws && npm run manifest:check && npm run validate:allowed-tools && npm run validate:skill-schema && npm run validate:links"
   },
   "devDependencies": {
     "semantic-release": "25.0.3",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "conventional-changelog-conventionalcommits": "8.0.0"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "keywords": [
     "agentic",

--- a/schemas/agent.schema.json
+++ b/schemas/agent.schema.json
@@ -90,6 +90,14 @@
     "path": {
       "type": "string",
       "minLength": 1
+    },
+    "companion_skills": {
+      "type": "array",
+      "description": "Explicit list of skill ids that pair with this agent. Overrides name-stripping convention. Set to [] to declare intentional no-pair.",
+      "items": {
+        "type": "string",
+        "pattern": "^[a-z0-9][a-z0-9-]*$"
+      }
     }
   },
   "additionalProperties": true

--- a/schemas/skill.frontmatter.schema.json
+++ b/schemas/skill.frontmatter.schema.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/Raishin/vanguard-frontier-agentic/schemas/skill.frontmatter.schema.json",
+  "title": "SKILL.md Frontmatter",
+  "description": "JSON Schema for the YAML frontmatter block in every SKILL.md file.",
+  "type": "object",
+  "required": [
+    "name",
+    "description",
+    "allowed-tools",
+    "metadata"
+  ],
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "Kebab-case identifier for the skill. Must start with a lowercase letter or digit.",
+      "pattern": "^[a-z0-9][a-z0-9-]*$"
+    },
+    "description": {
+      "type": "string",
+      "description": "Human-readable purpose statement. 50–1500 characters.",
+      "minLength": 50,
+      "maxLength": 1500
+    },
+    "allowed-tools": {
+      "description": "Explicit pre-approval list of tools this skill may invoke. May be a space-separated string or a YAML sequence of strings.",
+      "oneOf": [
+        {
+          "type": "string",
+          "minLength": 1
+        },
+        {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "type": "object",
+      "description": "Authorship and versioning block.",
+      "required": [
+        "author",
+        "version"
+      ],
+      "properties": {
+        "author": {
+          "type": "string",
+          "description": "Author identifier (e.g. 'github: handle').",
+          "minLength": 1
+        },
+        "version": {
+          "type": "string",
+          "description": "Semantic version of the skill.",
+          "pattern": "^\\d+\\.\\d+\\.\\d+(-[\\w.-]+)?$"
+        }
+      },
+      "additionalProperties": true
+    },
+    "disable-model-invocation": {
+      "type": "boolean",
+      "description": "Optional. When true, the skill suppresses direct model invocation and relies entirely on tool calls."
+    }
+  },
+  "additionalProperties": true
+}

--- a/scripts/apply-skill-allowed-tools.py
+++ b/scripts/apply-skill-allowed-tools.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Apply least-privilege `allowed-tools` to every SKILL.md frontmatter.
+
+Taxonomy (matched against skill id, first match wins):
+  maestro                  -> Agent Skill Read Grep Glob
+  *-patch-executor,
+  *-fix-operator,
+  *-corrector,
+  *-deployment-hotfix-*,
+  *-remediation-operator,
+  *-rollout-corrector,
+  *-pipeline-fix-operator  -> Read Edit Write MultiEdit Grep Glob
+  *-developer,
+  *-agentcore,
+  aws-generative-ai-developer,
+  *-application-developer  -> Read Edit Write MultiEdit Grep Glob Bash
+  *-live-*-guard,
+  velero-backup-restore-guard
+                           -> Read Grep Glob WebFetch
+  *-investigator,
+  *-responder,
+  *-advisor,
+  *-coordinator,
+  *-watch-coordinator,
+  *-analyst,
+  *-planner,
+  finops-cloud-price-advisor
+                           -> Read Grep Glob WebFetch
+  default (review/governor/
+  auditor/mapper/architect/
+  reviewer/steward/selector
+  /skill-designer)         -> Read Grep Glob
+
+Skip if `allowed-tools` is already declared (idempotent).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SKILLS_DIR = ROOT / "skills"
+
+PATCHERS = (
+    "-patch-executor", "-fix-operator", "-corrector",
+    "-deployment-hotfix-operator", "-remediation-operator",
+    "-rollout-corrector", "-pipeline-fix-operator",
+)
+
+DEVELOPERS = (
+    "-developer", "-application-developer",
+)
+
+LIVE_GUARDS = ("-live-",)
+
+INVESTIGATORS = (
+    "-investigator", "-responder", "-advisor", "-coordinator",
+    "-analyst", "-planner",
+)
+
+
+def classify(skill_id: str) -> str:
+    if skill_id.endswith("-maestro") or skill_id == "kubernetes-maestro" or skill_id == "terraform-maestro":
+        return "Agent Skill Read Grep Glob"
+    for s in PATCHERS:
+        if skill_id.endswith(s):
+            return "Read Edit Write MultiEdit Grep Glob"
+    if skill_id == "aws-agentcore" or skill_id == "aws-generative-ai-developer":
+        return "Read Edit Write MultiEdit Grep Glob Bash"
+    for s in DEVELOPERS:
+        if skill_id.endswith(s):
+            return "Read Edit Write MultiEdit Grep Glob Bash"
+    for s in LIVE_GUARDS:
+        if s in skill_id and skill_id.endswith("-guard"):
+            return "Read Grep Glob WebFetch"
+    if skill_id == "velero-backup-restore-guard":
+        return "Read Grep Glob WebFetch"
+    for s in INVESTIGATORS:
+        if skill_id.endswith(s):
+            return "Read Grep Glob WebFetch"
+    if skill_id == "finops-cloud-price-advisor":
+        return "Read Grep Glob WebFetch"
+    return "Read Grep Glob"
+
+
+def apply(skill_md: Path) -> tuple[bool, str]:
+    text = skill_md.read_text(encoding="utf-8")
+    if not text.startswith("---\n"):
+        return False, "no frontmatter"
+
+    end = text.find("\n---", 4)
+    if end == -1:
+        return False, "unterminated frontmatter"
+
+    fm_block = text[4:end]
+    if "\nallowed-tools:" in "\n" + fm_block:
+        return False, "already has allowed-tools"
+
+    skill_id = skill_md.parent.name
+    tools = classify(skill_id)
+
+    # Insert allowed-tools immediately after the description block,
+    # before the metadata: block (if any) or before the closing ---.
+    lines = fm_block.split("\n")
+    insert_at = None
+    for i, line in enumerate(lines):
+        if line.startswith("metadata:"):
+            insert_at = i
+            break
+    if insert_at is None:
+        insert_at = len(lines)
+
+    lines.insert(insert_at, f"allowed-tools: {tools}")
+    new_fm = "\n".join(lines)
+    new_text = "---\n" + new_fm + text[end:]
+    skill_md.write_text(new_text, encoding="utf-8")
+    return True, tools
+
+
+def main() -> int:
+    files = sorted(SKILLS_DIR.glob("*/*/SKILL.md"))
+    summary: dict[str, int] = {}
+    skipped = 0
+    for f in files:
+        ok, info = apply(f)
+        if ok:
+            summary[info] = summary.get(info, 0) + 1
+        else:
+            skipped += 1
+            if info != "already has allowed-tools":
+                print(f"WARN: {f.relative_to(ROOT)}: {info}", file=sys.stderr)
+
+    total = sum(summary.values())
+    print(f"Applied allowed-tools to {total} skills (skipped {skipped})")
+    for tools, count in sorted(summary.items(), key=lambda x: -x[1]):
+        print(f"  {count:3d}  {tools}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/export-marketplace-agents.mjs
+++ b/scripts/export-marketplace-agents.mjs
@@ -43,6 +43,10 @@ const PLATFORM_ALIASES = {
   kirocli: "kiro-cli",
 };
 
+const SKILLS_PLATFORM_CONFIG = {
+  "claude-code": ".claude/skills",
+};
+
 function usage(exitCode = 0) {
   const message = `
 Export selected marketplace agents into a consumer repository.
@@ -61,12 +65,20 @@ Roles:
   cloud-security-engineer, cloud-platform-engineer, cloud-dba,
   cloud-finops-analyst, cloud-solutions-architect, cloud-devops-engineer
 
+Companion skills:
+  By default, when --platform claude-code is selected, each agent's
+  same-named SKILL.md companion is also exported into <repo>/.claude/skills/.
+  Pairing rule: agent id '<name>-agent' bundles skill '<name>' if it exists.
+  Use --no-skills to export agents only.
+  Skills bundling is currently only supported on the claude-code platform.
+
 Examples:
   vfa-export-agents --list
   vfa-export-agents --list-roles
   vfa-export-agents --platform claude-code --agents azure-cosmosdb-platform-operator-agent
   vfa-export-agents --platform claude-code --role cloud-security-engineer
   vfa-export-agents --platform claude-code --role cloud-security-engineer --provider azure
+  vfa-export-agents --platform claude-code --all --no-skills --repo /path/to/project
   vfa-export-agents --platform kiro --agents azure-cosmosdb-platform-operator-agent --repo ../consumer-repo
   vfa-export-agents --platform copilot --all --repo /path/to/project --force
 `.trim();
@@ -85,6 +97,7 @@ function parseArgs(argv) {
     platform: null,
     role: null,
     provider: null,
+    noSkills: false,
   };
 
   for (let i = 0; i < argv.length; i += 1) {
@@ -104,6 +117,10 @@ function parseArgs(argv) {
     }
     if (arg === "--all") {
       args.all = true;
+      continue;
+    }
+    if (arg === "--no-skills") {
+      args.noSkills = true;
       continue;
     }
     if (arg === "--repo") {
@@ -195,6 +212,67 @@ function assertWithin(parent, child, label) {
       `This indicates a malformed metadata.json or path traversal attempt.`
     );
   }
+}
+
+function loadSkills() {
+  const skillsRoot = path.join(repoRoot, "skills");
+  if (!fs.existsSync(skillsRoot)) return new Map();
+  const byName = new Map();
+  for (const provider of fs.readdirSync(skillsRoot, { withFileTypes: true })) {
+    if (!provider.isDirectory()) continue;
+    const providerDir = path.join(skillsRoot, provider.name);
+    for (const skill of fs.readdirSync(providerDir, { withFileTypes: true })) {
+      if (!skill.isDirectory()) continue;
+      const skillDir = path.join(providerDir, skill.name);
+      if (fs.existsSync(path.join(skillDir, "SKILL.md"))) {
+        byName.set(skill.name, skillDir);
+      }
+    }
+  }
+  return byName;
+}
+
+function copySkillTree(sourceDir, destDir, force) {
+  assertWithin(repoRoot, sourceDir, "read skill source");
+  for (const entry of fs.readdirSync(sourceDir, { withFileTypes: true })) {
+    const src = path.join(sourceDir, entry.name);
+    const dst = path.join(destDir, entry.name);
+    if (entry.isSymbolicLink()) {
+      throw new Error(`Refusing to copy symbolic link in skill tree: ${src}`);
+    }
+    if (entry.isDirectory()) {
+      copySkillTree(src, dst, force);
+      continue;
+    }
+    if (!entry.isFile()) continue;
+    if (!force && fs.existsSync(dst)) {
+      throw new Error(`Refusing to overwrite existing file without --force: ${dst}`);
+    }
+    fs.mkdirSync(path.dirname(dst), { recursive: true });
+    fs.copyFileSync(src, dst);
+  }
+}
+
+function resolveCompanionSkills(selectedAgents, skillsByName, role, includeAll) {
+  const skillNames = new Set();
+  if (includeAll) {
+    for (const name of skillsByName.keys()) skillNames.add(name);
+  }
+  if (role && Array.isArray(role.skills)) {
+    for (const id of role.skills) skillNames.add(id);
+  }
+  const orphans = [];
+  for (const agent of selectedAgents) {
+    const skillName = agent.id.endsWith("-agent")
+      ? agent.id.slice(0, -"-agent".length)
+      : agent.id;
+    if (skillsByName.has(skillName)) {
+      skillNames.add(skillName);
+    } else if (!role) {
+      orphans.push(agent.id);
+    }
+  }
+  return { skillNames: [...skillNames].sort(), orphans };
 }
 
 function copyFile(source, destination, force) {
@@ -292,9 +370,11 @@ function main() {
   const platform = ensurePlatform(args.platform);
 
   let selectedAgents;
+  let selectedRole = null;
   if (args.role) {
     const rolesData = loadRoles();
     const role = Object.hasOwn(rolesData.roles, args.role) ? rolesData.roles[args.role] : undefined;
+    selectedRole = role;
     if (!role) {
       const validRoles = Object.keys(rolesData.roles).join(", ");
       throw new Error(`Unknown role: ${args.role}. Valid roles: ${validRoles}`);
@@ -352,6 +432,42 @@ function main() {
     console.log(
       `installed\t${operation.agentId}\t${operation.variantKey}\t${path.relative(args.repo, operation.dest)}`
     );
+  }
+
+  const skillsDestRoot = SKILLS_PLATFORM_CONFIG[platform];
+  if (args.noSkills) {
+    process.stderr.write(`[vfa] --no-skills: companion skills not bundled.\n`);
+  } else if (!skillsDestRoot) {
+    process.stderr.write(
+      `[vfa] Note: skills bundling is not yet supported on platform '${platform}'. ` +
+      `Agents exported only. Pass --no-skills to silence.\n`
+    );
+  } else {
+    const skillsByName = loadSkills();
+    const { skillNames, orphans } = resolveCompanionSkills(
+      selectedAgents,
+      skillsByName,
+      selectedRole,
+      args.all
+    );
+    let bundled = 0;
+    for (const skillName of skillNames) {
+      const sourceDir = skillsByName.get(skillName);
+      if (!sourceDir) continue;
+      const destDir = path.join(args.repo, skillsDestRoot, skillName);
+      assertWithin(args.repo, destDir, "write skill destination");
+      copySkillTree(sourceDir, destDir, args.force);
+      console.log(`installed\tskill:${skillName}\t${platform}\t${path.relative(args.repo, destDir)}`);
+      bundled += 1;
+    }
+    process.stderr.write(
+      `[vfa] Bundled ${bundled} companion skill(s) alongside ${selectedAgents.length} agent(s)` +
+      (orphans.length ? ` (no-skill agents: ${orphans.length})` : "") +
+      `. Use --no-skills to opt out.\n`
+    );
+    if (orphans.length && orphans.length <= 10) {
+      process.stderr.write(`[vfa] Agents without companion skill: ${orphans.join(", ")}\n`);
+    }
   }
 }
 

--- a/scripts/export-marketplace-agents.mjs
+++ b/scripts/export-marketplace-agents.mjs
@@ -178,6 +178,7 @@ function loadAgents() {
       provider: metadata.provider,
       summary: metadata.summary,
       harness_variants: metadata.harness_variants ?? {},
+      companion_skills: Array.isArray(metadata.companion_skills) ? metadata.companion_skills : undefined,
       metadataPath,
     };
   });
@@ -263,6 +264,15 @@ function resolveCompanionSkills(selectedAgents, skillsByName, role, includeAll) 
   }
   const orphans = [];
   for (const agent of selectedAgents) {
+    // Prefer explicit companion_skills if declared (even if empty — that means intentional no-pair)
+    if (Array.isArray(agent.companion_skills)) {
+      for (const skillId of agent.companion_skills) {
+        if (skillsByName.has(skillId)) skillNames.add(skillId);
+      }
+      // companion_skills: [] is intentional no-pair — do NOT count as orphan
+      continue;
+    }
+    // Fall back to name-stripping convention
     const skillName = agent.id.endsWith("-agent")
       ? agent.id.slice(0, -"-agent".length)
       : agent.id;

--- a/skills/argocd/argo-rollouts-progressive-delivery-review/SKILL.md
+++ b/skills/argocd/argo-rollouts-progressive-delivery-review/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: argo-rollouts-progressive-delivery-review
 description: Use this skill when reviewing Argo Rollouts progressive delivery configuration. Trigger when the user asks about canary or blue-green Rollout strategy correctness, AnalysisTemplate success/failure conditions, traffic weighting provider alignment, canaryService isolation, PDB deadlock risk with Rollout maxSurge settings, automated rollback posture, or manual vs automated promotion configuration.
+allowed-tools: Read Grep Glob
 metadata:
   author: "github: Raishin"
   version: "0.1.0"

--- a/skills/argocd/argocd-gitops-review/SKILL.md
+++ b/skills/argocd/argocd-gitops-review/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: argocd-gitops-review
 description: Use this skill for Argo CD GitOps review across Application, AppProject, ApplicationSet, sync windows, RBAC, sync impersonation, and Argo CD Agent multi-cluster topologies. Trigger when the user asks whether an Argo CD configuration is safe for production, whether automated sync should be enabled, whether prune+selfHeal is appropriate, whether AppProject scope is too wide, or how to enforce least-privilege sync identity.
+allowed-tools: Read Grep Glob
 metadata:
   author: "github: Raishin"
   version: "0.1.0"

--- a/skills/aws/aws-agentcore/SKILL.md
+++ b/skills/aws/aws-agentcore/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: aws-agentcore
 description: Build, test, migrate, integrate, and deploy Amazon Bedrock AgentCore agents. Use for AgentCore runtime, local development, import/migration, deployment, Memory, Gateway/MCP tools, Identity, Observability, Browser, Code Interpreter, policy, and harness-vs-code-path decisions. Load references only when that component is needed.
+allowed-tools: Read Edit Write MultiEdit Grep Glob Bash
 metadata:
   author: "github: Raishin"
   version: "0.1.6"

--- a/skills/aws/aws-api-edge-delivery-review/SKILL.md
+++ b/skills/aws/aws-api-edge-delivery-review/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: aws-api-edge-delivery-review
 description: Review AWS API and edge delivery posture across API Gateway, CloudFront, AWS WAF, Shield, ALB, custom domains, TLS policies, authentication, authorization, throttling, quotas, caching, origin protection, logging, and abuse controls. Use when public APIs, web entry points, or edge delivery can affect security and availability.
+allowed-tools: Read Grep Glob
 metadata:
   author: "github: Raishin"
   version: "0.1.2"

--- a/skills/aws/aws-bedrock-agent-security-governor/SKILL.md
+++ b/skills/aws/aws-bedrock-agent-security-governor/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: aws-bedrock-agent-security-governor
 description: Review Amazon Bedrock agents, AgentCore, Guardrails, knowledge bases, action groups, memory, MCP/tool integrations, prompt-injection and prompt-leakage defenses, PII handling, encryption, logging, observability, and least-privilege IAM. Use for AWS-native GenAI and agent security posture.
+allowed-tools: Read Grep Glob
 metadata:
   author: "github: Raishin"
   version: "0.1.2"

--- a/skills/aws/aws-change-impact-advisor/SKILL.md
+++ b/skills/aws/aws-change-impact-advisor/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: aws-change-impact-advisor
 description: Assess AWS change impact using change sets, deployment blast radius, rollback readiness, dependency mapping, risk, go/no-go context, approval context, and stakeholder communication. Prefer this for non-destructive pre-change advisory work; prefer IaC or platform-specific skills for deep implementation review.
+allowed-tools: Read Grep Glob WebFetch
 metadata:
   author: "github: Raishin"
   version: "0.1.0"

--- a/skills/aws/aws-ci-cd-release-engineer/SKILL.md
+++ b/skills/aws/aws-ci-cd-release-engineer/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: aws-ci-cd-release-engineer
 description: Review AWS CI/CD and release safety across CodePipeline, CodeBuild, CodeDeploy, GitHub Actions, GitLab, artifact provenance, deployment gates, approvals, tests, progressive delivery, rollback, change correlation, and incident-prevention recommendations. Use when AWS releases or pipelines can affect production reliability or security.
+allowed-tools: Read Grep Glob
 metadata:
   author: "github: Raishin"
   version: "0.1.2"

--- a/skills/aws/aws-compliance-evidence-mapper/SKILL.md
+++ b/skills/aws/aws-compliance-evidence-mapper/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: aws-compliance-evidence-mapper
 description: Map AWS compliance evidence for audits across Security Hub controls, AWS Config rules/conformance packs, Audit Manager assessments, evidence folders, manual evidence, AWS Artifact reports, CloudTrail, and control narratives. Use for evidence packaging and audit readiness, not general security hardening.
+allowed-tools: Read Grep Glob
 metadata:
   author: "github: Raishin"
   version: "0.1.2"

--- a/skills/aws/aws-cost-anomaly-watch-coordinator/SKILL.md
+++ b/skills/aws/aws-cost-anomaly-watch-coordinator/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: aws-cost-anomaly-watch-coordinator
 description: Review AWS cost anomalies using Cost Explorer, Cost Anomaly Detection, Budgets, usage spikes, commitments, and tagging gaps. Prefer this for proactive FinOps watch and non-destructive escalation; prefer aws-cost-optimization-governor for broader optimization strategy.
+allowed-tools: Read Grep Glob WebFetch
 metadata:
   author: "github: Raishin"
   version: "0.1.0"

--- a/skills/aws/aws-cost-optimization-governor/SKILL.md
+++ b/skills/aws/aws-cost-optimization-governor/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: aws-cost-optimization-governor
 description: Review AWS cost optimization and FinOps posture across Cost Explorer, Budgets, Cost Optimization Hub, Compute Optimizer, Savings Plans, Reserved Instances, tagging, showback, idle resources, rightsizing, storage, data transfer, and forecast risk. Use when the user asks to reduce or explain AWS cost.
+allowed-tools: Read Grep Glob
 metadata:
   author: "github: Raishin"
   version: "0.1.2"

--- a/skills/aws/aws-daily-operations-briefing-coordinator/SKILL.md
+++ b/skills/aws/aws-daily-operations-briefing-coordinator/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: aws-daily-operations-briefing-coordinator
 description: Prepare AWS daily operations briefings using CloudWatch, Personal Health Dashboard, Trusted Advisor, cost signals, deployment timelines, incidents, risks, and action backlog. Prefer this for non-destructive business and engineering status coordination; prefer observability, cost, or incident skills for deeper domain investigation.
+allowed-tools: Read Grep Glob WebFetch
 metadata:
   author: "github: Raishin"
   version: "0.1.0"

--- a/skills/aws/aws-data-protection-backup-steward/SKILL.md
+++ b/skills/aws/aws-data-protection-backup-steward/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: aws-data-protection-backup-steward
 description: Review AWS backup and data protection implementation across AWS Backup, EBS/RDS/EFS/S3 recovery patterns, vaults, vault lock, retention, encryption, cross-account/cross-Region copy, restore testing, lifecycle, and recovery evidence. Prefer resilience BCDR review for broader RTO/RPO, failover, and business continuity design.
+allowed-tools: Read Grep Glob
 metadata:
   author: "github: Raishin"
   version: "0.1.2"

--- a/skills/aws/aws-deployment-hotfix-operator/SKILL.md
+++ b/skills/aws/aws-deployment-hotfix-operator/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: aws-deployment-hotfix-operator
 description: Patch AWS deployment hotfix config, release parameters, manifest mistakes, environment drift, rollback blockers, and rollout blockers in-repo. Use for rapid non-destructive deployment corrections; do not use for live deploy/apply/destroy actions.
+allowed-tools: Read Edit Write MultiEdit Grep Glob
 metadata:
   author: "github: Raishin"
   version: "0.1.0"

--- a/skills/aws/aws-devops-agent-skill-designer/SKILL.md
+++ b/skills/aws/aws-devops-agent-skill-designer/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: aws-devops-agent-skill-designer
 description: Design, review, and improve AWS DevOps Agent-compatible skills, investigation workflows, learned skills, tool-use best practices, agent type targeting, frontmatter descriptions, reference materials, and operational output contracts. Use when creating or adapting skills for AWS DevOps Agent or AWS-style incident agents.
+allowed-tools: Read Grep Glob
 metadata:
   author: "github: Raishin"
   version: "0.1.2"

--- a/skills/aws/aws-dynamodb-data-modeling-performance-review/SKILL.md
+++ b/skills/aws/aws-dynamodb-data-modeling-performance-review/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: aws-dynamodb-data-modeling-performance-review
 description: Review Amazon DynamoDB data modeling and performance across access patterns, partition keys, sort keys, secondary indexes, GSI/LSI design, hot partitions, query versus scan behavior, capacity mode, adaptive capacity, global tables, TTL, DAX, item size, transactions, and cost. Use when DynamoDB correctness, latency, scaling, or cost depends on table design.
+allowed-tools: Read Grep Glob
 metadata:
   author: "github: Raishin"
   version: "0.1.2"

--- a/skills/aws/aws-ec2-compute-operations-steward/SKILL.md
+++ b/skills/aws/aws-ec2-compute-operations-steward/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: aws-ec2-compute-operations-steward
 description: Review Amazon EC2 compute operations across instances, Auto Scaling groups, Launch Templates, AMIs, Systems Manager, Patch Manager, Session Manager, EBS volumes, snapshots, health checks, instance refresh, lifecycle hooks, patch compliance, and fleet reliability. Use for EC2 day-2 operations and legacy workload stewardship.
+allowed-tools: Read Grep Glob
 metadata:
   author: "github: Raishin"
   version: "0.1.2"

--- a/skills/aws/aws-ecs-fargate-platform-operator/SKILL.md
+++ b/skills/aws/aws-ecs-fargate-platform-operator/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: aws-ecs-fargate-platform-operator
 description: Review Amazon ECS and Fargate platform operations across services, task definitions, task roles, execution roles, capacity providers, load balancers, deployment circuit breakers, blue/green, autoscaling, health checks, logs, secrets, networking, and rollback. Use only for ECS/Fargate; prefer EKS operator for Kubernetes.
+allowed-tools: Read Grep Glob
 metadata:
   author: "github: Raishin"
   version: "0.1.2"

--- a/skills/aws/aws-ecs-service-remediation-operator/SKILL.md
+++ b/skills/aws/aws-ecs-service-remediation-operator/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: aws-ecs-service-remediation-operator
 description: Correct AWS ECS and Fargate service definitions, task definition config, deployment parameters, health checks, environment settings, and rollout wiring in-repo. Use for non-destructive repo fixes only; do not force deployments or mutate live services from this role.
+allowed-tools: Read Edit Write MultiEdit Grep Glob
 metadata:
   author: "github: Raishin"
   version: "0.1.0"

--- a/skills/aws/aws-eks-platform-operator/SKILL.md
+++ b/skills/aws/aws-eks-platform-operator/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: aws-eks-platform-operator
 description: Review Amazon EKS Kubernetes platform operations across cluster access, IRSA, IAM roles for service accounts, pod identity, node groups, Karpenter, autoscaling, CNI/network policy, upgrades, reliability, observability, and cost. Use only for EKS/Kubernetes; prefer ECS/Fargate operator for ECS services.
+allowed-tools: Read Grep Glob
 metadata:
   author: "github: Raishin"
   version: "0.1.2"

--- a/skills/aws/aws-event-driven-architecture-review/SKILL.md
+++ b/skills/aws/aws-event-driven-architecture-review/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: aws-event-driven-architecture-review
 description: Review AWS event-driven system design across EventBridge, event buses, Pipes, SQS, SNS, Step Functions, event schemas, filtering, cross-account routing, retries, DLQs, replay, idempotency, monitoring, and event-loop risk. Prefer serverless production readiness for Lambda runtime/deployment readiness.
+allowed-tools: Read Grep Glob
 metadata:
   author: "github: Raishin"
   version: "0.1.2"

--- a/skills/aws/aws-generative-ai-developer/SKILL.md
+++ b/skills/aws/aws-generative-ai-developer/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: aws-generative-ai-developer
 description: Build Amazon Bedrock and serverless generative AI applications using Lambda, API Gateway, Step Functions, EventBridge, S3, DynamoDB, SQS, Guardrails, and IAM. Prefer this for serverless GenAI app design and implementation; prefer aws-agentcore for AgentCore runtime, aws-bedrock-agent-security-governor for deep Bedrock security, and aws-serverless-production-readiness for final operational hardening.
+allowed-tools: Read Edit Write MultiEdit Grep Glob Bash
 metadata:
   author: "github: Raishin"
   version: "0.1.0"

--- a/skills/aws/aws-iac-change-safety-review/SKILL.md
+++ b/skills/aws/aws-iac-change-safety-review/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: aws-iac-change-safety-review
 description: Review AWS infrastructure-as-code changes across CDK, CloudFormation, SAM, Terraform, Serverless Framework, generated templates, plans, stack updates, change sets, and drift. Use when the user asks whether an AWS IaC deployment is safe, what a change set will do, why a resource replacement will happen, or how to validate before production.
+allowed-tools: Read Grep Glob
 metadata:
   author: "github: Raishin"
   version: "0.1.2"

--- a/skills/aws/aws-iac-patch-executor/SKILL.md
+++ b/skills/aws/aws-iac-patch-executor/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: aws-iac-patch-executor
 description: Edit AWS IaC files including CloudFormation, SAM, CDK config, and Terraform to patch defects, prepare change set review, or unblock rollout work. Prefer this for bounded repo changes only; do not use for apply, deploy, or destructive infrastructure execution.
+allowed-tools: Read Edit Write MultiEdit Grep Glob
 metadata:
   author: "github: Raishin"
   version: "0.1.0"

--- a/skills/aws/aws-iam-least-privilege-review/SKILL.md
+++ b/skills/aws/aws-iam-least-privilege-review/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: aws-iam-least-privilege-review
 description: Review AWS IAM identity policies, trust policies, resource policies, permission boundaries, SCPs, session policies, role design, pass-role, federation, and Access Analyzer findings for least-privilege risk. Prefer KMS/secrets steward for key/secret lifecycle design and S3 perimeter governor for S3 exposure/data-perimeter posture unless the request is primarily policy surgery.
+allowed-tools: Read Grep Glob
 metadata:
   author: "github: Raishin"
   version: "0.1.2"

--- a/skills/aws/aws-kms-secrets-lifecycle-steward/SKILL.md
+++ b/skills/aws/aws-kms-secrets-lifecycle-steward/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: aws-kms-secrets-lifecycle-steward
 description: Review AWS KMS and Secrets Manager lifecycle posture across key policies, grants, rotation, multi-Region keys, imported key material, aliases, secret rotation, replication, caching, endpoint conditions, recovery, and break-glass access. Prefer this for cryptography/secret lifecycle; prefer IAM skill for general permissions review.
+allowed-tools: Read Grep Glob
 metadata:
   author: "github: Raishin"
   version: "0.1.2"

--- a/skills/aws/aws-landing-zone-governor/SKILL.md
+++ b/skills/aws/aws-landing-zone-governor/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: aws-landing-zone-governor
 description: Review and design AWS landing zones, AWS Control Tower environments, Organizations structures, OUs, account vending patterns, guardrails, central logging, security/audit accounts, and multi-account governance. Use when the user asks how to structure AWS accounts or govern a cloud estate.
+allowed-tools: Read Grep Glob
 metadata:
   author: "github: Raishin"
   version: "0.1.2"

--- a/skills/aws/aws-live-deployment-guarded-operator/SKILL.md
+++ b/skills/aws/aws-live-deployment-guarded-operator/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: aws-live-deployment-guarded-operator
 description: Operate guarded live AWS deployment changes with explicit account, region, profile, approval, dry-run, rollback, and verification gates. Use only when the target environment is confirmed and a live deployment action is intentionally requested.
+allowed-tools: Read Grep Glob
 metadata:
   author: "github: Raishin"
   version: "0.1.0"

--- a/skills/aws/aws-live-ecs-rollout-guard/SKILL.md
+++ b/skills/aws/aws-live-ecs-rollout-guard/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: aws-live-ecs-rollout-guard
 description: Guard live Amazon ECS and Fargate rollout actions with ecs service, task definition, deployment circuit breaker, alarms, rollback, health check, and approval gates. Use only for intentional live ECS rollout actions against confirmed targets.
+allowed-tools: Read Grep Glob WebFetch
 metadata:
   author: "github: Raishin"
   version: "0.1.0"

--- a/skills/aws/aws-live-iac-change-guard/SKILL.md
+++ b/skills/aws/aws-live-iac-change-guard/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: aws-live-iac-change-guard
 description: Guard live CloudFormation, SAM, CDK, and Terraform-backed AWS infrastructure changes with change set, drift, stack policy, rollback trigger, approval, and execute gates. Use only for intentional live IaC execution with confirmed targets.
+allowed-tools: Read Grep Glob WebFetch
 metadata:
   author: "github: Raishin"
   version: "0.1.0"

--- a/skills/aws/aws-live-pipeline-approval-operator/SKILL.md
+++ b/skills/aws/aws-live-pipeline-approval-operator/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: aws-live-pipeline-approval-operator
 description: Handle live CodePipeline approval and gated resume decisions with pipeline, stage, approver, SNS, approval, blast radius, and rollback checks. Use only when a real pipeline execution is paused or about to be approved.
+allowed-tools: Read Grep Glob
 metadata:
   author: "github: Raishin"
   version: "0.1.0"

--- a/skills/aws/aws-live-serverless-release-guard/SKILL.md
+++ b/skills/aws/aws-live-serverless-release-guard/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: aws-live-serverless-release-guard
 description: Guard live Lambda and serverless release actions with lambda alias, codedeploy, canary, linear, alarms, rollback, and approval gates. Use only for intentional live serverless rollout actions against confirmed targets.
+allowed-tools: Read Grep Glob WebFetch
 metadata:
   author: "github: Raishin"
   version: "0.1.0"

--- a/skills/aws/aws-maestro/SKILL.md
+++ b/skills/aws/aws-maestro/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: aws-maestro
 description: Route AWS tasks to the narrowest specialist or team of specialists from the 42-agent catalog. Use when you do not already know the specialist. Not for direct AWS answers; Maestro classifies, dispatches, and synthesizes only. Dispatches single agent for focused tasks, parallel team (max 4) for multi-domain tasks. Never auto-dispatches live-guard agents — requires explicit human confirmation with blast-radius and rollback before routing to any live deployment or production-change specialist.
+allowed-tools: Agent Skill Read Grep Glob
 metadata:
   author: "github: Raishin"
   version: "0.1.0"

--- a/skills/aws/aws-migration-cutover-architect/SKILL.md
+++ b/skills/aws/aws-migration-cutover-architect/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: aws-migration-cutover-architect
 description: Plan, review, and de-risk AWS migrations and cutovers across discovery, dependency mapping, wave planning, AWS Application Migration Service, Migration Hub, test launches, acceptance tests, downtime windows, rollback, DNS, data consistency, and post-cutover validation. Use for migration planning and cutover readiness.
+allowed-tools: Read Grep Glob
 metadata:
   author: "github: Raishin"
   version: "0.1.2"

--- a/skills/aws/aws-network-architect/SKILL.md
+++ b/skills/aws/aws-network-architect/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: aws-network-architect
 description: Design, review, and troubleshoot AWS network, hybrid, and multi-cloud connectivity across VPCs, Transit Gateway, Direct Connect, VPN, Cloud WAN, Route 53 Resolver, private DNS, CIDRs, route tables, endpoints, segmentation, ingress, egress, inspection, and failover. Prefer this for connectivity and routing; prefer API/edge, S3, or security skills for those specialized surfaces.
+allowed-tools: Read Grep Glob
 metadata:
   author: "github: Raishin"
   version: "0.1.2"

--- a/skills/aws/aws-non-destructive-task-automation-advisor/SKILL.md
+++ b/skills/aws/aws-non-destructive-task-automation-advisor/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: aws-non-destructive-task-automation-advisor
 description: Design AWS non-destructive task automation using EventBridge, Step Functions, Lambda, Systems Manager Automation, SNS, SQS, approvals, notifications, reporting, and evidence gathering. Use only for read-only or coordination-safe automation; do not use for destructive remediation or mutation-heavy runbooks.
+allowed-tools: Read Grep Glob WebFetch
 metadata:
   author: "github: Raishin"
   version: "0.1.0"

--- a/skills/aws/aws-observability-incident-responder/SKILL.md
+++ b/skills/aws/aws-observability-incident-responder/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: aws-observability-incident-responder
 description: Investigate broad AWS incidents and observability gaps using CloudWatch metrics, logs, alarms, traces, EventBridge events, service health, runbooks, timelines, blast radius, root-cause discipline, and post-incident actions. Prefer RDS/Aurora investigator for database-specific performance incidents.
+allowed-tools: Read Grep Glob WebFetch
 metadata:
   author: "github: Raishin"
   version: "0.1.2"

--- a/skills/aws/aws-pipeline-fix-operator/SKILL.md
+++ b/skills/aws/aws-pipeline-fix-operator/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: aws-pipeline-fix-operator
 description: Repair AWS pipeline configuration, buildspecs, workflow files, deployment steps, artifact wiring, release guardrails, and CodeDeploy integration in-repo. Use for non-destructive CI/CD corrections; do not trigger live pipeline runs or mutate cloud state.
+allowed-tools: Read Edit Write MultiEdit Grep Glob
 metadata:
   author: "github: Raishin"
   version: "0.1.0"

--- a/skills/aws/aws-private-ca-issuer-review/SKILL.md
+++ b/skills/aws/aws-private-ca-issuer-review/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: aws-private-ca-issuer-review
 description: Use this skill when reviewing AWS ACM Private CA (Private Certificate Authority) issuer configurations for cert-manager. Trigger on any request to audit AWSPCAIssuer, AWSPCAClusterIssuer, IRSA policy for cert-manager, certificate template ARNs, CRL configuration, or cross-account PCA usage.
+allowed-tools: Read Grep Glob
 metadata:
   author: "github: Raishin"
   version: "0.1.0"

--- a/skills/aws/aws-rds-aurora-performance-investigator/SKILL.md
+++ b/skills/aws/aws-rds-aurora-performance-investigator/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: aws-rds-aurora-performance-investigator
 description: Investigate Amazon RDS and Aurora-specific incidents involving latency, connection exhaustion, slow queries, lock waits, storage pressure, CPU/I/O saturation, replica lag, failover behavior, Performance Insights, and database capacity. Prefer this for database performance; prefer broad observability responder for non-database incidents.
+allowed-tools: Read Grep Glob WebFetch
 metadata:
   author: "github: Raishin"
   version: "0.1.2"

--- a/skills/aws/aws-resilience-bcdr-review/SKILL.md
+++ b/skills/aws/aws-resilience-bcdr-review/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: aws-resilience-bcdr-review
 description: Review AWS resilience and business continuity strategy across RTO/RPO, dependency maps, multi-AZ, multi-Region, failover/failback, game days, runbooks, drift, and recovery validation. Prefer data protection backup steward for backup-plan/vault/restore implementation details.
+allowed-tools: Read Grep Glob
 metadata:
   author: "github: Raishin"
   version: "0.1.2"

--- a/skills/aws/aws-s3-data-perimeter-governor/SKILL.md
+++ b/skills/aws/aws-s3-data-perimeter-governor/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: aws-s3-data-perimeter-governor
 description: Review Amazon S3 data perimeter and exposure posture across Block Public Access, Object Ownership, ACL removal, bucket/access point policies, TLS-only access, encryption, replication, lifecycle, logging, cross-account access, and prefix boundaries. Prefer this for S3 data exposure; prefer IAM skill for generic policy surgery.
+allowed-tools: Read Grep Glob
 metadata:
   author: "github: Raishin"
   version: "0.1.2"

--- a/skills/aws/aws-security-posture-hardening/SKILL.md
+++ b/skills/aws/aws-security-posture-hardening/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: aws-security-posture-hardening
 description: Review broad AWS security posture across Security Hub CSPM, GuardDuty, Inspector, Macie, Config, CloudTrail, IAM, public exposure, vulnerability findings, and remediation governance. Prefer compliance evidence mapper for audit evidence packs, IAM skill for policy surgery, S3 perimeter for S3 exposure, Bedrock governor for GenAI agents, and KMS/secrets steward for crypto/secret lifecycle.
+allowed-tools: Read Grep Glob
 metadata:
   author: "github: Raishin"
   version: "0.1.2"

--- a/skills/aws/aws-serverless-production-readiness/SKILL.md
+++ b/skills/aws/aws-serverless-production-readiness/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: aws-serverless-production-readiness
 description: Review AWS Lambda-centered serverless workloads for production readiness across execution roles, event sources, retries, DLQs/destinations, concurrency, idempotency, observability, deployment safety, performance, cost, and rollback. Prefer event-driven architecture for EventBridge/SNS/SQS/Step Functions system design, and DynamoDB/RDS skills for data-store performance.
+allowed-tools: Read Grep Glob
 metadata:
   author: "github: Raishin"
   version: "0.1.2"

--- a/skills/aws/aws-serverless-rollout-corrector/SKILL.md
+++ b/skills/aws/aws-serverless-rollout-corrector/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: aws-serverless-rollout-corrector
 description: Patch AWS serverless rollout definitions across Lambda, API Gateway, EventBridge, SQS, SNS, event source wiring, aliases, versions, and deployment config. Prefer this for repo-side rollout corrections; do not perform live rollout actions or destructive operations.
+allowed-tools: Read Edit Write MultiEdit Grep Glob
 metadata:
   author: "github: Raishin"
   version: "0.1.0"

--- a/skills/aws/aws-solution-architect/SKILL.md
+++ b/skills/aws/aws-solution-architect/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: aws-solution-architect
 description: Design and stress-test AWS cross-domain solution architectures when the request spans multiple AWS domains or needs an architecture decision record. Prefer narrower AWS skills for single-domain IAM, network, EKS, ECS, serverless, RDS, DynamoDB, S3, Bedrock, IaC, cost, security, migration, compliance, or incident asks.
+allowed-tools: Read Grep Glob
 metadata:
   author: "github: Raishin"
   version: "0.1.2"

--- a/skills/aws/aws-ticket-triage-escalation-coordinator/SKILL.md
+++ b/skills/aws/aws-ticket-triage-escalation-coordinator/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: aws-ticket-triage-escalation-coordinator
 description: Triage AWS tickets and alerts using priority, owner, evidence, incident context, escalation path, OpsCenter, health signals, and safe next steps. Prefer this for non-destructive request coordination and escalation; prefer deep domain skills for implementation or root-cause investigation.
+allowed-tools: Read Grep Glob WebFetch
 metadata:
   author: "github: Raishin"
   version: "0.1.0"

--- a/skills/azure/azure-ai-foundry-ops-governor/SKILL.md
+++ b/skills/azure/azure-ai-foundry-ops-governor/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: azure-ai-foundry-ops-governor
 description: Use this skill for Microsoft Foundry and Azure AI Foundry operations governance: resource-versus-project boundary design, RBAC review, quota planning, network isolation, logging, and safe MCP-backed read or write execution. Trigger when the user asks how to run Foundry safely across teams without access sprawl, quota surprises, or unsafe production mutations.
+allowed-tools: Read Grep Glob
 metadata:
   author: github: Raishin
   version: 0.1.0

--- a/skills/azure/azure-aks-platform-operator/SKILL.md
+++ b/skills/azure/azure-aks-platform-operator/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: azure-aks-platform-operator
 description: Operate Azure Kubernetes Service with an adversarial production posture. Use for AKS architecture sanity checks, upgrade safety, node-pool strategy, workload identity, network policy, scaling, observability, and operator-readiness reviews.
+allowed-tools: Read Grep Glob
 metadata:
   author: github: Raishin
   version: 0.1.0

--- a/skills/azure/azure-app-service-production-readiness/SKILL.md
+++ b/skills/azure/azure-app-service-production-readiness/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: azure-app-service-production-readiness
 description: Review Azure App Service and Web Apps for production readiness across plan tier fit, slots, networking, private ingress, identities, secrets, scaling, diagnostics, resilience, backup, rollback, and operator readiness. Use when a team wants a real go/no-go decision instead of shallow reassurance.
+allowed-tools: Read Grep Glob
 metadata:
   author: github: Raishin
   version: 0.1.0

--- a/skills/azure/azure-cosmosdb-application-developer/SKILL.md
+++ b/skills/azure/azure-cosmosdb-application-developer/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: azure-cosmosdb-application-developer
 description: Use this skill for Azure Cosmos DB application development work, especially NoSQL data modeling, document structure, partition-aware access patterns, point reads, query design, SDK usage, transactional batch scope, consistency-aware reads, change feed integration, and Cosmos DB development guidance.
+allowed-tools: Read Edit Write MultiEdit Grep Glob Bash
 metadata:
   author: github: Raishin
   version: 0.1.0

--- a/skills/azure/azure-cosmosdb-performance-investigator/SKILL.md
+++ b/skills/azure/azure-cosmosdb-performance-investigator/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: azure-cosmosdb-performance-investigator
 description: Use this skill for Azure Cosmos DB performance investigation, especially RU spikes, query latency, throttling, hot partitions, indexing inefficiency, partition-skew analysis, request-charge profiling, diagnostic-log review, and evidence-driven remediation planning.
+allowed-tools: Read Grep Glob WebFetch
 metadata:
   author: github: Raishin
   version: 0.1.0

--- a/skills/azure/azure-cosmosdb-platform-operator/SKILL.md
+++ b/skills/azure/azure-cosmosdb-platform-operator/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: azure-cosmosdb-platform-operator
 description: Use this skill for Azure Cosmos DB platform operations and design review, especially accounts, databases, containers, partition-key design, throughput and RU posture, consistency choices, indexing, throttling, multi-region replication, private connectivity, and Cosmos DB MCP-guided discovery.
+allowed-tools: Read Grep Glob
 metadata:
   author: github: Raishin
   version: 0.1.0

--- a/skills/azure/azure-cost-estimation-review/SKILL.md
+++ b/skills/azure/azure-cost-estimation-review/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: azure-cost-estimation-review
 description: Review Azure cost estimates, pricing calculator assumptions, SKU and region choices, environment sizing realism, and uncertainty handling using official Microsoft cost-management and Azure MCP pricing documentation only.
+allowed-tools: Read Grep Glob
 metadata:
   author: github: Raishin
   version: 0.1.0

--- a/skills/azure/azure-cost-optimization-governor/SKILL.md
+++ b/skills/azure/azure-cost-optimization-governor/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: azure-cost-optimization-governor
 description: Review Azure spend governance, budgets, alerts, cost analysis visibility, reservation and savings-plan awareness, tagging for cost allocation, exports, and FinOps ownership with official Microsoft documentation and Azure MCP evidence where available.
+allowed-tools: Read Grep Glob
 metadata:
   author: github: Raishin
   version: 0.1.0

--- a/skills/azure/azure-entra-id-specialist/SKILL.md
+++ b/skills/azure/azure-entra-id-specialist/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: azure-entra-id-specialist
 description: Use this skill for Microsoft Entra ID specialist work, especially Conditional Access, authentication methods, MFA and SSPR registration, identity protection, workload identities, app registrations, external identities, agent identities, break-glass posture, and tenant identity control reviews.
+allowed-tools: Read Grep Glob
 metadata:
   author: github: Raishin
   version: 0.1.0

--- a/skills/azure/azure-governance-policy-guardrails/SKILL.md
+++ b/skills/azure/azure-governance-policy-guardrails/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: azure-governance-policy-guardrails
 description: Use this skill for Azure Policy guardrails, initiatives, assignment scope, management-group inheritance, exclusions, remediation risk, tag governance, allowed regions or SKUs, and staged governance rollout reviews.
+allowed-tools: Read Grep Glob
 metadata:
   author: github: Raishin
   version: 0.1.0

--- a/skills/azure/azure-identity-governance-review/SKILL.md
+++ b/skills/azure/azure-identity-governance-review/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: azure-identity-governance-review
 description: Review Microsoft Entra identity governance posture for Azure operators, with focus on standing versus eligible access, Privileged Identity Management, access reviews, entitlement management, ownership gaps, and least-privilege control patterns.
+allowed-tools: Read Grep Glob
 metadata:
   author: github: Raishin
   version: 0.1.0

--- a/skills/azure/azure-key-vault-secret-lifecycle-auditor/SKILL.md
+++ b/skills/azure/azure-key-vault-secret-lifecycle-auditor/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: azure-key-vault-secret-lifecycle-auditor
 description: Audit Azure Key Vault secret lifecycle posture across RBAC, soft delete, purge protection, rotation, expiration, metadata hygiene, Event Grid notifications, and recovery readiness. Use when the question is whether secret management is actually safe, not just present.
+allowed-tools: Read Grep Glob
 metadata:
   author: github: Raishin
   version: 0.1.0

--- a/skills/azure/azure-keyvault-certificate-issuer-review/SKILL.md
+++ b/skills/azure/azure-keyvault-certificate-issuer-review/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: azure-keyvault-certificate-issuer-review
 description: Use this skill when reviewing Azure Key Vault certificate issuer configurations for cert-manager on AKS. Trigger on any request to audit Key Vault certificate policies, Managed Identity role assignments, exportability settings, private endpoint connectivity, integrated CA credentials, or rotation policy alignment.
+allowed-tools: Read Grep Glob
 metadata:
   author: "github: Raishin"
   version: "0.1.0"

--- a/skills/azure/azure-landing-zone-architect/SKILL.md
+++ b/skills/azure/azure-landing-zone-architect/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: azure-landing-zone-architect
 description: Use this skill for Azure landing-zone design, management-group and subscription hierarchy reviews, platform-versus-application boundary decisions, or multi-subscription Azure platform architecture critiques that span governance, identity, networking, security, and operations.
+allowed-tools: Read Grep Glob
 metadata:
   author: github: Raishin
   version: 0.1.0

--- a/skills/azure/azure-live-aks-rollout-guard/SKILL.md
+++ b/skills/azure/azure-live-aks-rollout-guard/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: azure-live-aks-rollout-guard
 description: Guard live AKS deployment rollouts with PDB audit, maxUnavailable/surge validation, rollout pause/undo gates, and post-rollout health verification.
+allowed-tools: Read Grep Glob WebFetch
 metadata:
   author: "github: Raishin"
   version: "0.1.0"

--- a/skills/azure/azure-live-app-service-slot-swap-guard/SKILL.md
+++ b/skills/azure/azure-live-app-service-slot-swap-guard/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: azure-live-app-service-slot-swap-guard
 description: Guard live App Service slot swaps with sticky-settings audit, warmup probe verification, swap-with-preview staging, and instant rollback posture.
+allowed-tools: Read Grep Glob WebFetch
 metadata:
   author: "github: Raishin"
   version: "0.1.0"

--- a/skills/azure/azure-live-arm-deployment-stack-guard/SKILL.md
+++ b/skills/azure/azure-live-arm-deployment-stack-guard/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: azure-live-arm-deployment-stack-guard
 description: Guard live ARM, Bicep, and Deployment Stack changes with what-if evidence, denySettings review, changeset diff, rollback posture, and approval gates.
+allowed-tools: Read Grep Glob WebFetch
 metadata:
   author: "github: Raishin"
   version: "0.1.0"

--- a/skills/azure/azure-live-cost-budget-action-guard/SKILL.md
+++ b/skills/azure/azure-live-cost-budget-action-guard/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: azure-live-cost-budget-action-guard
 description: Gate Azure budget action changes and GPU/HPC SKU provisioning against approved spend limits, with quota audits and emergency spend-stop playbooks.
+allowed-tools: Read Grep Glob WebFetch
 metadata:
   author: "github: Raishin"
   version: "0.1.0"

--- a/skills/azure/azure-live-entra-role-assignment-guard/SKILL.md
+++ b/skills/azure/azure-live-entra-role-assignment-guard/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: azure-live-entra-role-assignment-guard
 description: Guard live permanent Microsoft Entra ID and Azure RBAC role assignments with scope audit, principal-type risk classification, dangerous-role detection, and explicit approval gates before write. Use only when a direct (non-PIM) role assignment is intentionally requested against a confirmed target.
+allowed-tools: Read Grep Glob WebFetch
 metadata:
   author: "github: Raishin"
   version: "0.1.0"

--- a/skills/azure/azure-live-keyvault-rotation-purge-guard/SKILL.md
+++ b/skills/azure/azure-live-keyvault-rotation-purge-guard/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: azure-live-keyvault-rotation-purge-guard
 description: Guard Key Vault key rotation, rotation policy changes, soft-delete enforcement, and purge-protection enablement with irreversibility warnings and rollback evidence.
+allowed-tools: Read Grep Glob WebFetch
 metadata:
   author: "github: Raishin"
   version: "0.1.0"

--- a/skills/azure/azure-live-pim-jit-activation-guard/SKILL.md
+++ b/skills/azure/azure-live-pim-jit-activation-guard/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: azure-live-pim-jit-activation-guard
 description: Gate Entra ID PIM eligible role activations with justification, MFA, ticket binding, time-bound scope, and approval workflow gates before any privileged Azure role becomes active.
+allowed-tools: Read Grep Glob WebFetch
 metadata:
   author: "github: Raishin"
   version: "0.1.0"

--- a/skills/azure/azure-maestro/SKILL.md
+++ b/skills/azure/azure-maestro/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: azure-maestro
 description: Use this skill to classify a user task, select the right Azure specialist agent or team of specialists from the catalog, and dispatch them. Single specialist for focused single-domain tasks; parallel team (max 4) for tasks that span multiple domains. Never auto-dispatches live-guard agents — those always pause for human confirmation.
+allowed-tools: Agent Skill Read Grep Glob
 metadata:
   author: github: Raishin
   version: 0.1.0

--- a/skills/azure/azure-migrate-landing-zone-cutover/SKILL.md
+++ b/skills/azure/azure-migrate-landing-zone-cutover/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: azure-migrate-landing-zone-cutover
 description: Plan and stress-test Azure migration cutovers across landing-zone readiness, Azure Migrate assessments, dependency sequencing, permissions, rollback, and operational ownership. Use when a migration plan needs a go/no-go verdict instead of vague optimism.
+allowed-tools: Read Grep Glob
 metadata:
   author: github: Raishin
   version: 0.1.0

--- a/skills/azure/azure-network-topology-review/SKILL.md
+++ b/skills/azure/azure-network-topology-review/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: azure-network-topology-review
 description: Use this skill for Azure network architecture review, hub-spoke critique, routing and DNS dependency analysis, shared-services boundary decisions, firewall placement review, and landing-zone connectivity guidance.
+allowed-tools: Read Grep Glob
 metadata:
   author: github: Raishin
   version: 0.1.0

--- a/skills/azure/azure-observability-investigator/SKILL.md
+++ b/skills/azure/azure-observability-investigator/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: azure-observability-investigator
 description: Use this skill for Azure Monitor, Log Analytics, Application Insights, alerting, KQL triage, telemetry-gap analysis, workbooks, or operator-grade incident and posture investigations.
+allowed-tools: Read Grep Glob WebFetch
 metadata:
   author: github: Raishin
   version: 0.1.0

--- a/skills/azure/azure-platform-automation-devops/SKILL.md
+++ b/skills/azure/azure-platform-automation-devops/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: azure-platform-automation-devops
 description: Design and review Azure platform automation and DevOps delivery for landing zones, shared platform services, and safe infrastructure rollout flows. Use for IaC approach selection, Bicep versus Terraform positioning, bootstrap/run phase separation, pipeline control design, secret-handling posture, and rollout validation gates.
+allowed-tools: Read Grep Glob
 metadata:
   author: github: Raishin
   version: 0.1.0

--- a/skills/azure/azure-private-endpoint-adoption-planner/SKILL.md
+++ b/skills/azure/azure-private-endpoint-adoption-planner/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: azure-private-endpoint-adoption-planner
 description: Use this skill for Azure Private Link and private endpoint adoption planning, including hub-versus-spoke placement, private DNS zone linkage, route implications, centralized versus workload-local endpoint trade-offs, and safe rollout validation.
+allowed-tools: Read Grep Glob WebFetch
 metadata:
   author: github: Raishin
   version: 0.1.0

--- a/skills/azure/azure-rbac-review/SKILL.md
+++ b/skills/azure/azure-rbac-review/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: azure-rbac-review
 description: Use this skill for Azure RBAC, Entra-backed access, role assignment, custom role, scope, subscription, management group, or least-privilege review tasks. Trigger when the user asks whether Azure access is too broad or how to grant access safely.
+allowed-tools: Read Grep Glob
 metadata:
   author: github: Raishin
   version: 0.1.0

--- a/skills/azure/azure-resilience-bcdr-review/SKILL.md
+++ b/skills/azure/azure-resilience-bcdr-review/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: azure-resilience-bcdr-review
 description: Use this skill for Azure resilience, business continuity, and disaster recovery reviews covering RTO/RPO realism, failover and failback assumptions, shared-responsibility gaps, and recovery runbook or drill quality.
+allowed-tools: Read Grep Glob
 metadata:
   author: github: Raishin
   version: 0.1.0

--- a/skills/azure/azure-resource-health-incident-triage/SKILL.md
+++ b/skills/azure/azure-resource-health-incident-triage/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: azure-resource-health-incident-triage
 description: Use this skill for Azure Resource Health, Service Health, activity-log alert, and first-pass incident triage when the question is whether Azure platform health is part of the problem.
+allowed-tools: Read Grep Glob
 metadata:
   author: github: Raishin
   version: 0.1.0

--- a/skills/azure/azure-role-selector/SKILL.md
+++ b/skills/azure/azure-role-selector/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: azure-role-selector
 description: Use this skill when the user asks which Azure role to assign, how to grant minimum access, whether a built-in role is sufficient, or when a custom role may be required.
+allowed-tools: Read Grep Glob
 metadata:
   author: github: Raishin
   version: 0.1.0

--- a/skills/azure/azure-security-posture-hardening/SKILL.md
+++ b/skills/azure/azure-security-posture-hardening/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: azure-security-posture-hardening
 description: Use this skill for Azure security posture review, baseline hardening, managed identity adoption, Key Vault posture, private access decisions, Azure Policy guardrails, and logging or audit gap analysis. Trigger when the user asks how to harden an Azure workload or platform without defaulting to broad access or public exposure.
+allowed-tools: Read Grep Glob
 metadata:
   author: github: Raishin
   version: 0.1.0

--- a/skills/azure/azure-subscription-resource-organization/SKILL.md
+++ b/skills/azure/azure-subscription-resource-organization/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: azure-subscription-resource-organization
 description: Use this skill for Azure management-group hierarchy, subscription placement, resource-group boundary, and platform-versus-workload ownership decisions that affect governance, operations, and landing-zone scale.
+allowed-tools: Read Grep Glob
 metadata:
   author: github: Raishin
   version: 0.1.0

--- a/skills/backstage/backstage-scaffolder-template-review/SKILL.md
+++ b/skills/backstage/backstage-scaffolder-template-review/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: backstage-scaffolder-template-review
 description: Use this skill when reviewing Backstage Scaffolder software templates. Trigger when the user asks whether a template is safe for developer self-service, whether template RBAC gates are in place, whether input parameters are validated, whether a step action has excessive blast radius, or whether template outputs expose secrets.
+allowed-tools: Read Grep Glob
 metadata:
   author: "github: Raishin"
   version: "0.1.0"

--- a/skills/cert-manager/cert-manager-issuer-trust-review/SKILL.md
+++ b/skills/cert-manager/cert-manager-issuer-trust-review/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: cert-manager-issuer-trust-review
 description: Use this skill when reviewing cert-manager PKI configuration for Kubernetes clusters. Trigger when the user asks about Issuer or ClusterIssuer scope, CertificateRequestPolicy coverage, certificate SAN or duration risks, trust-manager bundle distribution, SPIFFE mesh CA integration, cert-manager webhook health, or cloud CA authentication method.
+allowed-tools: Read Grep Glob
 metadata:
   author: "github: Raishin"
   version: "0.1.0"

--- a/skills/cilium/cilium-network-policy-review/SKILL.md
+++ b/skills/cilium/cilium-network-policy-review/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: cilium-network-policy-review
 description: Use this skill for Cilium network policy review across the three policy formats (Kubernetes NetworkPolicy, CiliumNetworkPolicy, CiliumClusterwideNetworkPolicy), L7 policy via embedded Envoy, ClusterMesh cross-cluster semantics, Hubble flow observability, and CiliumEgressGatewayPolicy. Trigger when the user asks whether a network policy is too broad, whether default-deny is in place, whether L7 rules will actually be enforced, whether ClusterMesh policy semantics are correct, or whether an egress gateway IP collision is possible.
+allowed-tools: Read Grep Glob
 metadata:
   author: "github: Raishin"
   version: "0.1.0"

--- a/skills/falco/falco-runtime-threat-rules-review/SKILL.md
+++ b/skills/falco/falco-runtime-threat-rules-review/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: falco-runtime-threat-rules-review
 description: Use this skill when reviewing Falco rules files, falco.yaml configuration, or runtime security posture for a Kubernetes workload. Trigger when a user provides Falco rules YAML, asks whether their Falco setup covers a specific threat, questions rule exception scope, or wants to validate that Falco alert output reaches their SIEM or incident response pipeline.
+allowed-tools: Read Grep Glob
 metadata:
   author: "github: Raishin"
   version: "0.1.0"

--- a/skills/finops/finops-cloud-price-advisor/SKILL.md
+++ b/skills/finops/finops-cloud-price-advisor/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: finops-cloud-price-advisor
 description: Fetch live public prices and build cost estimates for AWS, Azure, and OCI using each cloud's public pricing API. Supports live-environment cost analysis (current resource inventory) and prototype cost planning (planned architecture spec). Currency defaults to USD; other currencies on request.
+allowed-tools: Read Grep Glob WebFetch
 metadata:
   author: "github: Raishin"
   version: "0.1.0"

--- a/skills/fluxcd/fluxcd-kustomization-helmrelease-review/SKILL.md
+++ b/skills/fluxcd/fluxcd-kustomization-helmrelease-review/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: fluxcd-kustomization-helmrelease-review
 description: Use this skill when reviewing FluxCD Kustomization, HelmRelease, GitRepository, HelmRepository, or OCIRepository resources. Trigger when the user asks whether a Flux configuration is safe for production, whether SOPS encryption is required, whether prune is safe on a given workload, whether commit signature verification is enabled, or whether a Flux multi-tenant setup uses least-privilege ServiceAccounts.
+allowed-tools: Read Grep Glob
 metadata:
   author: "github: Raishin"
   version: "0.1.0"

--- a/skills/istio/istio-ambient-mesh-review/SKILL.md
+++ b/skills/istio/istio-ambient-mesh-review/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: istio-ambient-mesh-review
 description: Use this skill for Istio service mesh review across both sidecar mode and ambient mode (ztunnel L4 + optional waypoint L7). Covers PeerAuthentication, AuthorizationPolicy, RequestAuthentication, Gateway, VirtualService, DestinationRule, Sidecar, and waypoint placement. Trigger when the user asks whether an Istio policy is correct, whether mTLS is strict, whether L7 AuthorizationPolicy will actually be enforced in ambient mode, or whether a mesh-wide PeerAuthentication change is safe.
+allowed-tools: Read Grep Glob
 metadata:
   author: "github: Raishin"
   version: "0.1.0"

--- a/skills/kubernetes/external-secrets-operator-review/SKILL.md
+++ b/skills/kubernetes/external-secrets-operator-review/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: external-secrets-operator-review
 description: Use this skill when reviewing External Secrets Operator (ESO) configuration, including SecretStore, ClusterSecretStore, ExternalSecret, and PushSecret resources. Trigger when a user provides ESO YAML manifests, asks about secret rotation interval compliance, questions whether ClusterSecretStore scope is too broad, or wants to audit the auth method used to reach an external secret store (AWS Secrets Manager, Azure Key Vault, GCP Secret Manager, HashiCorp Vault, 1Password).
+allowed-tools: Read Grep Glob
 metadata:
   author: "github: Raishin"
   version: "0.1.0"

--- a/skills/kubernetes/kubecost-chargeback-allocation-review/SKILL.md
+++ b/skills/kubernetes/kubecost-chargeback-allocation-review/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: kubecost-chargeback-allocation-review
 description: Use this skill when reviewing a Kubecost or OpenCost installation for enterprise chargeback readiness. Trigger when the user asks whether cost allocation is accurate, whether label taxonomy is complete enough for chargeback, whether idle cost is properly attributed, whether the cost API is secured, or whether savings recommendations are being actioned.
+allowed-tools: Read Grep Glob
 metadata:
   author: "github: Raishin"
   version: "0.1.0"

--- a/skills/kubernetes/kubernetes-live-rbac-mutation-guard/SKILL.md
+++ b/skills/kubernetes/kubernetes-live-rbac-mutation-guard/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: kubernetes-live-rbac-mutation-guard
 description: Guard live kubectl apply, create, or delete operations on Kubernetes RBAC objects — Roles, ClusterRoles, RoleBindings, ClusterRoleBindings — with privilege-escalation verb detection, scope assessment, current-state diff, and explicit approval before any write. Use only when an intentional RBAC mutation is requested against a confirmed cluster target.
+allowed-tools: Read Grep Glob WebFetch
 metadata:
   author: "github: Raishin"
   version: "0.1.0"

--- a/skills/kubernetes/kubernetes-maestro/SKILL.md
+++ b/skills/kubernetes/kubernetes-maestro/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: kubernetes-maestro
 description: Route Kubernetes tasks to the narrowest specialist or team of specialists from the catalog. Use when you do not already know the specialist. Not for direct Kubernetes answers; Maestro classifies, dispatches, and synthesizes only. Dispatches single agent for focused tasks, parallel team (max 4) for multi-domain tasks. Never auto-dispatches live-guard agents — requires explicit human confirmation with blast-radius and rollback before routing to any live mutation specialist.
+allowed-tools: Agent Skill Read Grep Glob
 metadata:
   author: "github: Raishin"
   version: "0.1.0"

--- a/skills/kubernetes/kubernetes-pod-security-admission-review/SKILL.md
+++ b/skills/kubernetes/kubernetes-pod-security-admission-review/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: kubernetes-pod-security-admission-review
 description: Use this skill for Kubernetes Pod Security Admission (PSA) review covering namespace labels for the three profiles (privileged, baseline, restricted), enforce/audit/warn modes, version pinning, and the migration path from deprecated PodSecurityPolicy. Trigger when the user asks whether a namespace label flip is safe, whether a workload meets a stricter profile, whether the audit/warn modes should be promoted to enforce, or whether an exemption is justified.
+allowed-tools: Read Grep Glob
 metadata:
   author: "github: Raishin"
   version: "0.1.0"

--- a/skills/kubernetes/kubernetes-pod-spec-review/SKILL.md
+++ b/skills/kubernetes/kubernetes-pod-spec-review/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: kubernetes-pod-spec-review
 description: Use this skill when reviewing a Kubernetes Pod spec, Deployment spec, or StatefulSet spec for correctness, security posture, and production-readiness. Trigger on any request to audit, validate, or score a workload manifest.
+allowed-tools: Read Grep Glob
 metadata:
   author: "github: Raishin"
   version: "0.1.0"

--- a/skills/kubernetes/kubernetes-rbac-review/SKILL.md
+++ b/skills/kubernetes/kubernetes-rbac-review/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: kubernetes-rbac-review
 description: Use this skill for Kubernetes RBAC, Role, ClusterRole, RoleBinding, ClusterRoleBinding, ServiceAccount, workload identity, or least-privilege review tasks. Trigger when the user asks whether cluster access is too broad, how to grant workload permissions safely, or how to audit RBAC state.
+allowed-tools: Read Grep Glob
 metadata:
   author: github: Raishin
   version: 0.1.0

--- a/skills/kubernetes/kubernetes-workload-identity-review/SKILL.md
+++ b/skills/kubernetes/kubernetes-workload-identity-review/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: kubernetes-workload-identity-review
 description: Use this skill for Kubernetes workload identity review covering AWS IRSA (IAM Roles for Service Accounts), Azure Workload Identity, GCP Workload Identity Federation, and the underlying ServiceAccount token volume projection plus OIDC issuer trust. Trigger when the user asks how a pod should authenticate to cloud services, whether long-lived credentials in a Secret can be replaced, whether the OIDC trust policy is correctly scoped, or whether ServiceAccount token reuse is a risk.
+allowed-tools: Read Grep Glob
 metadata:
   author: "github: Raishin"
   version: "0.1.0"

--- a/skills/kyverno/kyverno-policy-review/SKILL.md
+++ b/skills/kyverno/kyverno-policy-review/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: kyverno-policy-review
 description: Use this skill for Kyverno policy review across the stable policies.kyverno.io/v1 API surface — ValidatingPolicy, MutatingPolicy, GeneratingPolicy, DeletingPolicy, and ImageValidatingPolicy. Trigger when the user asks whether an admission policy is safe, whether a PolicyException is justified, whether a policy should be enforced or audited, whether a Kyverno policy should be replaced by a native ValidatingAdmissionPolicy (CEL), or whether image signature verification is correctly configured.
+allowed-tools: Read Grep Glob
 metadata:
   author: "github: Raishin"
   version: "0.1.0"

--- a/skills/oci/oci-autonomous-database-architect/SKILL.md
+++ b/skills/oci/oci-autonomous-database-architect/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: oci-autonomous-database-architect
 description: OCI Architect and operate Autonomous Database and Autonomous AI Database across serverless, dedicated Exadata, Cloud@Customer, Oracle Database@Azure, Oracle Database@Google Cloud, and Oracle Database@AWS contexts. Use for ADB design, compatibility, deployment-option selection, networking, security, DR, backup, migration, performance, and multicloud destination reviews.
+allowed-tools: Read Grep Glob
 metadata:
   author: github: Raishin
   version: 0.1.0

--- a/skills/oci/oci-certificates-issuer-review/SKILL.md
+++ b/skills/oci/oci-certificates-issuer-review/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: oci-certificates-issuer-review
 description: Use this skill when reviewing OCI Certificates Service issuer configurations for cert-manager on OKE. Trigger on any request to audit OCI CA hierarchy, issuance rules, OKE Workload Identity vs Instance Principal auth, IAM policy scope, OCSP reachability, or certificate version management.
+allowed-tools: Read Grep Glob
 metadata:
   author: "github: Raishin"
   version: "0.1.0"

--- a/skills/oci/oci-cloud-guard-responder/SKILL.md
+++ b/skills/oci/oci-cloud-guard-responder/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: oci-cloud-guard-responder
 description: Triage and govern OCI Cloud Guard problems, targets, responder recipes, detector findings, and security remediation safely. Use for Cloud Guard reviews, problem prioritization, remediation planning, and compliance evidence when official Oracle MCP tools or documentation fallback are needed.
+allowed-tools: Read Grep Glob WebFetch
 metadata:
   author: github: Raishin
   version: 0.1.0

--- a/skills/oci/oci-compute-instance-agent-operator/SKILL.md
+++ b/skills/oci/oci-compute-instance-agent-operator/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: oci-compute-instance-agent-operator
 description: Operate OCI Compute Instance Agent commands and executions safely for diagnostics, automation, and remediation. Use when issuing, tracking, or reviewing instance-agent commands across compute fleets.
+allowed-tools: Read Grep Glob
 metadata:
   author: github: Raishin
   version: 0.1.0

--- a/skills/oci/oci-compute-platform-operator/SKILL.md
+++ b/skills/oci/oci-compute-platform-operator/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: oci-compute-platform-operator
 description: Operate OCI Compute instances and platform capacity safely with compartment/region confirmation, instance lifecycle guardrails, least-privilege IAM checks, MCP/CLI discovery, and rollback-aware change plans.
+allowed-tools: Read Grep Glob
 metadata:
   author: github: Raishin
   version: 0.1.0

--- a/skills/oci/oci-cost-finops-analyst/SKILL.md
+++ b/skills/oci/oci-cost-finops-analyst/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: oci-cost-finops-analyst
 description: "Analyze Oracle Cloud Infrastructure cost, usage, budgets, tagging, rightsizing, commitment coverage, and FinOps governance. Use when asked to explain OCI spend, investigate cost spikes, build savings plans, review underused resources, design chargeback/showback, or challenge cost-optimization assumptions without breaking reliability."
+allowed-tools: Read Grep Glob WebFetch
 metadata:
   author: github: Raishin
   version: 0.1.0

--- a/skills/oci/oci-database-platform-dba/SKILL.md
+++ b/skills/oci/oci-database-platform-dba/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: oci-database-platform-dba
 description: Operate as a ruthless OCI database platform DBA for DB systems, Autonomous Database, Exadata, backups, patching, performance triage, capacity, and IAM-scoped database operations. Use when work touches OCI Database service posture, discovery, troubleshooting, change review, or least-privilege access.
+allowed-tools: Read Grep Glob
 metadata:
   author: github: Raishin
   version: 0.1.0

--- a/skills/oci/oci-dbtools-sql-analyst/SKILL.md
+++ b/skills/oci/oci-dbtools-sql-analyst/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: oci-dbtools-sql-analyst
 description: Use OCI Database Tools and database documentation safely for SQL inspection, report definitions, table metadata, and controlled query execution. Use for DBTools connections, read-only SQL analysis, and schema/report exploration.
+allowed-tools: Read Grep Glob WebFetch
 metadata:
   author: github: Raishin
   version: 0.1.0

--- a/skills/oci/oci-devops-container-platform-engineer/SKILL.md
+++ b/skills/oci/oci-devops-container-platform-engineer/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: oci-devops-container-platform-engineer
 description: "Engineer and review Oracle Cloud Infrastructure DevOps, OKE, OCIR, build/deploy pipelines, Kubernetes platform, and container runtime workflows. Use when asked to inspect OCI Container Engine clusters, DevOps projects, OCIR repositories, CI/CD IAM, deployment safety, cluster operations, image promotion, or container platform reliability."
+allowed-tools: Read Grep Glob
 metadata:
   author: github: Raishin
   version: 0.1.0

--- a/skills/oci/oci-exadata-database-architect/SKILL.md
+++ b/skills/oci/oci-exadata-database-architect/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: oci-exadata-database-architect
 description: Design, review, migrate, and operate Oracle Exadata Database Service across OCI Dedicated Infrastructure, Exascale Infrastructure, Cloud@Customer, and Oracle Database multicloud destinations including Azure, Google Cloud, and AWS, with official-doc grounding.
+allowed-tools: Read Grep Glob
 metadata:
   author: github: Raishin
   version: 0.1.0

--- a/skills/oci/oci-exadata-platform-architect/SKILL.md
+++ b/skills/oci/oci-exadata-platform-architect/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: oci-exadata-platform-architect
 description: OCI Design and operate Exadata Database Service across OCI Dedicated Infrastructure, Exadata Cloud@Customer, Oracle Database@Azure, Oracle Database@Google Cloud, and Oracle Database@AWS. Use for Exadata architecture, VM clusters, cloud Exadata infrastructure, Exascale, RAC, Data Guard, backup, migration, compatibility, capacity, network, and multicloud destination reviews.
+allowed-tools: Read Grep Glob
 metadata:
   author: github: Raishin
   version: 0.1.0

--- a/skills/oci/oci-fusion-apps-environment-operator/SKILL.md
+++ b/skills/oci/oci-fusion-apps-environment-operator/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: oci-fusion-apps-environment-operator
 description: OCI Review Fusion Apps as a Service environment families, environments, lifecycle status, availability, and operational readiness. Use for Fusion environment inventory, status checks, change planning, and support evidence.
+allowed-tools: Read Grep Glob
 metadata:
   author: github: Raishin
   version: 0.1.0

--- a/skills/oci/oci-goldengate-replication-operator/SKILL.md
+++ b/skills/oci/oci-goldengate-replication-operator/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: oci-goldengate-replication-operator
 description: OCI Operate and review Oracle GoldenGate domains, connections, extracts, replicats, checkpoint tables, trails, distribution paths, and replication health. Use for replication setup, lag triage, data movement, and cutover safety.
+allowed-tools: Read Grep Glob
 metadata:
   author: github: Raishin
   version: 0.1.0

--- a/skills/oci/oci-identity-access-governor/SKILL.md
+++ b/skills/oci/oci-identity-access-governor/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: oci-identity-access-governor
 description: Govern OCI Identity and Access Management with least-privilege policy review, compartment scoping, group/dynamic-group analysis, and safe access-change workflows. Use for OCI IAM policy design, access audits, privilege reduction, identity troubleshooting, or destructive-access risk review.
+allowed-tools: Read Grep Glob
 metadata:
   author: github: Raishin
   version: 0.1.0

--- a/skills/oci/oci-iot-digital-twin-engineer/SKILL.md
+++ b/skills/oci/oci-iot-digital-twin-engineer/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: oci-iot-digital-twin-engineer
 description: Design and operate OCI IoT digital twin adapters, models, instances, relationships, and domain context. Use for digital twin topology, lifecycle, integration, and safe model/relationship changes.
+allowed-tools: Read Grep Glob
 metadata:
   author: github: Raishin
   version: 0.1.0

--- a/skills/oci/oci-limits-capacity-planner/SKILL.md
+++ b/skills/oci/oci-limits-capacity-planner/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: oci-limits-capacity-planner
 description: Review OCI service limits, quotas, capacity availability, regional subscriptions, and growth risk. Use before deployments, migrations, DR expansion, shape changes, OKE scaling, database scaling, or quota increase requests.
+allowed-tools: Read Grep Glob WebFetch
 metadata:
   author: github: Raishin
   version: 0.1.0

--- a/skills/oci/oci-live-autonomous-db-lifecycle-guard/SKILL.md
+++ b/skills/oci/oci-live-autonomous-db-lifecycle-guard/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: oci-live-autonomous-db-lifecycle-guard
 description: Guard Autonomous Database lifecycle changes — scale, start, stop, clone, terminate — with protection-tag enforcement, backup verification, and connection-string impact analysis before any mutation.
+allowed-tools: Read Grep Glob WebFetch
 metadata:
   author: "github: Raishin"
   version: "0.1.0"

--- a/skills/oci/oci-live-cost-budget-runaway-guard/SKILL.md
+++ b/skills/oci/oci-live-cost-budget-runaway-guard/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: oci-live-cost-budget-runaway-guard
 description: Gate OCI budget mutations and GPU/HPC shape provisioning against compartment spend limits, with inventory searches, quota audits, and emergency spend-stop playbooks.
+allowed-tools: Read Grep Glob WebFetch
 metadata:
   author: "github: Raishin"
   version: "0.1.0"

--- a/skills/oci/oci-live-iam-policy-compartment-guard/SKILL.md
+++ b/skills/oci/oci-live-iam-policy-compartment-guard/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: oci-live-iam-policy-compartment-guard
 description: Guard OCI IAM policy writes and dynamic group changes with verb-hierarchy audit, compartment scope enforcement, anti-pattern detection (any-user/any-group), and rollback via statement restore.
+allowed-tools: Read Grep Glob WebFetch
 metadata:
   author: "github: Raishin"
   version: "0.1.0"

--- a/skills/oci/oci-live-network-security-rule-guard/SKILL.md
+++ b/skills/oci/oci-live-network-security-rule-guard/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: oci-live-network-security-rule-guard
 description: Guard live OCI Security List and Network Security Group (NSG) rule changes with current-state capture, open-internet and sensitive-port detection, stateful/stateless assessment, and explicit approval before ingress or egress rule mutation. Use only when an intentional network rule change targets a confirmed VCN component.
+allowed-tools: Read Grep Glob WebFetch
 metadata:
   author: "github: Raishin"
   version: "0.1.0"

--- a/skills/oci/oci-live-oke-rollout-guard/SKILL.md
+++ b/skills/oci/oci-live-oke-rollout-guard/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: oci-live-oke-rollout-guard
 description: Guard OKE deployment rollouts via DevOps Service approval stages with canary and blue-green evidence, rollout health verification, and kubectl rollout undo gates.
+allowed-tools: Read Grep Glob WebFetch
 metadata:
   author: "github: Raishin"
   version: "0.1.0"

--- a/skills/oci/oci-live-resource-manager-stack-guard/SKILL.md
+++ b/skills/oci/oci-live-resource-manager-stack-guard/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: oci-live-resource-manager-stack-guard
 description: Guard OCI Resource Manager stack plan, apply, and destroy jobs with drift detection, state-version rollback, stack auto-lock awareness, and approval gates.
+allowed-tools: Read Grep Glob WebFetch
 metadata:
   author: "github: Raishin"
   version: "0.1.0"

--- a/skills/oci/oci-live-vault-key-destruction-guard/SKILL.md
+++ b/skills/oci/oci-live-vault-key-destruction-guard/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: oci-live-vault-key-destruction-guard
 description: Guard Vault master encryption key scheduled-deletion and HSM rotation with data-association audits, key-usage reference checks, deletion-window enforcement, and cancellation playbooks.
+allowed-tools: Read Grep Glob WebFetch
 metadata:
   author: "github: Raishin"
   version: "0.1.0"

--- a/skills/oci/oci-load-balancer-traffic-engineer/SKILL.md
+++ b/skills/oci/oci-load-balancer-traffic-engineer/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: oci-load-balancer-traffic-engineer
 description: Design, review, and troubleshoot OCI Load Balancer and Network Load Balancer traffic paths, listeners, backend sets, certificates, health checks, logging, and failover. Use for L7/L4 traffic engineering and availability reviews.
+allowed-tools: Read Grep Glob
 metadata:
   author: github: Raishin
   version: 0.1.0

--- a/skills/oci/oci-maestro/SKILL.md
+++ b/skills/oci/oci-maestro/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: oci-maestro
 description: OCI Maestro routing skill. Classify the user's OCI task, select the narrowest specialist agent or the right team of specialists from the catalog, and dispatch them — single specialist for focused tasks, parallel team for multi-domain tasks. Never auto-dispatch live-guard agents.
+allowed-tools: Agent Skill Read Grep Glob
 metadata:
   author: github: Raishin
   version: 0.1.0

--- a/skills/oci/oci-migration-cutover-architect/SKILL.md
+++ b/skills/oci/oci-migration-cutover-architect/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: oci-migration-cutover-architect
 description: Plan OCI migrations and cutovers with Cloud Migrations, dependency discovery, waves, rollback, DNS, data sync, validation, and support readiness. Use for migration assessment, move groups, cutover runbooks, and go/no-go reviews.
+allowed-tools: Read Grep Glob
 metadata:
   author: github: Raishin
   version: 0.1.0

--- a/skills/oci/oci-multi-cloud-architect/SKILL.md
+++ b/skills/oci/oci-multi-cloud-architect/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: oci-multi-cloud-architect
 description: Design and review OCI multi-cloud architectures connecting Oracle Cloud Infrastructure with AWS, Azure, Google Cloud, on-premises, or SaaS through VPN, FastConnect, Direct Connect, ExpressRoute, Cloud Interconnect, identity federation, DNS, routing, security, observability, and operating-model controls.
+allowed-tools: Read Grep Glob
 metadata:
   author: github: Raishin
   version: 0.1.0

--- a/skills/oci/oci-mysql-heatwave-ai-specialist/SKILL.md
+++ b/skills/oci/oci-mysql-heatwave-ai-specialist/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: oci-mysql-heatwave-ai-specialist
 description: OCI Operate and review MySQL HeatWave, MySQL AI, vector/RAG workflows, connection configs, object storage ingestion, and SQL safety. Use for MySQL AI questions, HeatWave ML, vector store loading, and MySQL operational reviews.
+allowed-tools: Read Grep Glob
 metadata:
   author: github: Raishin
   version: 0.1.0

--- a/skills/oci/oci-network-architect/SKILL.md
+++ b/skills/oci/oci-network-architect/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: oci-network-architect
 description: Design, review, and troubleshoot OCI networking with safe compartment/region scoping, least-privilege network access, VCN/subnet/routing/security-list/NSG analysis, and evidence-based MCP or CLI discovery.
+allowed-tools: Read Grep Glob
 metadata:
   author: github: Raishin
   version: 0.1.0

--- a/skills/oci/oci-observability-incident-responder/SKILL.md
+++ b/skills/oci/oci-observability-incident-responder/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: oci-observability-incident-responder
 description: Operate as a ruthless OCI observability and incident responder for Monitoring alarms, Logging, Events, Notifications, service health, metrics, runbooks, and IAM-scoped incident response. Use when work touches OCI alarms, telemetry, alert triage, incident evidence, or response permissions.
+allowed-tools: Read Grep Glob WebFetch
 metadata:
   author: github: Raishin
   version: 0.1.0

--- a/skills/oci/oci-recovery-service-operator/SKILL.md
+++ b/skills/oci/oci-recovery-service-operator/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: oci-recovery-service-operator
 description: Operate OCI Recovery Service protected databases, protection policies, recovery service subnets, backup health, redo status, and recovery metrics. Use for database recovery posture, protected database health, and restore readiness.
+allowed-tools: Read Grep Glob
 metadata:
   author: github: Raishin
   version: 0.1.0

--- a/skills/oci/oci-registry-artifact-governor/SKILL.md
+++ b/skills/oci/oci-registry-artifact-governor/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: oci-registry-artifact-governor
 description: Govern OCI Registry repositories, container images, artifact access, retention, promotion, and deployment safety. Use for OCIR repository reviews, image lifecycle, DevOps/OKE integration, and least-privilege push/pull access.
+allowed-tools: Read Grep Glob
 metadata:
   author: github: Raishin
   version: 0.1.0

--- a/skills/oci/oci-resource-search-inventory-analyst/SKILL.md
+++ b/skills/oci/oci-resource-search-inventory-analyst/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: oci-resource-search-inventory-analyst
 description: Build OCI resource inventories and dependency maps using Resource Search, compartments, tags, and cross-service discovery. Use for tenancy inventory, ownership gaps, orphan detection, migration scoping, and architecture evidence collection.
+allowed-tools: Read Grep Glob WebFetch
 metadata:
   author: github: Raishin
   version: 0.1.0

--- a/skills/oci/oci-security-compliance-reviewer/SKILL.md
+++ b/skills/oci/oci-security-compliance-reviewer/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: oci-security-compliance-reviewer
 description: "Review Oracle Cloud Infrastructure security, IAM, network, logging, encryption, and compliance posture. Use when asked to audit OCI policies, compartments, tenancy security, Cloud Guard findings, buckets, vaults, security lists, NSGs, or least-privilege access; prepare compliance evidence; or challenge risky OCI admin assumptions before changes."
+allowed-tools: Read Grep Glob
 metadata:
   author: github: Raishin
   version: 0.1.0

--- a/skills/oci/oci-solution-architect/SKILL.md
+++ b/skills/oci/oci-solution-architect/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: oci-solution-architect
 description: Design, review, and stress-test Oracle Cloud Infrastructure solution architectures across identity, compartments, networking, compute, database, storage, observability, security, reliability, cost, and operations. Use when asked for OCI landing zones, target architectures, architecture review boards, migration designs, production readiness, or tradeoff decisions.
+allowed-tools: Read Grep Glob
 metadata:
   author: github: Raishin
   version: 0.1.0

--- a/skills/oci/oci-storage-backup-steward/SKILL.md
+++ b/skills/oci/oci-storage-backup-steward/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: oci-storage-backup-steward
 description: Operate as a ruthless OCI storage and backup steward for Object Storage, Block Volume, File Storage, backup policies, retention, replication, lifecycle rules, restore readiness, and IAM-scoped storage operations. Use when work touches OCI storage inventory, backup posture, recovery planning, or storage permissions.
+allowed-tools: Read Grep Glob
 metadata:
   author: github: Raishin
   version: 0.1.0

--- a/skills/oci/oci-support-incident-coordinator/SKILL.md
+++ b/skills/oci/oci-support-incident-coordinator/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: oci-support-incident-coordinator
 description: Coordinate OCI support incidents with evidence quality, severity discipline, resource scope, timelines, and escalation readiness. Use for support tickets, incident evidence packs, Oracle SR preparation, and post-incident follow-up.
+allowed-tools: Read Grep Glob WebFetch
 metadata:
   author: github: Raishin
   version: 0.1.0

--- a/skills/oci/oracle-oci-mcp-grounded-advisor/SKILL.md
+++ b/skills/oci/oracle-oci-mcp-grounded-advisor/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: oracle-oci-mcp-grounded-advisor
 description: Use this skill when the user asks about Oracle MCP servers, SQLcl MCP, OCI MCP, Oracle Database agent access, OCI automation, or cloud/database advice that must be grounded in official Oracle sources.
+allowed-tools: Read Grep Glob WebFetch
 metadata:
   author: github: Raishin
   version: 0.1.0

--- a/skills/opentelemetry/opentelemetry-collector-config-review/SKILL.md
+++ b/skills/opentelemetry/opentelemetry-collector-config-review/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: opentelemetry-collector-config-review
 description: Use this skill for OpenTelemetry Operator review covering OpenTelemetryCollector deployment modes (Deployment, StatefulSet, DaemonSet, Sidecar), Instrumentation CR auto-instrumentation across Java/Node/Python/.NET/Go, Target Allocator for distributed Prometheus scraping, and pipeline correctness across receivers, processors, and exporters. Trigger when the user asks whether a collector configuration will lose telemetry, whether the right deployment mode is used, whether memory_limiter and batch are present, whether tail_sampling is safe to change, or whether auto-instrumentation will cover a workload after restart.
+allowed-tools: Read Grep Glob
 metadata:
   author: "github: Raishin"
   version: "0.1.0"

--- a/skills/prometheus/prometheus-alerting-cardinality-review/SKILL.md
+++ b/skills/prometheus/prometheus-alerting-cardinality-review/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: prometheus-alerting-cardinality-review
 description: Use this skill when reviewing Prometheus or AlertManager configuration for cardinality, alerting correctness, scrape security, remote_write safety, or retention adequacy. Trigger when a user provides prometheus.yml, alertmanager.yml, recording rules YAML, alerting rules YAML, or asks whether their Prometheus setup is production-ready.
+allowed-tools: Read Grep Glob
 metadata:
   author: "github: Raishin"
   version: "0.1.0"

--- a/skills/sigstore/sigstore-cosign-supply-chain-review/SKILL.md
+++ b/skills/sigstore/sigstore-cosign-supply-chain-review/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: sigstore-cosign-supply-chain-review
 description: Use this skill when reviewing Sigstore Cosign supply chain security for Kubernetes workloads. Trigger when the user asks whether images are properly signed, whether Kyverno imageVerify policy is correctly scoped, whether SLSA provenance attestations exist, whether SBOM attestations are present, whether keyless signing is in use, or whether Rekor transparency log posture is appropriate for private images.
+allowed-tools: Read Grep Glob
 metadata:
   author: "github: Raishin"
   version: "0.1.0"

--- a/skills/terraform/terraform-maestro/SKILL.md
+++ b/skills/terraform/terraform-maestro/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: terraform-maestro
 description: Route Terraform and IaC tasks to the right specialist from the cross-cloud IaC catalog. Use when you do not already know the specific IaC specialist needed. Not for direct Terraform answers; Maestro classifies, dispatches, and synthesizes only. Dispatches single agent for focused tasks, parallel team (max 4) for multi-domain tasks. Never auto-dispatches live-guard agents — requires explicit human confirmation with blast-radius and rollback before routing to any live apply, destroy, or stack mutation.
+allowed-tools: Agent Skill Read Grep Glob
 metadata:
   author: "github: Raishin"
   version: "0.1.0"

--- a/skills/velero/velero-backup-restore-guard/SKILL.md
+++ b/skills/velero/velero-backup-restore-guard/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: velero-backup-restore-guard
 description: Use this skill when guarding Velero backup schedule changes, restore operations, BackupStorageLocation mutations, or volume snapshot configuration. Trigger on any request to run a velero restore, delete a Schedule, change a BSL default, or modify backup retention.
+allowed-tools: Read Grep Glob WebFetch
 metadata:
   author: "github: Raishin"
   version: "0.1.0"

--- a/tests/validate-skill-allowed-tools.py
+++ b/tests/validate-skill-allowed-tools.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Validate that every SKILL.md declares an allowed-tools frontmatter field.
+
+The `allowed-tools` field aligns each skill with the Claude Code skills spec
+(https://code.claude.com/docs/en/skills) and makes the tool surface explicit.
+It is a pre-approval list (not a deny-list); harness deny rules in
+settings.json are still the enforcement boundary, but declaring the field
+here makes intent reviewable.
+
+Cross-platform note: SKILL.md is a Claude Code artifact in this repo
+(skills/<provider>/<name>/SKILL.md). Other harnesses do not consume SKILL.md
+frontmatter, so this field is harmless for non-Claude exports.
+
+Validation rules:
+  1. Every SKILL.md must contain an `allowed-tools` key in YAML frontmatter.
+  2. The value must be either a non-empty space-separated string or a
+     non-empty YAML list of strings.
+  3. Each token must match the recognised tool grammar:
+       Bare tool name:   ^[A-Z][A-Za-z0-9]+$         (Read, Edit, Bash)
+       Constrained tool: ^[A-Z][A-Za-z0-9]+\(.+\)$    (Bash(git add *))
+       Skill/Agent invocation tokens are also allowed.
+  4. At least one token must be present.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SKILLS_DIR = ROOT / "skills"
+
+TOKEN_RE = re.compile(r"^[A-Z][A-Za-z0-9]+(\([^)]+\))?$")
+
+
+def parse_frontmatter(text: str) -> dict[str, str] | None:
+    if not text.startswith("---\n"):
+        return None
+    end = text.find("\n---", 4)
+    if end == -1:
+        return None
+    block = text[4:end]
+    fm: dict[str, str] = {}
+    current_key: str | None = None
+    current_lines: list[str] = []
+    for line in block.splitlines():
+        if not line.startswith(" ") and ":" in line:
+            if current_key is not None:
+                fm[current_key] = "\n".join(current_lines).strip()
+            key, _, rest = line.partition(":")
+            current_key = key.strip()
+            current_lines = [rest.strip()]
+        else:
+            current_lines.append(line)
+    if current_key is not None:
+        fm[current_key] = "\n".join(current_lines).strip()
+    return fm
+
+
+def tokenize_allowed_tools(value: str) -> list[str]:
+    """Split a space-separated allowed-tools value, respecting parentheses."""
+    tokens: list[str] = []
+    buf: list[str] = []
+    depth = 0
+    for ch in value:
+        if ch == "(":
+            depth += 1
+            buf.append(ch)
+        elif ch == ")":
+            depth -= 1
+            buf.append(ch)
+        elif ch.isspace() and depth == 0:
+            if buf:
+                tokens.append("".join(buf))
+                buf = []
+        else:
+            buf.append(ch)
+    if buf:
+        tokens.append("".join(buf))
+    return tokens
+
+
+def validate_skill(skill_md: Path) -> list[str]:
+    text = skill_md.read_text(encoding="utf-8")
+    fm = parse_frontmatter(text)
+    if fm is None:
+        return [f"{skill_md}: no YAML frontmatter found"]
+
+    if "allowed-tools" not in fm:
+        return [f"{skill_md}: missing required 'allowed-tools' frontmatter field"]
+
+    raw = fm["allowed-tools"].strip()
+    if raw.startswith("[") and raw.endswith("]"):
+        inner = raw[1:-1].strip()
+        tokens = [t.strip().strip("'\"") for t in inner.split(",") if t.strip()]
+    else:
+        tokens = tokenize_allowed_tools(raw)
+
+    errors: list[str] = []
+    if not tokens:
+        errors.append(f"{skill_md}: 'allowed-tools' is empty")
+        return errors
+
+    for tok in tokens:
+        if not TOKEN_RE.match(tok):
+            errors.append(
+                f"{skill_md}: invalid allowed-tools token '{tok}' "
+                f"(expected ToolName or ToolName(constraint))"
+            )
+    return errors
+
+
+def main() -> int:
+    skill_files = sorted(SKILLS_DIR.glob("*/*/SKILL.md"))
+    if not skill_files:
+        print("ERROR: no SKILL.md files found", file=sys.stderr)
+        return 2
+
+    all_errors: list[str] = []
+    for skill_md in skill_files:
+        all_errors.extend(validate_skill(skill_md))
+
+    if all_errors:
+        print(f"FAIL: {len(all_errors)} allowed-tools issue(s) across "
+              f"{len(skill_files)} skill(s):", file=sys.stderr)
+        for err in all_errors[:20]:
+            print(f"  - {err}", file=sys.stderr)
+        if len(all_errors) > 20:
+            print(f"  ... and {len(all_errors) - 20} more", file=sys.stderr)
+        return 1
+
+    print(f"OK: validated allowed-tools on {len(skill_files)} skills")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/validate-skill-frontmatter-schema.py
+++ b/tests/validate-skill-frontmatter-schema.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+"""Validate SKILL.md frontmatter against schemas/skill.frontmatter.schema.json.
+
+Uses jsonschema for validation (consistent with existing jsonschema usage
+in validate-catalog.py). Falls back to a minimal hand-rolled validator if
+jsonschema is unavailable.
+
+Validation covers:
+  - Required fields: name, description, allowed-tools, metadata
+  - metadata required sub-fields: author, version
+  - name: pattern ^[a-z0-9][a-z0-9-]*$
+  - description: minLength 50, maxLength 1500
+  - allowed-tools: non-empty string or non-empty list of strings
+  - metadata.version: semver pattern ^\\d+\\.\\d+\\.\\d+(-[\\w.-]+)?$
+  - metadata.author: minLength 1
+  - disable-model-invocation (optional): boolean
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SKILLS_DIR = ROOT / "skills"
+SCHEMA_PATH = ROOT / "schemas" / "skill.frontmatter.schema.json"
+
+# ──────────────────────────────────────────────────────────────────────────────
+# YAML frontmatter parser (stdlib only, mirrors validate-skill-allowed-tools.py)
+# ──────────────────────────────────────────────────────────────────────────────
+
+def parse_frontmatter_raw(text: str) -> dict | None:
+    """Return a dict of the raw YAML frontmatter block, or None on failure.
+
+    Supports:
+      - scalar values  (key: value)
+      - quoted scalars (key: "value")
+      - nested mappings (metadata:\\n  sub: val)
+      - block sequences (key:\\n  - item)
+      - inline sequences (key: [a, b])
+
+    Uses the hand-rolled parser (not PyYAML) to avoid failures on unquoted
+    colons in description values — a known pattern in this corpus.
+    """
+    if not text.startswith("---\n"):
+        return None
+    end = text.find("\n---", 4)
+    if end == -1:
+        return None
+    block = text[4:end]
+
+    # Use hand-rolled parser to handle unquoted colons in scalar values.
+    return _minimal_yaml_parse(block)
+
+
+def _minimal_yaml_parse(block: str) -> dict:
+    """Parse a restricted YAML subset into a Python dict."""
+    result: dict = {}
+    lines = block.splitlines()
+    i = 0
+
+    def parse_scalar(s: str):
+        s = s.strip()
+        if (s.startswith('"') and s.endswith('"')) or \
+           (s.startswith("'") and s.endswith("'")):
+            return s[1:-1]
+        if s.lower() == "true":
+            return True
+        if s.lower() == "false":
+            return False
+        return s
+
+    while i < len(lines):
+        line = lines[i]
+        # top-level key
+        if line and not line.startswith(" ") and ":" in line:
+            key, _, rest = line.partition(":")
+            key = key.strip()
+            rest = rest.strip()
+
+            if rest == "":
+                # look ahead for block sequence or nested mapping
+                children_list: list = []
+                children_dict: dict = {}
+                i += 1
+                while i < len(lines) and (lines[i].startswith("  ") or lines[i] == ""):
+                    child = lines[i]
+                    if child.strip() == "":
+                        i += 1
+                        continue
+                    if child.startswith("  - "):
+                        children_list.append(child[4:].strip())
+                    elif child.startswith("  ") and ":" in child:
+                        ckey, _, crest = child.strip().partition(":")
+                        children_dict[ckey.strip()] = parse_scalar(crest)
+                    i += 1
+                if children_list:
+                    result[key] = children_list
+                elif children_dict:
+                    result[key] = children_dict
+                else:
+                    result[key] = None
+                continue
+            elif rest.startswith("[") and rest.endswith("]"):
+                inner = rest[1:-1]
+                result[key] = [t.strip().strip("'\"") for t in inner.split(",") if t.strip()]
+            else:
+                result[key] = parse_scalar(rest)
+        i += 1
+
+    return result
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Schema-based validation
+# ──────────────────────────────────────────────────────────────────────────────
+
+NAME_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$")
+VERSION_RE = re.compile(r"^\d+\.\d+\.\d+(-[\w.-]+)?$")
+
+
+def _try_jsonschema_validate(instance: dict, schema: dict) -> list[str]:
+    """Validate using jsonschema if available; return list of error messages."""
+    try:
+        import jsonschema  # type: ignore
+        errors = []
+        validator_cls = jsonschema.validators.validator_for(schema)
+        validator = validator_cls(schema)
+        for err in sorted(validator.iter_errors(instance), key=lambda e: list(e.path)):
+            path = ".".join(str(p) for p in err.absolute_path) or "<root>"
+            errors.append(f"  field '{path}': {err.message}")
+        return errors
+    except ImportError:
+        return []  # fall through to hand-rolled validator
+
+
+def _hand_rolled_validate(fm: dict) -> list[str]:
+    """Minimal validator that mirrors the schema constraints."""
+    errors: list[str] = []
+
+    # Required top-level fields
+    for req in ("name", "description", "allowed-tools", "metadata"):
+        if req not in fm or fm[req] is None:
+            errors.append(f"  field '{req}': required field is missing")
+
+    # name pattern
+    name = fm.get("name")
+    if isinstance(name, str):
+        if not NAME_RE.match(name):
+            errors.append(
+                f"  field 'name': '{name}' does not match pattern ^[a-z0-9][a-z0-9-]*$"
+            )
+    elif name is not None:
+        errors.append(f"  field 'name': must be a string, got {type(name).__name__}")
+
+    # description length
+    desc = fm.get("description")
+    if isinstance(desc, str):
+        if len(desc) < 50:
+            errors.append(
+                f"  field 'description': length {len(desc)} is below minimum 50"
+            )
+        if len(desc) > 1500:
+            errors.append(
+                f"  field 'description': length {len(desc)} exceeds maximum 1500"
+            )
+    elif desc is not None:
+        errors.append(f"  field 'description': must be a string, got {type(desc).__name__}")
+
+    # allowed-tools: string or list of strings, non-empty
+    at = fm.get("allowed-tools")
+    if at is not None:
+        if isinstance(at, str):
+            if len(at.strip()) == 0:
+                errors.append("  field 'allowed-tools': string value must not be empty")
+        elif isinstance(at, list):
+            if len(at) == 0:
+                errors.append("  field 'allowed-tools': list must contain at least one item")
+            for idx, item in enumerate(at):
+                if not isinstance(item, str) or len(item.strip()) == 0:
+                    errors.append(
+                        f"  field 'allowed-tools[{idx}]': each item must be a non-empty string"
+                    )
+        else:
+            errors.append(
+                f"  field 'allowed-tools': must be a string or array, got {type(at).__name__}"
+            )
+
+    # metadata sub-fields
+    meta = fm.get("metadata")
+    if isinstance(meta, dict):
+        author = meta.get("author")
+        if author is None:
+            errors.append("  field 'metadata.author': required field is missing")
+        elif not isinstance(author, str) or len(author) < 1:
+            errors.append("  field 'metadata.author': must be a non-empty string")
+
+        version = meta.get("version")
+        if version is None:
+            errors.append("  field 'metadata.version': required field is missing")
+        elif not isinstance(version, str):
+            errors.append(
+                f"  field 'metadata.version': must be a string, got {type(version).__name__}"
+            )
+        elif not VERSION_RE.match(version):
+            errors.append(
+                f"  field 'metadata.version': '{version}' does not match semver pattern"
+            )
+    elif meta is not None:
+        errors.append(
+            f"  field 'metadata': must be a mapping/object, got {type(meta).__name__}"
+        )
+
+    # disable-model-invocation (optional): must be boolean if present
+    dmi = fm.get("disable-model-invocation")
+    if dmi is not None and not isinstance(dmi, bool):
+        errors.append(
+            f"  field 'disable-model-invocation': must be a boolean, got {type(dmi).__name__}"
+        )
+
+    return errors
+
+
+def validate_skill(skill_md: Path, schema: dict) -> list[str]:
+    text = skill_md.read_text(encoding="utf-8")
+    fm = parse_frontmatter_raw(text)
+    if fm is None or not isinstance(fm, dict):
+        return [f"  no valid YAML frontmatter block found"]
+
+    # Prefer jsonschema; fall back to hand-rolled
+    errors = _try_jsonschema_validate(fm, schema)
+    if not errors and _hand_rolled_validate(fm):
+        # jsonschema not available or returned nothing; use hand-rolled
+        errors = _hand_rolled_validate(fm)
+    elif not errors:
+        # double-check with hand-rolled to catch anything jsonschema might miss
+        errors = _hand_rolled_validate(fm)
+
+    return errors
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Entry point
+# ──────────────────────────────────────────────────────────────────────────────
+
+def main() -> int:
+    if not SCHEMA_PATH.exists():
+        print(f"ERROR: schema not found at {SCHEMA_PATH}", file=sys.stderr)
+        return 2
+
+    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+
+    skill_files = sorted(SKILLS_DIR.glob("*/*/SKILL.md"))
+    if not skill_files:
+        print("ERROR: no SKILL.md files found", file=sys.stderr)
+        return 2
+
+    failed: list[tuple[Path, list[str]]] = []
+
+    for skill_md in skill_files:
+        errors = validate_skill(skill_md, schema)
+        if errors:
+            failed.append((skill_md, errors))
+
+    if failed:
+        print(
+            f"FAIL: {len(failed)} skill(s) failed frontmatter schema validation "
+            f"(out of {len(skill_files)} checked):",
+            file=sys.stderr,
+        )
+        for path, errs in failed:
+            print(f"\n  {path}", file=sys.stderr)
+            for e in errs:
+                print(f"    {e}", file=sys.stderr)
+        return 1
+
+    print(
+        f"OK: all {len(skill_files)} skills passed SKILL.md frontmatter schema validation"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Hardens the marketplace surface across security disclosure, supply-chain provenance, schema enforcement, and contributor onboarding. Makes companion skills install automatically alongside agents, and ships least-privilege tool declarations on every SKILL.md.

## Changes by domain

### Skills CLI and bundling
- `vfa-export-agents` bundles companion skills by default on `--platform claude-code`. Pairing resolved from `companion_skills` agent metadata, with name-stripping fallback. `--no-skills` opts out.
- `--all` exports every catalogued skill (138), including 4 with no agent peer.
- New optional `companion_skills: string[]` field in agent `metadata.json`. Six previously orphan agents migrated to declare correct pairings.

### Skill quality
- New `allowed-tools` field on every SKILL.md frontmatter, classified by skill role. Distribution: 87 read-only, 38 read+web, 5 patchers, 5 maestros, 3 developers — 91% read-only or read+web baseline.
- New JSON Schema (Draft 2020-12) for SKILL.md frontmatter at `schemas/skill.frontmatter.schema.json`. All 138 skills pass on first run.

### Security and supply chain
- `SECURITY.md` with disclosure policy, response SLA (ack ≤5 business days, triage ≤10, 90-day coordinated window), in/out scope, Safe Harbor.
- CodeQL workflow for JavaScript and Python on push, PR, and weekly (`security-extended,security-and-quality` queries).
- `npm provenance` enabled via `publishConfig.provenance: true` (semantic-release auto-passes `--provenance` with the existing `id-token: write` permission).
- Dependabot for GitHub Actions and npm with weekly grouped PRs.

### Governance and contributor experience
- `CODEOWNERS` with provider-scoped review across 18 provider domains and 6 critical infrastructure paths.
- `CONTRIBUTING.md` with quick start, asset-type guidance, validation gate reference.
- Structured GitHub issue forms (`bug.yml`, `skill-or-agent-proposal.yml`) and a PR template.
- `CODE_OF_CONDUCT.md` adopting Contributor Covenant 2.1 by reference.

### CI and tooling
- New `validate:allowed-tools` and `validate:skill-schema` gates wired into `npm run validate`.
- New `install-paths-smoke.yml` workflow asserting documented `vfa-export-agents` paths behave as documented.
- GitHub Actions bumped to v6 (`actions/checkout@v6.0.2`, `actions/setup-node@v6.4.0`, `actions/setup-python@v6.2.0`).
- Smoke test runs on Node 24.

### Documentation
- New `docs/integrations/skills-cli.md` trust matrix covering all three install paths (`npm`, `vfa-export-agents`, third-party `skills` CLI) with explicit per-path versioning, pinnability, and trust posture.
- README badge row, navigation links to CONTRIBUTING / SECURITY / CoC.
- `CLAUDE.md`, `AGENTS.md` synced with new validation gates and metadata fields.
- `CHANGELOG.md` carries an Unreleased preview pending semantic-release on master push.

## Validation evidence

- [x] `npm run validate` — six gates green: catalog, AWS quality, manifest, allowed-tools, skill-schema, links (604 URLs).
- [x] Local smoke: `--all`, `--no-skills`, `--role cloud-security-engineer`, `--platform cursor` all behave per spec.
- [x] `kubernetes-psa-review-agent` correctly bundles `kubernetes-pod-security-admission-review` skill via the new `companion_skills` field.
- [ ] CI checks: validate, smoke, CodeQL JS, CodeQL Python (pending).

## Trust posture

- Export script does no network I/O, runs no installed asset, and modifies nothing outside `<--repo>` — bounded by `assertWithin()` checks.
- Skill copies refuse symlinks and refuse overwrites without `--force`.
- Pairing is now declarative-first (metadata field) with name-stripping as fallback, removing the previous stringly-typed coupling.
- `allowed-tools` is a Claude Code pre-approval list (UX), not a deny-list. Harness `settings.json` deny rules remain the enforcement boundary; declaring intent here makes review auditable.

## Risks and rollback

- Existing automation calling `vfa-export-agents --platform claude-code` now produces a `.claude/skills/` directory in the target repo. Mitigation: documented `--no-skills` opt-out.
- `terraform-reviewer` exports without a companion skill and is named in stderr.
- Each commit is independently revertable. The companion-skills default change lives in a single commit; reverting restores agents-only export.

## Follow-ups (separate PRs / next batch)

- README / shields cosmetics polish once badges render
- `updated:` timestamp + cross-cutting `category` taxonomy on skill metadata
- Cross-harness skill format support (Cursor / Codex / Copilot / Gemini / Kiro currently print "not yet supported")
- AGENT.md content schema (only `metadata.json` is schema-validated today)
- OpenSSF Scorecard workflow
- SLSA / sigstore release attestations beyond npm provenance
- Branch protection as code (`.github/settings.yml` via Probot Settings)
- Markdownlint + codespell quality gates