### PR TITLE
fix: fuzz test proto injection, lockfile sync, validate node_modules exclusion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2484,6 +2484,19 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/micromatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/mime": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-4.1.0.tgz",
@@ -4776,13 +4789,13 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=8.6"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
@@ -5856,19 +5869,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
-      }
-    },
-    "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/to-regex-range": {

--- a/scripts/export-marketplace-agents.mjs
+++ b/scripts/export-marketplace-agents.mjs
@@ -233,7 +233,7 @@ function loadAgents() {
 
 function normalizePlatform(platform) {
   const lowered = platform.toLowerCase();
-  return PLATFORM_ALIASES[lowered] ?? lowered;
+  return Object.hasOwn(PLATFORM_ALIASES, lowered) ? PLATFORM_ALIASES[lowered] : lowered;
 }
 
 function ensurePlatform(platform) {

--- a/tests/fuzz-properties.test.mjs
+++ b/tests/fuzz-properties.test.mjs
@@ -42,7 +42,7 @@ const HARNESS_PATH_TRAVERSAL =
 
 function normalizePlatform(platform, aliases) {
   const lowered = platform.toLowerCase();
-  return aliases[lowered] ?? lowered;
+  return Object.hasOwn(aliases, lowered) ? aliases[lowered] : lowered;
 }
 
 const ALIASES = {

--- a/tests/validate-catalog.py
+++ b/tests/validate-catalog.py
@@ -130,7 +130,7 @@ def validate_metadata_file(item: dict) -> None:
 def validate_no_obvious_secrets() -> None:
     checked_suffixes = {".md", ".json", ".py", ".toml", ".yaml", ".yml"}
     for path in ROOT.rglob("*"):
-        if ".git" in path.parts or path.is_dir() or path.suffix not in checked_suffixes:
+        if ".git" in path.parts or "node_modules" in path.parts or path.is_dir() or path.suffix not in checked_suffixes:
             continue
         text = path.read_text(encoding="utf-8", errors="ignore")
         for pattern in SECRET_PATTERNS:


### PR DESCRIPTION
## Summary

Three bugs that broke CI and the release workflow after PR #19 merged:

- **Fuzz test proto-key injection** — fast-check found `"__proto__"` as a counterexample for `normalizePlatform`. `aliases["__proto__"]` returns `Object.prototype` (not `undefined`), so the `??` fallback never fired and `typeof result` was `'object'` not `'string'`. Fixed in both `scripts/export-marketplace-agents.mjs` and the fuzz test's reproduced copy by switching to `Object.hasOwn()`.

- **`validate-catalog.py` scanning `node_modules`** — the secret-pattern heuristic was doing `ROOT.rglob("*")` without excluding `node_modules/`. Package READMEs (e.g. `registry-auth-token`) contain example token strings that trigger the pattern, causing the release workflow's Validate step to fail. Added `"node_modules" in path.parts` to the skip condition.

- **`package-lock.json` out of sync** — `npm update --legacy-peer-deps` (used earlier to patch ip-address XSS) left `picomatch@2.3.2` in the lockfile while the resolved graph requires `picomatch@4.0.4`. The release workflow runs `npm ci` (no `--legacy-peer-deps`), which failed with `EUSAGE`. Regenerated lockfile with `npm install`.

## Test plan

- [ ] `node tests/fuzz-properties.test.mjs` — all 13 properties pass
- [ ] `python3 tests/validate-catalog.py` — 639 entries validated, 0 secret errors
- [ ] `npm ci` — clean install, 0 vulnerabilities
- [ ] Merge and verify release workflow creates v1.7.0


---
_Generated by [Claude Code](https://claude.ai/code/session_01ByVA8jHADSaUJX4kBW7BfG)_