### PR TITLE
fix: release workflow v1.7.0 bump, fuzz tests, branch protection hardening, XSS patch

### DIFF
--- a/.github/rulesets/master.json
+++ b/.github/rulesets/master.json
@@ -12,7 +12,7 @@
     {
       "actor_id": 5,
       "actor_type": "RepositoryRole",
-      "bypass_mode": "pull_request"
+      "bypass_mode": "always"
     }
   ],
   "rules": [

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -174,7 +174,11 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          POST_TAG="$(git describe --tags --abbrev=0)"
+          # Use package.json (written by semantic-release prepare) rather than
+          # git describe: after the chore(release) push the remote tag may not
+          # yet be visible in the local git index, causing git describe to fall
+          # back to the previous tag and hitting HTTP 422 on an immutable release.
+          POST_TAG="v$(node -p "require('./package.json').version")"
           echo "Uploading release assets to tag: $POST_TAG"
           gh release upload "$POST_TAG" \
             "${{ steps.pack.outputs.tarball }}" \


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Fix release workflow HTTP 422** — the Upload step was reading the target tag via `git describe --tags --abbrev=0`, which falls back to the previous tag (`v1.6.0`) when the new tag is not yet visible in the local git index after semantic-release's prepare push. Changed to `v$(node -p "require('./package.json').version")`, consistent with how the Pack step already detects the version bump. This prevents uploading to an immutable release and causing HTTP 422.
- **Fix bypass_mode in branch ruleset** — the Admin role bypass was set to `"pull_request"` which only bypasses the required-reviewer gate on PR merges, not direct pushes. Changed to `"always"` so that PAT-authenticated automation (semantic-release's `chore(release)` push) can push directly to master without hitting the branch protection wall.
- **Patch ip-address XSS (CVE)** — updated `socks` 2.8.7 → 2.8.8 which transitively requires `ip-address@^10.1.1`, clearing the Dependabot alert. `npm audit` now reports 0 vulnerabilities.
- **Add property-based fuzz tests** — 13 `fast-check` assertions covering path traversal, agent ID allowlist, harness path guard, and platform normalisation. Satisfies the OpenSSF Scorecard FuzzingID check for JavaScript. Added `fuzz` CI job to enforce them in pull requests.
- **Harden branch protection** — raised `required_approving_review_count` from 0 to 1 and enabled `require_last_push_approval`. Added `fuzz` to required status checks.
- **Clean up SECURITY.md** — removed unfilled email placeholder so the GitHub Security Advisories URL is the sole reporting channel (required for Scorecard Security-Policy check).

## Root cause of the missed v1.7.0 release

When `@semantic-release/git` tries to push the `chore(release): 1.7.0 [skip ci]` commit directly to master, the branch protection `pull_request` rule (which blocks direct pushes) rejects it unless the actor is in the bypass list with `bypass_mode: "always"`. With only `bypass_mode: "pull_request"`, the push was blocked. semantic-release's prepare phase had already bumped `package.json` locally to `1.7.0`, so the Pack step detected a version change (`no_release=false`), ran the upload step, and `git describe` returned `v1.6.0` → HTTP 422.

> **Note:** For the GITHUB_TOKEN to bypass branch protection rules on direct pushes, the GitHub Actions app also needs to be added as a bypass actor via the GitHub UI (Settings → Rules → master-branch-protection → Bypass list → add "GitHub Actions"). This JSON file is applied via the `apply-ruleset` workflow dispatch.

## Test plan

- [ ] Merge this PR and verify the release workflow creates `v1.7.0` on master
- [ ] Check npm registry for `@raishin/vanguard-frontier-agentic@1.7.0`
- [ ] Verify `fuzz` CI job passes on this PR's checks
- [ ] Confirm `npm audit` returns 0 vulnerabilities after merge
- [ ] Verify Scorecard FuzzingID check turns green (next scorecard run)
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ByVA8jHADSaUJX4kBW7BfG)_