### PR TITLE
fix(release): unblock v1.4.0 — clone frozen commit in writerOpts.transform

### DIFF
--- a/.releaserc.js
+++ b/.releaserc.js
@@ -56,9 +56,11 @@ module.exports = {
           commitPartial:
             "*{{#if scope}} **{{scope}}:**{{~/if}} {{subject}}{{#if shortHash}} ({{shortHash}}){{/if}}\n" +
             "{{#if body}}\n{{body}}\n{{/if}}\n",
+          // conventional-changelog-writer v8 freezes the commit object,
+          // so mutating fields directly throws "Cannot modify immutable
+          // object". Return a shallow copy with the cleaned body instead.
           transform(commit) {
-            commit.body = cleanBody(commit.body);
-            return commit;
+            return { ...commit, body: cleanBody(commit.body) };
           },
         },
       },


### PR DESCRIPTION
## Summary

- Release workflow on master fails at `generateNotes` with `Error: Cannot modify immutable object.`
- `conventional-changelog-writer` v8 freezes commit objects; our custom `writerOpts.transform` in `.releaserc.js` mutates `commit.body` in place, which throws on the first commit it processes.
- Fix: return a shallow copy with the cleaned body instead of mutating.

## Stack trace from the failed run

```
Object.set (node_modules/conventional-changelog-writer/dist/commit.js:15:19)
transform (.releaserc.js:60:25)
transformCommit (node_modules/conventional-changelog-writer/dist/commit.js:31:29)
write (node_modules/conventional-changelog-writer/dist/writers.js:39:28)
```

## Test plan

- [ ] CI green on this PR
- [ ] After merge, `Release` workflow runs on master and produces the v1.4.0 tag, GitHub release, and npm publish
- [ ] If it doesn't auto-trigger, run `Release` via `workflow_dispatch` (dry-run first to confirm `generateNotes` succeeds)

https://claude.ai/code/session_017UWt6E1tM5Cc4r6epi3JpJ

---
_Generated by [Claude Code](https://claude.ai/code/session_017UWt6E1tM5Cc4r6epi3JpJ)_