### PR TITLE
feat!: 2.0.0 — zero-trust scope enforcement, full role×provider matrix coverage

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vanguard-frontier-agentic",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "Cloud and zero-trust agentic workflow marketplace for skills, agents, rules, MCP references, and compliance-aware architecture.",
   "author": {
     "name": "Raishin",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vanguard-frontier-agentic",
-  "version": "1.9.0",
+  "version": "2.0.0",
   "description": "Cloud and zero-trust agentic workflow marketplace for skills, agents, rules, MCP references, and compliance-aware architecture.",
   "author": {
     "name": "Raishin",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vanguard-frontier-agentic",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "Cloud and zero-trust agentic workflow marketplace for skills, agents, rules, MCP references, and compliance-aware architecture.",
   "author": {
     "name": "Raishin",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vanguard-frontier-agentic",
-  "version": "1.9.0",
+  "version": "2.0.0",
   "description": "Cloud and zero-trust agentic workflow marketplace for skills, agents, rules, MCP references, and compliance-aware architecture.",
   "author": {
     "name": "Raishin",

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/github/copilot-cli/main/schemas/marketplace.schema.json",
   "name": "vanguard-frontier-agentic",
   "description": "Curated marketplace for cloud and zero-trust AI workflows. 331 agents, 286 skills, and rules across AWS, Azure, OCI, GCP, Alibaba Cloud, Huawei Cloud, Kubernetes, and Terraform.",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "owner": {
     "name": "Raishin",
     "url": "https://github.com/Raishin"

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/github/copilot-cli/main/schemas/marketplace.schema.json",
   "name": "vanguard-frontier-agentic",
   "description": "Curated marketplace for cloud and zero-trust AI workflows. 331 agents, 286 skills, and rules across AWS, Azure, OCI, GCP, Alibaba Cloud, Huawei Cloud, Kubernetes, and Terraform.",
-  "version": "1.9.0",
+  "version": "2.0.0",
   "owner": {
     "name": "Raishin",
     "url": "https://github.com/Raishin"

--- a/.github/workflows/packed-artifact-smoke.yml
+++ b/.github/workflows/packed-artifact-smoke.yml
@@ -9,8 +9,10 @@ jobs:
   packed-artifact-smoke:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      # SHA-pinned to v6.0.2 — verified 2026-05-16 against github.com/actions/checkout/releases/tag/v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      # SHA-pinned to v6.4.0 — verified 2026-05-16 against github.com/actions/setup-node/releases/tag/v6.4.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: "22"
           cache: "npm"
@@ -20,32 +22,53 @@ jobs:
         run: npm pack --silent
       - name: Install tarball into clean consumer project
         run: |
-          TARBALL="$(ls -1 *.tgz | head -n1)"
-          mkdir -p /tmp/vfa-consumer
-          cd /tmp/vfa-consumer
+          set -euo pipefail
+          # Assert exactly one tarball was produced — multiple .tgz would indicate a stale
+          # workspace artifact from a previous run (self-hosted runners without cleanup).
+          TARBALL_COUNT="$(ls -1 *.tgz 2>/dev/null | wc -l)"
+          if [ "$TARBALL_COUNT" -ne 1 ]; then
+            echo "ERROR: expected exactly 1 .tgz, found $TARBALL_COUNT" >&2
+            ls -1 *.tgz >&2
+            exit 1
+          fi
+          TARBALL="$(ls -1 *.tgz)"
+          CONSUMER_DIR="${{ runner.temp }}/vfa-consumer"
+          mkdir -p "$CONSUMER_DIR"
+          cd "$CONSUMER_DIR"
           npm init -y
           npm install "$GITHUB_WORKSPACE/$TARBALL"
+          # Export CONSUMER_DIR for subsequent steps
+          echo "CONSUMER_DIR=$CONSUMER_DIR" >> "$GITHUB_ENV"
       - name: Smoke packaged CLI — list
         run: |
-          cd /tmp/vfa-consumer
-          npx vfa-export-agents --list > /tmp/vfa-list.txt
-          test -s /tmp/vfa-list.txt
-          echo "CLI --list output: $(wc -l < /tmp/vfa-list.txt) lines"
+          set -euo pipefail
+          OUT="${{ runner.temp }}/vfa-list.txt"
+          cd "$CONSUMER_DIR"
+          npx vfa-export-agents --list > "$OUT"
+          test -s "$OUT"
+          echo "CLI --list output: $(wc -l < "$OUT") lines"
       - name: Smoke packaged CLI — list-roles
         run: |
-          cd /tmp/vfa-consumer
-          npx vfa-export-agents --list-roles > /tmp/vfa-roles.txt
-          test -s /tmp/vfa-roles.txt
-          echo "CLI --list-roles output: $(wc -l < /tmp/vfa-roles.txt) lines"
+          set -euo pipefail
+          OUT="${{ runner.temp }}/vfa-roles.txt"
+          cd "$CONSUMER_DIR"
+          npx vfa-export-agents --list-roles > "$OUT"
+          test -s "$OUT"
+          echo "CLI --list-roles output: $(wc -l < "$OUT") lines"
       - name: Smoke packaged CLI — list-providers
         run: |
-          cd /tmp/vfa-consumer
-          npx vfa-export-agents --list-providers > /tmp/vfa-providers.txt
-          test -s /tmp/vfa-providers.txt
-          echo "CLI --list-providers output: $(wc -l < /tmp/vfa-providers.txt) lines"
+          set -euo pipefail
+          OUT="${{ runner.temp }}/vfa-providers.txt"
+          cd "$CONSUMER_DIR"
+          npx vfa-export-agents --list-providers > "$OUT"
+          test -s "$OUT"
+          echo "CLI --list-providers output: $(wc -l < "$OUT") lines"
       - name: Smoke packaged script — agents:export
         run: |
-          PKG_DIR="/tmp/vfa-consumer/node_modules/@raishin/vanguard-frontier-agentic"
+          set -euo pipefail
+          OUT="${{ runner.temp }}/vfa-script.txt"
+          PKG_DIR="$CONSUMER_DIR/node_modules/@raishin/vanguard-frontier-agentic"
           cd "$PKG_DIR"
-          node scripts/export-marketplace-agents.mjs --list > /tmp/vfa-script.txt
-          test -s /tmp/vfa-script.txt
+          node scripts/export-marketplace-agents.mjs --list > "$OUT"
+          test -s "$OUT"
+          echo "Raw script output: $(wc -l < "$OUT") lines"

--- a/.github/workflows/packed-artifact-smoke.yml
+++ b/.github/workflows/packed-artifact-smoke.yml
@@ -1,0 +1,51 @@
+name: Published Package Smoke
+on:
+  pull_request:
+  push:
+    branches: [master, main]
+permissions:
+  contents: read
+jobs:
+  packed-artifact-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+      - name: Install dev dependencies
+        run: npm ci
+      - name: Pack artefact
+        run: npm pack --silent
+      - name: Install tarball into clean consumer project
+        run: |
+          TARBALL="$(ls -1 *.tgz | head -n1)"
+          mkdir -p /tmp/vfa-consumer
+          cd /tmp/vfa-consumer
+          npm init -y
+          npm install "$GITHUB_WORKSPACE/$TARBALL"
+      - name: Smoke packaged CLI — list
+        run: |
+          cd /tmp/vfa-consumer
+          npx vfa-export-agents --list > /tmp/vfa-list.txt
+          test -s /tmp/vfa-list.txt
+          echo "CLI --list output: $(wc -l < /tmp/vfa-list.txt) lines"
+      - name: Smoke packaged CLI — list-roles
+        run: |
+          cd /tmp/vfa-consumer
+          npx vfa-export-agents --list-roles > /tmp/vfa-roles.txt
+          test -s /tmp/vfa-roles.txt
+          echo "CLI --list-roles output: $(wc -l < /tmp/vfa-roles.txt) lines"
+      - name: Smoke packaged CLI — list-providers
+        run: |
+          cd /tmp/vfa-consumer
+          npx vfa-export-agents --list-providers > /tmp/vfa-providers.txt
+          test -s /tmp/vfa-providers.txt
+          echo "CLI --list-providers output: $(wc -l < /tmp/vfa-providers.txt) lines"
+      - name: Smoke packaged script — agents:export
+        run: |
+          PKG_DIR="/tmp/vfa-consumer/node_modules/@raishin/vanguard-frontier-agentic"
+          cd "$PKG_DIR"
+          node scripts/export-marketplace-agents.mjs --list > /tmp/vfa-script.txt
+          test -s /tmp/vfa-script.txt

--- a/.github/workflows/provider-scope-regression.yml
+++ b/.github/workflows/provider-scope-regression.yml
@@ -15,40 +15,66 @@ jobs:
           node-version: "22"
       - name: Export AWS-scoped security engineer role
         run: |
-          mkdir -p /tmp/vfa-scope-aws
+          DEST="${{ runner.temp }}/vfa-scope-aws"
+          mkdir -p "$DEST"
           node scripts/export-marketplace-agents.mjs \
             --platform claude-code \
             --role cloud-security-engineer \
             --provider aws \
-            --repo /tmp/vfa-scope-aws
+            --repo "$DEST"
+          echo "DEST=$DEST" >> "$GITHUB_ENV"
+      - name: Assert skills directory was created
+        run: |
+          SKILL_DIR="$DEST/.claude/skills"
+          if [ ! -d "$SKILL_DIR" ]; then
+            echo "ERROR: .claude/skills was not created — skill export did not run" >&2
+            exit 1
+          fi
+          echo "PASS: Skills directory exists at $SKILL_DIR"
       - name: Assert no non-AWS skills leaked
         run: |
-          SKILL_DIR="/tmp/vfa-scope-aws/.claude/skills"
-          if [ -d "$SKILL_DIR" ]; then
-            find "$SKILL_DIR" -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | sort > /tmp/aws-skills.txt
-            echo "Exported skills:"
-            cat /tmp/aws-skills.txt
-            if grep -qE '^(azure-|gcp-|oci-|alibaba-|huawei-)' /tmp/aws-skills.txt; then
-              echo "ERROR: Non-AWS skill leaked into AWS-scoped export:" >&2
-              grep -E '^(azure-|gcp-|oci-|alibaba-|huawei-)' /tmp/aws-skills.txt >&2
-              exit 1
-            fi
-            echo "PASS: No non-AWS skills found in AWS-scoped export"
-          else
-            echo "No skills directory found — skills may not have been exported"
+          SKILL_DIR="$DEST/.claude/skills"
+          find "$SKILL_DIR" -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | sort > /tmp/aws-skills.txt
+          echo "Exported skills ($(wc -l < /tmp/aws-skills.txt) total):"
+          cat /tmp/aws-skills.txt
+          # Check all non-AWS provider prefixes (not just the 5 originally listed)
+          if grep -qE '^(azure-|gcp-|oci-|alibaba-|huawei-|ovhcloud-|scaleway-|hetzner-|contabo-|ionos-|kubernetes-|terraform-|argocd-|istio-|cilium-|kyverno-|nvidia-|opentelemetry-)' /tmp/aws-skills.txt; then
+            echo "ERROR: Non-AWS skill leaked into AWS-scoped export:" >&2
+            grep -E '^(azure-|gcp-|oci-|alibaba-|huawei-|ovhcloud-|scaleway-|hetzner-|contabo-|ionos-|kubernetes-|terraform-|argocd-|istio-|cilium-|kyverno-|nvidia-|opentelemetry-)' /tmp/aws-skills.txt >&2
+            exit 1
           fi
-      - name: Dry-run shows agents AND skills
+          echo "PASS: No non-AWS skills found in AWS-scoped export"
+      - name: Dry-run shows agents AND skills without errors
         run: |
+          DRYRUN_OUT="${{ runner.temp }}/vfa-dryrun.txt"
           node scripts/export-marketplace-agents.mjs \
             --platform claude-code \
             --role cloud-security-engineer \
             --provider aws \
-            --dry-run \
-            --repo /tmp/vfa-dryrun-test > /tmp/vfa-dryrun.txt 2>&1 || true
+            --dry-run > "$DRYRUN_OUT" 2>&1
           echo "Dry-run output:"
-          cat /tmp/vfa-dryrun.txt
-          if ! grep -q "export agent:" /tmp/vfa-dryrun.txt; then
+          cat "$DRYRUN_OUT"
+          if ! grep -q "export agent:" "$DRYRUN_OUT"; then
             echo "ERROR: dry-run did not output any agents" >&2
             exit 1
           fi
-          echo "PASS: Dry-run output contains agents"
+          if ! grep -q "export skill:" "$DRYRUN_OUT"; then
+            echo "ERROR: dry-run did not output any skills" >&2
+            exit 1
+          fi
+          echo "PASS: Dry-run output contains agents and skills"
+      - name: Assert empty --provider is rejected
+        run: |
+          set +e
+          node scripts/export-marketplace-agents.mjs \
+            --platform claude-code \
+            --role cloud-security-engineer \
+            --provider "" \
+            --dry-run 2>&1
+          EXIT=$?
+          set -e
+          if [ "$EXIT" -eq 0 ]; then
+            echo "ERROR: --provider \"\" should be rejected but exited 0" >&2
+            exit 1
+          fi
+          echo "PASS: --provider \"\" correctly rejected (exit $EXIT)"

--- a/.github/workflows/provider-scope-regression.yml
+++ b/.github/workflows/provider-scope-regression.yml
@@ -9,12 +9,15 @@ jobs:
   provider-scope:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      # SHA-pinned to v6.0.2 — verified 2026-05-16 against github.com/actions/checkout/releases/tag/v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      # SHA-pinned to v6.4.0 — verified 2026-05-16 against github.com/actions/setup-node/releases/tag/v6.4.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: "22"
       - name: Export AWS-scoped security engineer role
         run: |
+          set -euo pipefail
           DEST="${{ runner.temp }}/vfa-scope-aws"
           mkdir -p "$DEST"
           node scripts/export-marketplace-agents.mjs \
@@ -25,6 +28,7 @@ jobs:
           echo "DEST=$DEST" >> "$GITHUB_ENV"
       - name: Assert skills directory was created
         run: |
+          set -euo pipefail
           SKILL_DIR="$DEST/.claude/skills"
           if [ ! -d "$SKILL_DIR" ]; then
             echo "ERROR: .claude/skills was not created — skill export did not run" >&2
@@ -33,19 +37,24 @@ jobs:
           echo "PASS: Skills directory exists at $SKILL_DIR"
       - name: Assert no non-AWS skills leaked
         run: |
+          set -euo pipefail
           SKILL_DIR="$DEST/.claude/skills"
-          find "$SKILL_DIR" -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | sort > /tmp/aws-skills.txt
-          echo "Exported skills ($(wc -l < /tmp/aws-skills.txt) total):"
-          cat /tmp/aws-skills.txt
+          # Write intermediate file to runner.temp (not /tmp) to avoid symlink/race attacks
+          # in parallel CI runs on self-hosted runners sharing /tmp.
+          SKILLS_LIST="${{ runner.temp }}/aws-skills.txt"
+          find "$SKILL_DIR" -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | sort > "$SKILLS_LIST"
+          echo "Exported skills ($(wc -l < "$SKILLS_LIST") total):"
+          cat "$SKILLS_LIST"
           # Check all non-AWS provider prefixes (not just the 5 originally listed)
-          if grep -qE '^(azure-|gcp-|oci-|alibaba-|huawei-|ovhcloud-|scaleway-|hetzner-|contabo-|ionos-|kubernetes-|terraform-|argocd-|istio-|cilium-|kyverno-|nvidia-|opentelemetry-)' /tmp/aws-skills.txt; then
+          if grep -qE '^(azure-|gcp-|oci-|alibaba-|huawei-|ovhcloud-|scaleway-|hetzner-|contabo-|ionos-|kubernetes-|terraform-|argocd-|istio-|cilium-|kyverno-|nvidia-|opentelemetry-)' "$SKILLS_LIST"; then
             echo "ERROR: Non-AWS skill leaked into AWS-scoped export:" >&2
-            grep -E '^(azure-|gcp-|oci-|alibaba-|huawei-|ovhcloud-|scaleway-|hetzner-|contabo-|ionos-|kubernetes-|terraform-|argocd-|istio-|cilium-|kyverno-|nvidia-|opentelemetry-)' /tmp/aws-skills.txt >&2
+            grep -E '^(azure-|gcp-|oci-|alibaba-|huawei-|ovhcloud-|scaleway-|hetzner-|contabo-|ionos-|kubernetes-|terraform-|argocd-|istio-|cilium-|kyverno-|nvidia-|opentelemetry-)' "$SKILLS_LIST" >&2
             exit 1
           fi
           echo "PASS: No non-AWS skills found in AWS-scoped export"
       - name: Dry-run shows agents AND skills without errors
         run: |
+          set -euo pipefail
           DRYRUN_OUT="${{ runner.temp }}/vfa-dryrun.txt"
           node scripts/export-marketplace-agents.mjs \
             --platform claude-code \
@@ -65,6 +74,7 @@ jobs:
           echo "PASS: Dry-run output contains agents and skills"
       - name: Assert empty --provider is rejected
         run: |
+          set -euo pipefail
           set +e
           node scripts/export-marketplace-agents.mjs \
             --platform claude-code \

--- a/.github/workflows/provider-scope-regression.yml
+++ b/.github/workflows/provider-scope-regression.yml
@@ -1,0 +1,54 @@
+name: Provider Scope Regression
+on:
+  pull_request:
+  push:
+    branches: [master, main]
+permissions:
+  contents: read
+jobs:
+  provider-scope:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - name: Export AWS-scoped security engineer role
+        run: |
+          mkdir -p /tmp/vfa-scope-aws
+          node scripts/export-marketplace-agents.mjs \
+            --platform claude-code \
+            --role cloud-security-engineer \
+            --provider aws \
+            --repo /tmp/vfa-scope-aws
+      - name: Assert no non-AWS skills leaked
+        run: |
+          SKILL_DIR="/tmp/vfa-scope-aws/.claude/skills"
+          if [ -d "$SKILL_DIR" ]; then
+            find "$SKILL_DIR" -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | sort > /tmp/aws-skills.txt
+            echo "Exported skills:"
+            cat /tmp/aws-skills.txt
+            if grep -qE '^(azure-|gcp-|oci-|alibaba-|huawei-)' /tmp/aws-skills.txt; then
+              echo "ERROR: Non-AWS skill leaked into AWS-scoped export:" >&2
+              grep -E '^(azure-|gcp-|oci-|alibaba-|huawei-)' /tmp/aws-skills.txt >&2
+              exit 1
+            fi
+            echo "PASS: No non-AWS skills found in AWS-scoped export"
+          else
+            echo "No skills directory found — skills may not have been exported"
+          fi
+      - name: Dry-run shows agents AND skills
+        run: |
+          node scripts/export-marketplace-agents.mjs \
+            --platform claude-code \
+            --role cloud-security-engineer \
+            --provider aws \
+            --dry-run \
+            --repo /tmp/vfa-dryrun-test > /tmp/vfa-dryrun.txt 2>&1 || true
+          echo "Dry-run output:"
+          cat /tmp/vfa-dryrun.txt
+          if ! grep -q "export agent:" /tmp/vfa-dryrun.txt; then
+            echo "ERROR: dry-run did not output any agents" >&2
+            exit 1
+          fi
+          echo "PASS: Dry-run output contains agents"

--- a/.releaserc.js
+++ b/.releaserc.js
@@ -91,11 +91,15 @@ module.exports = {
           "CHANGELOG.md",
           "package.json",
           // Synchronized by scripts/release-prepare.mjs during prepare.
-          // Commit them so the next release diff stays clean and the
-          // attested tarball matches the committed tree.
+          // package.json is the single source of truth; all versioned files
+          // below are derived from it and committed together in the release
+          // commit so the next diff stays clean and the attested tarball
+          // matches the committed tree.
           ".claude-plugin/plugin.json",
           ".cursor-plugin/plugin.json",
           "plugins/vanguard-frontier-agentic/.codex-plugin/plugin.json",
+          ".github/plugin/marketplace.json",
+          "SECURITY.md",
           "catalog/asset-integrity.json",
         ],
         message: "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,84 @@
+## 🔴 v2.0.0 — *Zero-Trust Scope Enforcement* &mdash; 2026-05-16
+
+> _Provider-scoped exports are now strict and auditable. 334 agents · 335 skills · 26 providers · 16 roles_
+>
+> This release closes a class of privilege-escalation bugs in the export CLI and hardens the
+> entire provider-scope boundary from user input through to CI attestation.
+
+### ⚠️ BREAKING CHANGES
+
+**1. `--provider <p>` now strictly scopes skills to the selected provider.**
+
+Previous behavior: `--provider aws --role cloud-security-engineer` exported the AWS agents
+*plus all 70+ role-level skills regardless of their provider* (Azure, GCP, OCI, Alibaba etc.).
+Consumers who relied on `--provider aws` to also receive cross-cloud role skills must now
+either drop `--provider` (exports all providers in the role) or run separate invocations per
+provider.
+
+**2. `--provider ""` is now a hard error (exit 1).**
+
+Empty-string `--provider` previously normalised to `null` (falsy bypass), silently disabling
+all scope filtering and exporting every provider's content. It now throws immediately with a
+descriptive error. Automation scripts that passed `--provider ""` as a no-op will break.
+
+**3. Symlink destinations are rejected in `--force` mode.**
+
+`copyFile()` now calls `lstatSync` on the destination before any write and throws if it is a
+symbolic link. Any workflow that pre-created a symlink at the export destination to redirect
+output (intentional or accidental) must remove the symlink before running.
+
+**4. Unknown CLI flags now produce a descriptive error, not silent usage output.**
+
+The parser was migrated to Node.js built-in `util.parseArgs` (strict mode). Unknown flags
+exit 1 with the flag name in the error message instead of the previous generic usage printout.
+Scripts that checked stderr for specific legacy strings may need updating.
+
+### Features
+
+* Full 93-combination role×provider matrix validation: every valid `--provider <p> --role <r>`
+  combination is now regression-tested; 323 invalid combinations are verified to reject with
+  `"No agents found"` rather than silently degrading
+* All 26 providers verified clean in standalone `--provider <p> --all` scope sweep
+* `--provider=aws` inline equals-sign form now works (previously silently rejected by parser)
+* `--dry-run` now resolves and prints the full skill plan before any files are written,
+  making the dry-run output a reliable preview of the actual write
+* `--list-providers`, `--dry-run`, `--no-skills` documented in CLI `--help` output
+
+### Security
+
+* **OWASP A01** — Provider scope enforcement: 3 of 3 skill resolution paths now apply the
+  selectedProvider gate (role.skills, includeAll, per-agent companion_skills + name-stripping)
+* **OWASP A01** — `--provider ""` falsy bypass closed; empty-string and whitespace-only values
+  are rejected before reaching any validation logic
+* **OWASP A08** — GitHub Actions SHA-pinned to verified commit digests (v6.0.2 / v6.4.0);
+  upgraded from mutable `@v4` tags
+* **OWASP A05** — CI temp paths moved from `/tmp` (race/symlink risk) to `${{ runner.temp }}`
+  in both new workflows; `set -euo pipefail` added to every bash step
+* **TOCTOU** — Symlink destination check in `copyFile()` closes the most exploitable write
+  redirection window; residual O_NOFOLLOW gap documented in `assertWithin()` comment
+* Catalog-driven rival-skill detection replaces hardcoded 5-prefix list (now covers all 26 providers)
+
+### CI
+
+* `packed-artifact-smoke.yml` — packs tarball, installs into clean consumer project, asserts
+  exactly 1 .tgz produced, uses `${{ runner.temp }}` throughout
+* `provider-scope-regression.yml` — AWS-scoped export + skills-dir assertion + dry-run
+  completeness + `--provider ""` rejection, all with SHA-pinned actions
+
+### Test coverage: 11 → 38 assertions
+
+| Group | Tests | Coverage |
+|-------|-------|----------|
+| A1–A4 | 4 | Catalog integrity |
+| B5–B9 | 5 | Provider export counts + rejection |
+| C10–C11 | 2 | NVIDIA role presence |
+| D12–D15, D14b, D14c, D14d | 8 | Full provider×role scope matrix (93 valid + 323 invalid combos) |
+| E15–E18 | 4 | Dry-run completeness |
+| F19–F27 | 9 | Full CLI flag surface with real writes |
+| G28–G35 | 8 | Error/rejection cases incl. equals-sign, Unicode, unknown flags |
+
+---
+
 ## 🛡️ v1.9.0 — *Provenance, Policy, Portability* &mdash; 2026-05-14
 
 > _Multi-cloud agent marketplace · `AWS` · `Azure` · `OCI` · `Terraform`_

--- a/README.md
+++ b/README.md
@@ -465,6 +465,9 @@ Everything you can install, and exactly how to install it. One section, no hunti
 | `--force`      | —                                                     | ➕ optional                              | Overwrite files that already exist                   |
 | `--list`       | —                                                     | 🔍 standalone                            | Print all agent IDs, providers, and names; then exit |
 | `--list-roles` | —                                                     | 🔍 standalone                            | Print role IDs with agent counts; then exit          |
+| `--list-providers` | —                                                 | 🔍 standalone                            | List all providers with agent counts; then exit      |
+| `--dry-run`    | —                                                     | ➕ optional                              | Print the export plan without writing files          |
+| `--no-skills`  | —                                                     | ➕ optional                              | Skip companion skill bundling                        |
 
 ---
 
@@ -575,6 +578,7 @@ npx vfa-export-agents --platform copilot --role cloud-devops-engineer --provider
 | ----------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
 | 🔍 See what agents exist                         | `npx vfa-export-agents --list`                                                                                        |
 | 🔍 See what roles exist                          | `npx vfa-export-agents --list-roles`                                                                                  |
+| 🔍 See what providers exist                      | `npx vfa-export-agents --list-providers`                                                                              |
 | 👤 Install for my job role (Claude Code)         | `npx vfa-export-agents --platform claude-code --role <role> --repo .`                                                 |
 | ☁️ Install for my job role, one cloud only       | `npx vfa-export-agents --platform claude-code --role <role> --provider aws --repo .`                                  |
 | ☸️ Install K8s admission security role           | `npx vfa-export-agents --platform claude-code --role kubernetes-admission-security-engineer --repo .`                 |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,7 +9,7 @@ The table below shows which versions of `@raishin/vanguard-frontier-agentic`
 | ------------- | ------------------ |
 | 1.9.x         | Yes — current minor |
 | 1.8.x         | Yes — previous minor |
-| < 1.8.0       | No                 |
+| < 1.8.0      | No                 |
 
 Fixes are back-ported to the previous minor only when the vulnerability is
 rated high or critical. Older versions receive no patches; upgrade to a

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,13 +3,13 @@
 ## Supported Versions
 
 The table below shows which versions of `@raishin/vanguard-frontier-agentic`
-(current published version: **1.9.0**) receive security fixes.
+(current published version: **2.0.0**) receive security fixes.
 
 | Version range | Supported          |
 | ------------- | ------------------ |
-| 1.9.x         | Yes — current minor |
-| 1.8.x         | Yes — previous minor |
-| < 1.8.0      | No                 |
+| 2.0.x         | Yes — current minor |
+| 1.x           | Yes — previous minor |
+| < 2.0.0      | No                 |
 
 Fixes are back-ported to the previous minor only when the vulnerability is
 rated high or critical. Older versions receive no patches; upgrade to a

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,13 +3,13 @@
 ## Supported Versions
 
 The table below shows which versions of `@raishin/vanguard-frontier-agentic`
-(current published version: **1.3.0**) receive security fixes.
+(current published version: **1.9.0**) receive security fixes.
 
 | Version range | Supported          |
 | ------------- | ------------------ |
-| 1.3.x         | Yes — current minor |
-| 1.2.x         | Yes — previous minor |
-| < 1.2.0       | No                 |
+| 1.9.x         | Yes — current minor |
+| 1.8.x         | Yes — previous minor |
+| < 1.8.0       | No                 |
 
 Fixes are back-ported to the previous minor only when the vulnerability is
 rated high or critical. Older versions receive no patches; upgrade to a

--- a/catalog/asset-integrity.json
+++ b/catalog/asset-integrity.json
@@ -15813,7 +15813,7 @@
     },
     {
       "tree": "scripts",
-      "aggregate_sha256": "4929ac32655bf6c754b54b8acd072408e2ecb4ca2df7e820670f6cba3ceea748",
+      "aggregate_sha256": "7fb1d3a3f860611419438e44f7eb7853d6d91f0f2cd4bd02ad7ed11e4ad7fe58",
       "files": [
         {
           "path": "scripts/apply-skill-allowed-tools.py",
@@ -15827,8 +15827,8 @@
         },
         {
           "path": "scripts/export-marketplace-agents.mjs",
-          "sha256": "6e20e183e850a24b20677d1106f07b4a8d74d8b47dc081bd47f029becd400b95",
-          "bytes": 21240
+          "sha256": "0912736196bd5dc2bc0788fb8366d311ae1099c1fd28c770e2d1c3de556afddd",
+          "bytes": 22469
         },
         {
           "path": "scripts/gen_azure_live_guards.py",
@@ -15966,7 +15966,7 @@
     },
     {
       "tree": ".claude-plugin",
-      "aggregate_sha256": "1ada7418d40d7c6e7cf36a832a6a7e435a2c934289a3717513bf5dbc9176b569",
+      "aggregate_sha256": "378d7bc7423a45d848f71c3a67812f9ce2aff0d0d490c947aca7d0c8ddb1ba6d",
       "files": [
         {
           "path": ".claude-plugin/README.md",
@@ -15980,14 +15980,14 @@
         },
         {
           "path": ".claude-plugin/plugin.json",
-          "sha256": "4774403f7b4587a39c690040d0cb9c536c8cc60273101e2ddd2d365cd2f67f1d",
+          "sha256": "c09f1c131869b8702e8c88f408102dc07faaef4ebd0bc34f4d389c47c09c9cb2",
           "bytes": 31096
         }
       ]
     },
     {
       "tree": ".cursor-plugin",
-      "aggregate_sha256": "64d4b189312b626710517998378869747801ad7f916076337c554f2eec7327ab",
+      "aggregate_sha256": "2bf14976a6e086381957266a20cb42b2a38a90e2351e952595af3bed846c007d",
       "files": [
         {
           "path": ".cursor-plugin/README.md",
@@ -15996,14 +15996,14 @@
         },
         {
           "path": ".cursor-plugin/plugin.json",
-          "sha256": "9196493107b5df130ed5b4ef0ab792d34cd926a45684e4ee53c1408cca9f667f",
+          "sha256": "c78fad760caac43cb5b01987db878b0b49e3f3e630a47701b44a67007115c89c",
           "bytes": 29402
         }
       ]
     },
     {
       "tree": ".github/plugin",
-      "aggregate_sha256": "880548b543ab00b34853dea0e0b5433e8e53e8ee377dc3388ba929cea19bf82a",
+      "aggregate_sha256": "13cf9b1480e70df43ad167f2f73aa080587d5d6a08dd04442f434d33a6f89183",
       "files": [
         {
           "path": ".github/plugin/README.md",
@@ -16012,7 +16012,7 @@
         },
         {
           "path": ".github/plugin/marketplace.json",
-          "sha256": "f9b3789a86f1e6ce483b293dfa127d79a414b83be410e58e5478c61f77379c74",
+          "sha256": "26c02c289cadcb732b837a5d679d2085d2cad88a547b3221d413c34a29fb120b",
           "bytes": 790
         }
       ]
@@ -20248,12 +20248,12 @@
   "root_files": [
     {
       "path": "README.md",
-      "sha256": "04694282dff1fc5f98d7f931882203178ad74a52b70822e99389a7f847a4a2f1",
-      "bytes": 65050
+      "sha256": "7390f5d68bfd01cf4cfae66348d2af28274b9b36b3f6204247291b48fa0c5d1c",
+      "bytes": 65754
     },
     {
       "path": "SECURITY.md",
-      "sha256": "aa9b4b923339b76fb9f23bad804af52ba8eb946009ccc157db061bb4a90b208c",
+      "sha256": "df11b1ed7d15ceb7e8800ae45832a3da14e98c5c90608d2d77acbdaa9ad64715",
       "bytes": 7074
     },
     {
@@ -20288,8 +20288,8 @@
     },
     {
       "path": "package.json",
-      "sha256": "4d5e9beccfb91b44b81ef9d98537285e2ee475e7b3678e66bc0dee3e2d9bf539",
-      "bytes": 5058
+      "sha256": "1945ce17dd00f750221b198a4409c753ed790e8d0ec23f207536ea2126f3d395",
+      "bytes": 5072
     },
     {
       "path": ".releaserc.js",
@@ -20297,5 +20297,5 @@
       "bytes": 3765
     }
   ],
-  "aggregate_sha256": "07fca8114ca214fafb9f4634127c85016f2fdfaeec5b331d1109a706f0eb6baf"
+  "aggregate_sha256": "dbfdf508a09bfcec6b6fbf3b47316fe6d2729603fa565af4095e93088df4e60d"
 }

--- a/catalog/asset-integrity.json
+++ b/catalog/asset-integrity.json
@@ -15813,7 +15813,7 @@
     },
     {
       "tree": "scripts",
-      "aggregate_sha256": "7fb1d3a3f860611419438e44f7eb7853d6d91f0f2cd4bd02ad7ed11e4ad7fe58",
+      "aggregate_sha256": "6db28689aa2c8705f2858fd61378de688b0ced830a9eb1c8455f04142497a6b8",
       "files": [
         {
           "path": "scripts/apply-skill-allowed-tools.py",
@@ -15857,8 +15857,8 @@
         },
         {
           "path": "scripts/release-prepare.mjs",
-          "sha256": "7f91ce7071275081d8a0a1a7be609f77b34e29dbd130abc8e92859197957a214",
-          "bytes": 3580
+          "sha256": "3f934abd022a7dac7c5cbdd4bc845cf0519e488c6b602c5a0259f67917fec8df",
+          "bytes": 5357
         },
         {
           "path": "scripts/update-catalog-new-agents.py",
@@ -20253,8 +20253,8 @@
     },
     {
       "path": "SECURITY.md",
-      "sha256": "df11b1ed7d15ceb7e8800ae45832a3da14e98c5c90608d2d77acbdaa9ad64715",
-      "bytes": 7074
+      "sha256": "7842166b2d47b49f47ff5bced053202c8d5a2c938f4309ae16c197971add8b49",
+      "bytes": 7073
     },
     {
       "path": "LICENSE",
@@ -20293,9 +20293,9 @@
     },
     {
       "path": ".releaserc.js",
-      "sha256": "8f7ae05ee74e08da68ed276927a9088e7fef2d11940928c5233e1f849a61f09d",
-      "bytes": 3765
+      "sha256": "467483143385a4c5ad9be41b36d210fdc6f366d84f9a8123562c421389ce23a3",
+      "bytes": 3976
     }
   ],
-  "aggregate_sha256": "dbfdf508a09bfcec6b6fbf3b47316fe6d2729603fa565af4095e93088df4e60d"
+  "aggregate_sha256": "96e4f2e5edb7ccd037402a3cd92e571a40c597a2bcfd163b5763127f07dad1e5"
 }

--- a/catalog/asset-integrity.json
+++ b/catalog/asset-integrity.json
@@ -15813,7 +15813,7 @@
     },
     {
       "tree": "scripts",
-      "aggregate_sha256": "6db28689aa2c8705f2858fd61378de688b0ced830a9eb1c8455f04142497a6b8",
+      "aggregate_sha256": "8eef25df231ceb0a71c1afe93da1a654982c4fbbe42d5f9e466f9f76692b0448",
       "files": [
         {
           "path": "scripts/apply-skill-allowed-tools.py",
@@ -15827,8 +15827,8 @@
         },
         {
           "path": "scripts/export-marketplace-agents.mjs",
-          "sha256": "0912736196bd5dc2bc0788fb8366d311ae1099c1fd28c770e2d1c3de556afddd",
-          "bytes": 22469
+          "sha256": "c18d662e1d2bda185f48bae61d5288f04019ff05246b6336aa09b2dfde590f27",
+          "bytes": 22666
         },
         {
           "path": "scripts/gen_azure_live_guards.py",
@@ -15857,8 +15857,8 @@
         },
         {
           "path": "scripts/release-prepare.mjs",
-          "sha256": "3f934abd022a7dac7c5cbdd4bc845cf0519e488c6b602c5a0259f67917fec8df",
-          "bytes": 5357
+          "sha256": "e3355f89ffb1f69e48e3ef3551891caf47f93fc7cb24ebc0f5c9a3164ac01300",
+          "bytes": 5729
         },
         {
           "path": "scripts/update-catalog-new-agents.py",
@@ -16035,7 +16035,7 @@
     },
     {
       "tree": "tests",
-      "aggregate_sha256": "0be4350e5ff20943510e2315ba9b00cd5f2fd4e085abed542c8232958793f20f",
+      "aggregate_sha256": "d5fc59e400c08942927651a431a78cf4bf02d37487273008b633fc0c55b50217",
       "files": [
         {
           "path": "tests/AGENTS.md",
@@ -20144,8 +20144,8 @@
         },
         {
           "path": "tests/test-vfa-export-coverage.test.mjs",
-          "sha256": "61afc0937744331a6ac237ac5d953f812c9e82cb8677d5b02e534ac009f03956",
-          "bytes": 21613
+          "sha256": "19edd79490b2735e92ef8048c879fe6cdd920248da4801a9495defec890eee03",
+          "bytes": 23161
         },
         {
           "path": "tests/validate-agent-frontmatter-schema.py",
@@ -20297,5 +20297,5 @@
       "bytes": 3976
     }
   ],
-  "aggregate_sha256": "b82f5063a09e8c9a53e7fbbf5669d81a4d25166a3c57d973747ab6aa92971fdf"
+  "aggregate_sha256": "8f7d3981d3b95fad5b128cf22ea5a79d19ae643112576c87826398cedccf68ae"
 }

--- a/catalog/asset-integrity.json
+++ b/catalog/asset-integrity.json
@@ -15950,7 +15950,7 @@
     },
     {
       "tree": "plugins",
-      "aggregate_sha256": "68da1b895dc114ca71b3b64ec2c4081f67b9301c956f022873f348ab84efca2d",
+      "aggregate_sha256": "89dbb21f326d0ee511c8cdb5ef90dac61c82136e5308c0232cc5ffbec695ee6b",
       "files": [
         {
           "path": "plugins/cross-platform-agent-template/.codex-plugin/plugin.json",
@@ -15959,14 +15959,14 @@
         },
         {
           "path": "plugins/vanguard-frontier-agentic/.codex-plugin/plugin.json",
-          "sha256": "d04cadc1b4cc4bbd8d85073d6f0642897c23f64cb10e79e4bc13b0b670ccdf8d",
+          "sha256": "f6d1f8638ea0893a1e6b0d26c0b1ae1c9243d15cd26001c28e03e8f0d3435b77",
           "bytes": 1850
         }
       ]
     },
     {
       "tree": ".claude-plugin",
-      "aggregate_sha256": "378d7bc7423a45d848f71c3a67812f9ce2aff0d0d490c947aca7d0c8ddb1ba6d",
+      "aggregate_sha256": "8f27d61aa6898b5a91d769060783a8db823e848b44815c8edcf8c16ef1de07c2",
       "files": [
         {
           "path": ".claude-plugin/README.md",
@@ -15980,14 +15980,14 @@
         },
         {
           "path": ".claude-plugin/plugin.json",
-          "sha256": "c09f1c131869b8702e8c88f408102dc07faaef4ebd0bc34f4d389c47c09c9cb2",
+          "sha256": "6c9dbfeaddf0283338afb2ddad73b1d82ff0035a1ae10e959962561664582e3d",
           "bytes": 31096
         }
       ]
     },
     {
       "tree": ".cursor-plugin",
-      "aggregate_sha256": "2bf14976a6e086381957266a20cb42b2a38a90e2351e952595af3bed846c007d",
+      "aggregate_sha256": "68dfb3892cbd739a86537a4a0cfeca8515f8b5f1ff9530f9d99e5e30593f83de",
       "files": [
         {
           "path": ".cursor-plugin/README.md",
@@ -15996,14 +15996,14 @@
         },
         {
           "path": ".cursor-plugin/plugin.json",
-          "sha256": "c78fad760caac43cb5b01987db878b0b49e3f3e630a47701b44a67007115c89c",
+          "sha256": "f3951243263966fce5a91571dc5091287fd9494d312f5d45aaa7e2b2833b63ed",
           "bytes": 29402
         }
       ]
     },
     {
       "tree": ".github/plugin",
-      "aggregate_sha256": "13cf9b1480e70df43ad167f2f73aa080587d5d6a08dd04442f434d33a6f89183",
+      "aggregate_sha256": "a9939490f08887d2cdc2b82427a4c41c349724b84bbba227e205fb86be306a89",
       "files": [
         {
           "path": ".github/plugin/README.md",
@@ -16012,7 +16012,7 @@
         },
         {
           "path": ".github/plugin/marketplace.json",
-          "sha256": "26c02c289cadcb732b837a5d679d2085d2cad88a547b3221d413c34a29fb120b",
+          "sha256": "d49a4e31aaaf3651aeb26dabc876a114040da8b93d32079f03220a04f092c216",
           "bytes": 790
         }
       ]
@@ -16035,7 +16035,7 @@
     },
     {
       "tree": "tests",
-      "aggregate_sha256": "7780e43032ef7f04517ee7620554f6fb78869b9899f3228a5d81babe991adf75",
+      "aggregate_sha256": "5c3188eb58b43b6bb930296e00cded5df10ee6373490cdb0b890bf05cb8418a4",
       "files": [
         {
           "path": "tests/AGENTS.md",
@@ -20144,8 +20144,8 @@
         },
         {
           "path": "tests/test-vfa-export-coverage.test.mjs",
-          "sha256": "cf37c7cb5756503d43aed5d2369a9e7fafed597dc13cb3f30455cc18bee43b95",
-          "bytes": 29401
+          "sha256": "88e00f7980e54ba379b32e1e04df36db51ef825a17b8d326530737e7b76e9e54",
+          "bytes": 32204
         },
         {
           "path": "tests/validate-agent-frontmatter-schema.py",
@@ -20253,7 +20253,7 @@
     },
     {
       "path": "SECURITY.md",
-      "sha256": "7842166b2d47b49f47ff5bced053202c8d5a2c938f4309ae16c197971add8b49",
+      "sha256": "fac0f794caa05509f12bb8a4a1c92bc5e15e715c9cc50d06e8dcc0c0c34df8e9",
       "bytes": 7073
     },
     {
@@ -20288,7 +20288,7 @@
     },
     {
       "path": "package.json",
-      "sha256": "1945ce17dd00f750221b198a4409c753ed790e8d0ec23f207536ea2126f3d395",
+      "sha256": "179f7dc13d61d4a73da23fe686d5346654848e3172667b351fd805169cd4f3fd",
       "bytes": 5072
     },
     {
@@ -20297,5 +20297,5 @@
       "bytes": 3976
     }
   ],
-  "aggregate_sha256": "54f62648de364c2ce11ada9fe89f48f70a22a9a2964ff15888dcebe84992b9c1"
+  "aggregate_sha256": "3331c50ef8edc250cc80de4dd2fc5f88a3e1ad319fa6ccbf43504cf556b81606"
 }

--- a/catalog/asset-integrity.json
+++ b/catalog/asset-integrity.json
@@ -15813,7 +15813,7 @@
     },
     {
       "tree": "scripts",
-      "aggregate_sha256": "bd5e668fdd61c5748b3154c5385fe0591263ecb235272be25835dd469cdb44b3",
+      "aggregate_sha256": "c7cf5fccd73f10c273ecee2c09137b1bc467c0df0dba30b30d6328934dfa6ee5",
       "files": [
         {
           "path": "scripts/apply-skill-allowed-tools.py",
@@ -15841,6 +15841,11 @@
           "bytes": 69191
         },
         {
+          "path": "scripts/generate-changelog-counts.mjs",
+          "sha256": "3d31b02bf758fca65dd3ecefefc00e1242d160d3885931d396f912a136b4a2d0",
+          "bytes": 1404
+        },
+        {
           "path": "scripts/generate-cursor-plugin.mjs",
           "sha256": "24c9b58afc6c55be80b8e701a5fd7a64b0330d0b2836a37fa8b7b2ce5943a68b",
           "bytes": 4406
@@ -15857,8 +15862,8 @@
         },
         {
           "path": "scripts/release-prepare.mjs",
-          "sha256": "e3355f89ffb1f69e48e3ef3551891caf47f93fc7cb24ebc0f5c9a3164ac01300",
-          "bytes": 5729
+          "sha256": "ec33640391c4a45e6f7c2570c177152bdeb9612e3b47daf1a88e4b41732f9301",
+          "bytes": 7408
         },
         {
           "path": "scripts/update-catalog-new-agents.py",
@@ -20297,5 +20302,5 @@
       "bytes": 3976
     }
   ],
-  "aggregate_sha256": "3331c50ef8edc250cc80de4dd2fc5f88a3e1ad319fa6ccbf43504cf556b81606"
+  "aggregate_sha256": "38dc90d9be4eb7e886237f9f887499fe95967386a9521e983008827d3965fa4c"
 }

--- a/catalog/asset-integrity.json
+++ b/catalog/asset-integrity.json
@@ -15813,7 +15813,7 @@
     },
     {
       "tree": "scripts",
-      "aggregate_sha256": "579bfb0dec26e5628443da669dd9bc368d588a45557db8361d713052624bf90b",
+      "aggregate_sha256": "bd5e668fdd61c5748b3154c5385fe0591263ecb235272be25835dd469cdb44b3",
       "files": [
         {
           "path": "scripts/apply-skill-allowed-tools.py",
@@ -15827,8 +15827,8 @@
         },
         {
           "path": "scripts/export-marketplace-agents.mjs",
-          "sha256": "639371b13ee5fed985c669a7776b5902e21efea354239f20c5c9a71587c00b82",
-          "bytes": 23325
+          "sha256": "6b5c1a2558d02bac69e5cfd6d4c08b0c0d51b01b277da1f1200a0eac0443e3cc",
+          "bytes": 25376
         },
         {
           "path": "scripts/gen_azure_live_guards.py",
@@ -16035,7 +16035,7 @@
     },
     {
       "tree": "tests",
-      "aggregate_sha256": "05dae5e0b7a3c5e79fa29e25528610eaf74b0e8658666410d5e1044c7aefacb4",
+      "aggregate_sha256": "d74b4c6cc2cb9803ef0a38d685277397480c2c05d6fbd419061add1ef702f355",
       "files": [
         {
           "path": "tests/AGENTS.md",
@@ -20144,8 +20144,8 @@
         },
         {
           "path": "tests/test-vfa-export-coverage.test.mjs",
-          "sha256": "bdf9ae3eb1124a151a238d84ead993857358f9b038aa4c689283f939739354f1",
-          "bytes": 23621
+          "sha256": "a53aebce4ff322158aba314dc2c6098fc1c6425fb17e76a6da519fec398348f0",
+          "bytes": 25627
         },
         {
           "path": "tests/validate-agent-frontmatter-schema.py",
@@ -20297,5 +20297,5 @@
       "bytes": 3976
     }
   ],
-  "aggregate_sha256": "db04a05503ea1743455ffeaeaff906b4b1d62e7fae8bee39d41c73ee00b7a2ca"
+  "aggregate_sha256": "4d3d19129b90a731e5265de58c03d9d88f4888aecbe1e16a48e5a0ae7ff56e74"
 }

--- a/catalog/asset-integrity.json
+++ b/catalog/asset-integrity.json
@@ -16035,7 +16035,7 @@
     },
     {
       "tree": "tests",
-      "aggregate_sha256": "52a319417659083a1eacf037bd760430b95543294cf897597a7946fafee870b2",
+      "aggregate_sha256": "7780e43032ef7f04517ee7620554f6fb78869b9899f3228a5d81babe991adf75",
       "files": [
         {
           "path": "tests/AGENTS.md",
@@ -20144,8 +20144,8 @@
         },
         {
           "path": "tests/test-vfa-export-coverage.test.mjs",
-          "sha256": "b21c453d4cea666efaafdd7cffce1c5b30ea6ec0308800537185175217efd19e",
-          "bytes": 26799
+          "sha256": "cf37c7cb5756503d43aed5d2369a9e7fafed597dc13cb3f30455cc18bee43b95",
+          "bytes": 29401
         },
         {
           "path": "tests/validate-agent-frontmatter-schema.py",
@@ -20297,5 +20297,5 @@
       "bytes": 3976
     }
   ],
-  "aggregate_sha256": "661f9cd9a739dbd1978e1ae3bda6c6033899a87788e7a663e46c2000a2aa2b53"
+  "aggregate_sha256": "54f62648de364c2ce11ada9fe89f48f70a22a9a2964ff15888dcebe84992b9c1"
 }

--- a/catalog/asset-integrity.json
+++ b/catalog/asset-integrity.json
@@ -16035,7 +16035,7 @@
     },
     {
       "tree": "tests",
-      "aggregate_sha256": "d74b4c6cc2cb9803ef0a38d685277397480c2c05d6fbd419061add1ef702f355",
+      "aggregate_sha256": "52a319417659083a1eacf037bd760430b95543294cf897597a7946fafee870b2",
       "files": [
         {
           "path": "tests/AGENTS.md",
@@ -20144,8 +20144,8 @@
         },
         {
           "path": "tests/test-vfa-export-coverage.test.mjs",
-          "sha256": "a53aebce4ff322158aba314dc2c6098fc1c6425fb17e76a6da519fec398348f0",
-          "bytes": 25627
+          "sha256": "b21c453d4cea666efaafdd7cffce1c5b30ea6ec0308800537185175217efd19e",
+          "bytes": 26799
         },
         {
           "path": "tests/validate-agent-frontmatter-schema.py",
@@ -20297,5 +20297,5 @@
       "bytes": 3976
     }
   ],
-  "aggregate_sha256": "4d3d19129b90a731e5265de58c03d9d88f4888aecbe1e16a48e5a0ae7ff56e74"
+  "aggregate_sha256": "661f9cd9a739dbd1978e1ae3bda6c6033899a87788e7a663e46c2000a2aa2b53"
 }

--- a/catalog/asset-integrity.json
+++ b/catalog/asset-integrity.json
@@ -15813,7 +15813,7 @@
     },
     {
       "tree": "scripts",
-      "aggregate_sha256": "8eef25df231ceb0a71c1afe93da1a654982c4fbbe42d5f9e466f9f76692b0448",
+      "aggregate_sha256": "579bfb0dec26e5628443da669dd9bc368d588a45557db8361d713052624bf90b",
       "files": [
         {
           "path": "scripts/apply-skill-allowed-tools.py",
@@ -15827,8 +15827,8 @@
         },
         {
           "path": "scripts/export-marketplace-agents.mjs",
-          "sha256": "c18d662e1d2bda185f48bae61d5288f04019ff05246b6336aa09b2dfde590f27",
-          "bytes": 22666
+          "sha256": "639371b13ee5fed985c669a7776b5902e21efea354239f20c5c9a71587c00b82",
+          "bytes": 23325
         },
         {
           "path": "scripts/gen_azure_live_guards.py",
@@ -16035,7 +16035,7 @@
     },
     {
       "tree": "tests",
-      "aggregate_sha256": "d5fc59e400c08942927651a431a78cf4bf02d37487273008b633fc0c55b50217",
+      "aggregate_sha256": "05dae5e0b7a3c5e79fa29e25528610eaf74b0e8658666410d5e1044c7aefacb4",
       "files": [
         {
           "path": "tests/AGENTS.md",
@@ -20144,8 +20144,8 @@
         },
         {
           "path": "tests/test-vfa-export-coverage.test.mjs",
-          "sha256": "19edd79490b2735e92ef8048c879fe6cdd920248da4801a9495defec890eee03",
-          "bytes": 23161
+          "sha256": "bdf9ae3eb1124a151a238d84ead993857358f9b038aa4c689283f939739354f1",
+          "bytes": 23621
         },
         {
           "path": "tests/validate-agent-frontmatter-schema.py",
@@ -20297,5 +20297,5 @@
       "bytes": 3976
     }
   ],
-  "aggregate_sha256": "8f7d3981d3b95fad5b128cf22ea5a79d19ae643112576c87826398cedccf68ae"
+  "aggregate_sha256": "db04a05503ea1743455ffeaeaff906b4b1d62e7fae8bee39d41c73ee00b7a2ca"
 }

--- a/catalog/asset-integrity.json
+++ b/catalog/asset-integrity.json
@@ -16035,7 +16035,7 @@
     },
     {
       "tree": "tests",
-      "aggregate_sha256": "8ca46e860c605cabcb3df72cde9cdc12c8a81685552070453a5219a670c2618e",
+      "aggregate_sha256": "0be4350e5ff20943510e2315ba9b00cd5f2fd4e085abed542c8232958793f20f",
       "files": [
         {
           "path": "tests/AGENTS.md",
@@ -20144,8 +20144,8 @@
         },
         {
           "path": "tests/test-vfa-export-coverage.test.mjs",
-          "sha256": "7c162de47eecafc2443af85a1de86ef0c249df32618c5043ddb40e3d77e9873a",
-          "bytes": 8166
+          "sha256": "61afc0937744331a6ac237ac5d953f812c9e82cb8677d5b02e534ac009f03956",
+          "bytes": 21613
         },
         {
           "path": "tests/validate-agent-frontmatter-schema.py",
@@ -20297,5 +20297,5 @@
       "bytes": 3976
     }
   ],
-  "aggregate_sha256": "96e4f2e5edb7ccd037402a3cd92e571a40c597a2bcfd163b5763127f07dad1e5"
+  "aggregate_sha256": "b82f5063a09e8c9a53e7fbbf5669d81a4d25166a3c57d973747ab6aa92971fdf"
 }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "rules/",
     "mcp/",
     "templates/",
-    "assets/"
+    "assets/",
+    "tests/"
   ],
   "scripts": {
     "agents:export": "node scripts/export-marketplace-agents.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@raishin/vanguard-frontier-agentic",
-  "version": "1.9.0",
+  "version": "2.0.0",
   "description": "Cloud and zero-trust agentic workflow marketplace for skills, agents, rules, MCP references, and compliance-aware architecture.",
   "license": "Apache-2.0",
   "repository": {

--- a/plugins/vanguard-frontier-agentic/.codex-plugin/plugin.json
+++ b/plugins/vanguard-frontier-agentic/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vanguard-frontier-agentic",
-  "version": "1.9.0",
+  "version": "2.0.0",
   "description": "Curated marketplace for cloud and zero-trust AI workflows. 331 agents, 286 skills, and rules across AWS, Azure, OCI, GCP, Alibaba Cloud, Huawei Cloud, Kubernetes, and Terraform.",
   "author": {
     "name": "Raishin",

--- a/scripts/export-marketplace-agents.mjs
+++ b/scripts/export-marketplace-agents.mjs
@@ -4,6 +4,7 @@ import fs from "node:fs";
 import path from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
+import { parseArgs as utilParseArgs } from "node:util";
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 
@@ -153,83 +154,71 @@ Examples:
 }
 
 function parseArgs(argv) {
-  const args = {
-    repo: process.cwd(),
-    force: false,
-    list: false,
-    listRoles: false,
-    listProviders: false,
-    all: false,
-    dryRun: false,
-    agents: [],
-    platform: null,
-    role: null,
-    provider: null,
-    noSkills: false,
-  };
-
-  for (let i = 0; i < argv.length; i += 1) {
-    const arg = argv[i];
-    if (arg === "--help" || arg === "-h") usage(0);
-    if (arg === "--list") {
-      args.list = true;
-      continue;
-    }
-    if (arg === "--list-roles") {
-      args.listRoles = true;
-      continue;
-    }
-    if (arg === "--list-providers") {
-      args.listProviders = true;
-      continue;
-    }
-    if (arg === "--force") {
-      args.force = true;
-      continue;
-    }
-    if (arg === "--all") {
-      args.all = true;
-      continue;
-    }
-    if (arg === "--dry-run") {
-      args.dryRun = true;
-      continue;
-    }
-    if (arg === "--no-skills") {
-      args.noSkills = true;
-      continue;
-    }
-    if (arg === "--repo") {
-      args.repo = path.resolve(argv[++i] ?? "");
-      continue;
-    }
-    if (arg === "--platform") {
-      args.platform = argv[++i] ?? "";
-      continue;
-    }
-    if (arg === "--agents") {
-      args.agents = (argv[++i] ?? "")
-        .split(",")
-        .map((value) => value.trim())
-        .filter(Boolean);
-      continue;
-    }
-    if (arg === "--role") {
-      args.role = argv[++i] ?? "";
-      continue;
-    }
-    if (arg === "--provider") {
-      const provVal = (argv[++i] ?? "").trim();
-      if (!provVal) {
-        throw new Error("--provider requires a non-empty value. Run 'vfa-export-agents --list-providers' for valid options.");
-      }
-      args.provider = provVal;
-      continue;
-    }
+  // Use Node.js built-in util.parseArgs (stable since v18.3, available in v22):
+  // - handles --key=value inline form natively
+  // - returns null-prototype values object (prototype pollution safe)
+  // - strict mode throws a real Error for unknown flags (not a silent usage() exit)
+  let parsed;
+  try {
+    parsed = utilParseArgs({
+      args: argv,
+      strict: true,
+      allowPositionals: false,
+      options: {
+        help:             { type: "boolean", short: "h", default: false },
+        list:             { type: "boolean", default: false },
+        "list-roles":     { type: "boolean", default: false },
+        "list-providers": { type: "boolean", default: false },
+        force:            { type: "boolean", default: false },
+        all:              { type: "boolean", default: false },
+        "dry-run":        { type: "boolean", default: false },
+        "no-skills":      { type: "boolean", default: false },
+        platform:         { type: "string" },
+        role:             { type: "string" },
+        provider:         { type: "string" },
+        repo:             { type: "string" },
+        agents:           { type: "string" },
+      },
+    });
+  } catch (err) {
+    // Unknown or mistyped flags surface here with a clear message.
+    console.error(err.message);
     usage(1);
   }
 
-  return args;
+  const v = parsed.values;
+  if (v.help) usage(0);
+
+  // Validate --provider: empty string and whitespace-only are rejected.
+  // unicode zero-width chars (e.g. U+200B) pass trim() in some engines so
+  // the downstream format regex /^[a-z0-9][a-z0-9-]*$/ acts as a second gate.
+  const providerRaw = v.provider ?? null;
+  if (providerRaw !== null) {
+    const provVal = providerRaw.trim();
+    if (!provVal) {
+      throw new Error(
+        "--provider requires a non-empty value. " +
+        "Run 'vfa-export-agents --list-providers' for valid options."
+      );
+    }
+  }
+
+  return {
+    repo:          v.repo ? path.resolve(v.repo) : process.cwd(),
+    force:         v.force ?? false,
+    list:          v.list ?? false,
+    listRoles:     v["list-roles"] ?? false,
+    listProviders: v["list-providers"] ?? false,
+    all:           v.all ?? false,
+    dryRun:        v["dry-run"] ?? false,
+    noSkills:      v["no-skills"] ?? false,
+    platform:      v.platform ?? null,
+    role:          v.role ?? null,
+    provider:      providerRaw !== null ? providerRaw.trim() : null,
+    agents:        v.agents
+      ? v.agents.split(",").map((s) => s.trim()).filter(Boolean)
+      : [],
+  };
 }
 
 function walk(dir, matcher, results = []) {
@@ -283,6 +272,16 @@ function ensurePlatform(platform) {
 }
 
 function assertWithin(parent, child, label) {
+  // Lexical containment check — path.resolve() is purely string-based and does
+  // NOT follow symlinks. This guards against traversal strings (../../) and
+  // metadata.json with absolute paths outside the repo.
+  //
+  // Residual TOCTOU: if an adversary races to create a symlink at `child`
+  // AFTER this check but BEFORE the actual write, the symlink target would be
+  // written to. copyFile()/copySkillTree() use lstatSync on source AND
+  // destination to detect pre-existing symlinks, which closes the window for
+  // the common case. A fully TOCTOU-proof solution requires O_NOFOLLOW at the
+  // kernel level, which is not exposed by Node.js fs APIs.
   const resolvedParent = path.resolve(parent);
   const resolvedChild = path.resolve(child);
   const sep = path.sep;
@@ -389,8 +388,21 @@ function copyFile(source, destination, force) {
   if (sourceStat.isSymbolicLink()) {
     throw new Error(`Refusing to copy symbolic link as harness source: ${source}`);
   }
-  if (!force && fs.existsSync(destination)) {
-    throw new Error(`Refusing to overwrite existing file without --force: ${destination}`);
+  if (fs.existsSync(destination)) {
+    // Reject symlink destinations regardless of --force. A symlink at the
+    // destination would redirect the write outside the repo tree, bypassing
+    // assertWithin(). lstatSync does not follow the symlink — exactly what we
+    // want here to detect the link itself.
+    const destStat = fs.lstatSync(destination);
+    if (destStat.isSymbolicLink()) {
+      throw new Error(
+        `Refusing to write to symbolic link destination: ${destination}. ` +
+        `Remove the symlink and retry.`
+      );
+    }
+    if (!force) {
+      throw new Error(`Refusing to overwrite existing file without --force: ${destination}`);
+    }
   }
   fs.mkdirSync(path.dirname(destination), { recursive: true });
   fs.copyFileSync(source, destination);

--- a/scripts/export-marketplace-agents.mjs
+++ b/scripts/export-marketplace-agents.mjs
@@ -119,8 +119,13 @@ Selectors (mutually exclusive):
 
   --provider <p> --role <r>  → narrow the role to agents whose provider == p.
   --provider <p>             → standalone; equivalent to --all filtered to p.
-  --dry-run            Print the export plan as "export agent: <id> [provider=<p>]"
-                       lines without copying any files. Exit 0 on success.
+
+Options:
+  --repo <path>          Target repository path (default: cwd).
+  --force                Overwrite existing files without prompting.
+  --list-providers        List all providers with agent counts; then exit.
+  --dry-run              Print the export plan without writing files.
+  --no-skills            Skip companion skill bundling.
 
 Companion skills:
   By default, when --platform supports skill bundling (claude-code, copilot, gemini),
@@ -137,8 +142,8 @@ Examples:
   vfa-export-agents --platform claude-code --agents azure-cosmosdb-platform-operator-agent
   vfa-export-agents --platform claude-code --role cloud-security-engineer
   vfa-export-agents --platform claude-code --role cloud-security-engineer --provider azure
-  vfa-export-agents --platform claude-code --provider nvidia
-  vfa-export-agents --platform claude-code --provider nvidia --dry-run
+  vfa-export-agents --platform claude-code --provider aws
+  vfa-export-agents --platform claude-code --provider azure --dry-run
   vfa-export-agents --platform claude-code --all --no-skills --repo /path/to/project
   vfa-export-agents --platform kiro --agents azure-cosmosdb-platform-operator-agent --repo ../consumer-repo
   vfa-export-agents --platform copilot --all --repo /path/to/project --force
@@ -297,7 +302,7 @@ function loadSkills() {
       if (!skill.isDirectory()) continue;
       const skillDir = path.join(providerDir, skill.name);
       if (fs.existsSync(path.join(skillDir, "SKILL.md"))) {
-        byName.set(skill.name, skillDir);
+        byName.set(skill.name, { dir: skillDir, provider: provider.name });
       }
     }
   }
@@ -325,13 +330,22 @@ function copySkillTree(sourceDir, destDir, force) {
   }
 }
 
-function resolveCompanionSkills(selectedAgents, skillsByName, role, includeAll) {
+function resolveCompanionSkills(selectedAgents, skillsByName, role, includeAll, selectedProvider) {
   const skillNames = new Set();
   if (includeAll) {
-    for (const name of skillsByName.keys()) skillNames.add(name);
+    for (const [name, meta] of skillsByName.entries()) {
+      if (!selectedProvider || meta.provider === selectedProvider || meta.provider === "shared") {
+        skillNames.add(name);
+      }
+    }
   }
   if (role && Array.isArray(role.skills)) {
-    for (const id of role.skills) skillNames.add(id);
+    for (const id of role.skills) {
+      const meta = skillsByName.get(id);
+      if (!selectedProvider || !meta || meta.provider === selectedProvider || meta.provider === "shared") {
+        skillNames.add(id);
+      }
+    }
   }
   const orphans = [];
   for (const agent of selectedAgents) {
@@ -533,7 +547,28 @@ function main() {
     for (const agent of selectedAgents) {
       console.log(`export agent: ${agent.id} [provider=${agent.provider}]`);
     }
-    process.stderr.write(`[vfa] --dry-run: ${selectedAgents.length} agent(s) planned, no files written.\n`);
+    const skillsDestRoot = SKILLS_PLATFORM_CONFIG[platform];
+    let dryRunSkillCount = 0;
+    if (!args.noSkills && skillsDestRoot) {
+      const skillsByName = loadSkills();
+      const includeAllSkills = args.all && !args.provider;
+      const { skillNames } = resolveCompanionSkills(
+        selectedAgents,
+        skillsByName,
+        selectedRole,
+        includeAllSkills,
+        args.provider ?? null
+      );
+      for (const skillName of skillNames) {
+        console.log(`export skill: ${skillName}`);
+        dryRunSkillCount += 1;
+      }
+    }
+    process.stderr.write(
+      `[vfa] --dry-run: ${selectedAgents.length} agent(s)` +
+      (dryRunSkillCount > 0 ? `, ${dryRunSkillCount} skill(s)` : "") +
+      ` planned, no files written.\n`
+    );
     return;
   }
 
@@ -581,11 +616,12 @@ function main() {
       selectedAgents,
       skillsByName,
       selectedRole,
-      includeAllSkills
+      includeAllSkills,
+      args.provider ?? null
     );
     let bundled = 0;
     for (const skillName of skillNames) {
-      const sourceDir = skillsByName.get(skillName);
+      const sourceDir = skillsByName.get(skillName)?.dir;
       if (!sourceDir) continue;
       const destDir = path.join(args.repo, skillsDestRoot, skillName);
       assertWithin(args.repo, destDir, "write skill destination");

--- a/scripts/export-marketplace-agents.mjs
+++ b/scripts/export-marketplace-agents.mjs
@@ -219,7 +219,11 @@ function parseArgs(argv) {
       continue;
     }
     if (arg === "--provider") {
-      args.provider = argv[++i] ?? "";
+      const provVal = (argv[++i] ?? "").trim();
+      if (!provVal) {
+        throw new Error("--provider requires a non-empty value. Run 'vfa-export-agents --list-providers' for valid options.");
+      }
+      args.provider = provVal;
       continue;
     }
     usage(1);

--- a/scripts/export-marketplace-agents.mjs
+++ b/scripts/export-marketplace-agents.mjs
@@ -346,7 +346,11 @@ function resolveCompanionSkills(selectedAgents, skillsByName, role, includeAll, 
   if (role && Array.isArray(role.skills)) {
     for (const id of role.skills) {
       const meta = skillsByName.get(id);
-      if (!selectedProvider || !meta || meta.provider === selectedProvider || meta.provider === "shared") {
+      // Exclude skills not found on disk — do not promote undefined through the
+      // provider gate (the old `!meta` branch made dry-run output lie about what
+      // would actually be written, masking catalog rot).
+      if (!meta) continue;
+      if (!selectedProvider || meta.provider === selectedProvider || meta.provider === "shared") {
         skillNames.add(id);
       }
     }
@@ -356,7 +360,12 @@ function resolveCompanionSkills(selectedAgents, skillsByName, role, includeAll, 
     // Prefer explicit companion_skills if declared (even if empty — that means intentional no-pair)
     if (Array.isArray(agent.companion_skills)) {
       for (const skillId of agent.companion_skills) {
-        if (skillsByName.has(skillId)) skillNames.add(skillId);
+        const meta = skillsByName.get(skillId);
+        // Apply the same provider scope gate used for role.skills — prevents a
+        // cross-provider companion_skills declaration from leaking rival skills.
+        if (meta && (!selectedProvider || meta.provider === selectedProvider || meta.provider === "shared")) {
+          skillNames.add(skillId);
+        }
       }
       // companion_skills: [] is intentional no-pair — do NOT count as orphan
       continue;
@@ -365,7 +374,8 @@ function resolveCompanionSkills(selectedAgents, skillsByName, role, includeAll, 
     const skillName = agent.id.endsWith("-agent")
       ? agent.id.slice(0, -"-agent".length)
       : agent.id;
-    if (skillsByName.has(skillName)) {
+    const meta = skillsByName.get(skillName);
+    if (meta && (!selectedProvider || meta.provider === selectedProvider || meta.provider === "shared")) {
       skillNames.add(skillName);
     } else if (!role) {
       orphans.push(agent.id);

--- a/scripts/generate-changelog-counts.mjs
+++ b/scripts/generate-changelog-counts.mjs
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+/**
+ * Generate dynamic catalog counts for CHANGELOG.md and other versioning docs.
+ * Called by release-prepare.mjs to keep counts current across releases.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+// Count agents
+const agentDirs = fs.readdirSync(path.join(repoRoot, "agents"), { recursive: true });
+const agentCount = agentDirs.filter(f => String(f).endsWith("metadata.json")).length;
+
+// Count skills (on-disk SKILL.md files)
+const skillDirs = fs.readdirSync(path.join(repoRoot, "skills"), { recursive: true });
+const skillCount = skillDirs.filter(f => String(f).endsWith("SKILL.md")).length;
+
+// Count catalog providers (agents only, not skill-only dirs)
+const allProviders = new Set();
+for (const f of agentDirs) {
+  if (!String(f).endsWith("metadata.json")) continue;
+  const m = JSON.parse(fs.readFileSync(path.join(repoRoot, "agents", String(f)), "utf8"));
+  if (m.provider) allProviders.add(m.provider);
+}
+const providerCount = allProviders.size;
+
+// Count roles
+const roles = JSON.parse(fs.readFileSync(path.join(repoRoot, "catalog/install-roles.json"), "utf8"));
+const roleCount = Object.keys(roles.roles).length;
+
+console.log(`${agentCount} agents · ${skillCount} skills · ${providerCount} providers · ${roleCount} roles`);

--- a/scripts/release-prepare.mjs
+++ b/scripts/release-prepare.mjs
@@ -26,7 +26,7 @@
  * Idempotent: re-running on an already-synced tree is a no-op.
  */
 
-import { readFileSync, writeFileSync } from "node:fs";
+import { readFileSync, writeFileSync, readdirSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -104,6 +104,42 @@ function syncSecurityMd(nextVersion) {
   return true;
 }
 
+function syncChangelogCounts(nextVersion) {
+  // Update counts in CHANGELOG.md from the live catalog to prevent stale hardcoded values.
+  // Pattern: > _Provider-scoped exports... 334 agents · 335 skills · 26 providers · 16 roles_
+  const abs = join(REPO, "CHANGELOG.md");
+  let content = readFileSync(abs, "utf8");
+
+  // Count agents, skills, providers, roles from live catalog
+  const agentDirs = readdirSync(join(REPO, "agents"), { recursive: true });
+  const agentCount = agentDirs.filter(f => String(f).endsWith("metadata.json")).length;
+
+  const skillDirs = readdirSync(join(REPO, "skills"), { recursive: true });
+  const skillCount = skillDirs.filter(f => String(f).endsWith("SKILL.md")).length;
+
+  const allProviders = new Set();
+  for (const f of agentDirs) {
+    if (!String(f).endsWith("metadata.json")) continue;
+    const m = JSON.parse(readFileSync(join(REPO, "agents", String(f)), "utf8"));
+    if (m.provider) allProviders.add(m.provider);
+  }
+  const providerCount = allProviders.size;
+
+  const roles = JSON.parse(readFileSync(join(REPO, "catalog/install-roles.json"), "utf8"));
+  const roleCount = Object.keys(roles.roles).length;
+
+  // Replace counts in all version blurb lines
+  const versionRegex = /(\> _[^.]+\. )\d+ agents · \d+ skills · \d+ providers · \d+ roles/g;
+  const updated = content.replace(
+    versionRegex,
+    `$1${agentCount} agents · ${skillCount} skills · ${providerCount} providers · ${roleCount} roles`
+  );
+
+  if (updated === content) return false;
+  writeFileSync(abs, updated, "utf8");
+  return true;
+}
+
 function regenerate(cmd, args) {
   const result = spawnSync(cmd, args, { cwd: REPO, stdio: "inherit" });
   if (result.status !== 0) {
@@ -124,6 +160,10 @@ for (const rel of VERSION_PINNED_PLUGINS) {
 if (syncSecurityMd(NEXT_VERSION)) {
   console.log("[release-prepare] updated SECURITY.md");
   touched += 1;
+}
+
+if (syncChangelogCounts(NEXT_VERSION)) {
+  console.log("[release-prepare] updated CHANGELOG.md counts");
 }
 
 // Re-run the Claude Code + Cursor manifest generators so any other

--- a/scripts/release-prepare.mjs
+++ b/scripts/release-prepare.mjs
@@ -7,16 +7,21 @@
  * tarball. Synchronizes every published artifact whose content depends on
  * `package.json.version` or on file hashes that include `package.json`:
  *
- *   1. .claude-plugin/plugin.json         — version-parity (validate:plugin-manifest)
- *   2. .cursor-plugin/plugin.json         — version-parity (validate:multi-harness-marketplace)
+ *   1. .claude-plugin/plugin.json              — version-parity (validate:plugin-manifest)
+ *   2. .cursor-plugin/plugin.json              — version-parity (validate:multi-harness-marketplace)
  *   3. plugins/vanguard-frontier-agentic/.codex-plugin/plugin.json
- *                                         — version-parity (validate:codex-marketplace)
- *   4. catalog/asset-integrity.json       — includes package.json sha256
+ *                                              — version-parity (validate:codex-marketplace)
+ *   4. .github/plugin/marketplace.json         — Copilot marketplace version field
+ *   5. SECURITY.md                             — "current published version" + supported-version table
+ *   6. catalog/asset-integrity.json            — includes package.json sha256
  *
  * Without this step the released tarball would ship plugin manifests whose
  * version diverges from `package.json` (breaks every harness's version-parity
  * gate) and an asset-integrity manifest whose package.json hash no longer
  * matches the released tree (breaks downstream attestation verification).
+ *
+ * `package.json` is the single source of truth for the release version.
+ * No other file should hard-code a version string that this script can derive.
  *
  * Idempotent: re-running on an already-synced tree is a no-op.
  */
@@ -44,6 +49,8 @@ const VERSION_PINNED_PLUGINS = [
   ".claude-plugin/plugin.json",
   ".cursor-plugin/plugin.json",
   "plugins/vanguard-frontier-agentic/.codex-plugin/plugin.json",
+  // Copilot marketplace manifest — version field only; content is manually curated.
+  ".github/plugin/marketplace.json",
 ];
 
 function syncPluginVersion(relPath) {
@@ -54,6 +61,40 @@ function syncPluginVersion(relPath) {
   }
   data.version = NEXT_VERSION;
   writeFileSync(abs, JSON.stringify(data, null, 2) + "\n", "utf8");
+  return true;
+}
+
+// Sync the "current published version" banner and supported-version table in
+// SECURITY.md from package.json. Keeps the security policy credible without
+// requiring a manual edit on every release.
+function syncSecurityMd(nextVersion) {
+  const abs = join(REPO, "SECURITY.md");
+  let content = readFileSync(abs, "utf8");
+  const [major, minor] = nextVersion.split(".").map(Number);
+  const curr = `${major}.${minor}.x`;
+  const prev = `${major}.${Math.max(0, minor - 1)}.x`;
+  const floor = `${major}.${Math.max(0, minor - 1)}.0`;
+
+  const updated = content
+    .replace(
+      /current published version: \*\*[\d.]+\*\*/,
+      `current published version: **${nextVersion}**`
+    )
+    .replace(
+      /\| \d+\.\d+\.x\s+\| Yes — current minor \|[^\n]*/,
+      `| ${curr.padEnd(13)} | Yes — current minor |`
+    )
+    .replace(
+      /\| \d+\.\d+\.x\s+\| Yes — previous minor \|[^\n]*/,
+      `| ${prev.padEnd(13)} | Yes — previous minor |`
+    )
+    .replace(
+      /\| < \d+\.\d+\.\d+\s+\| No[^\n]*/,
+      `| < ${floor.padEnd(10)} | No                 |`
+    );
+
+  if (updated === content) return false;
+  writeFileSync(abs, updated, "utf8");
   return true;
 }
 
@@ -72,6 +113,11 @@ for (const rel of VERSION_PINNED_PLUGINS) {
     console.log(`[release-prepare] updated ${rel}`);
     touched += 1;
   }
+}
+
+if (syncSecurityMd(NEXT_VERSION)) {
+  console.log("[release-prepare] updated SECURITY.md");
+  touched += 1;
 }
 
 // Re-run the Claude Code + Cursor manifest generators so any other

--- a/scripts/release-prepare.mjs
+++ b/scripts/release-prepare.mjs
@@ -72,8 +72,14 @@ function syncSecurityMd(nextVersion) {
   let content = readFileSync(abs, "utf8");
   const [major, minor] = nextVersion.split(".").map(Number);
   const curr = `${major}.${minor}.x`;
-  const prev = `${major}.${Math.max(0, minor - 1)}.x`;
-  const floor = `${major}.${Math.max(0, minor - 1)}.0`;
+
+  // At a major-version boundary (X.0.0), the "previous minor" is the last
+  // minor of the previous major — which this script cannot know precisely.
+  // Use `(major-1).x` as a conservative label and `< X.0.0` as the floor.
+  // A human must verify the exact prior-major support window on X.0.0 releases.
+  const isMajorBump = minor === 0;
+  const prev = isMajorBump ? `${major - 1}.x` : `${major}.${minor - 1}.x`;
+  const floor = isMajorBump ? `${major}.0.0` : `${major}.${minor - 1}.0`;
 
   const updated = content
     .replace(
@@ -85,11 +91,11 @@ function syncSecurityMd(nextVersion) {
       `| ${curr.padEnd(13)} | Yes — current minor |`
     )
     .replace(
-      /\| \d+\.\d+\.x\s+\| Yes — previous minor \|[^\n]*/,
+      /\| [\d.x]+\s+\| Yes — previous minor \|[^\n]*/,
       `| ${prev.padEnd(13)} | Yes — previous minor |`
     )
     .replace(
-      /\| < \d+\.\d+\.\d+\s+\| No[^\n]*/,
+      /\| < [\d.]+\s+\| No[^\n]*/,
       `| < ${floor.padEnd(10)} | No                 |`
     );
 

--- a/tests/test-vfa-export-coverage.test.mjs
+++ b/tests/test-vfa-export-coverage.test.mjs
@@ -128,7 +128,8 @@ if (danglingRoleSkills.length === 0) {
 // ── B. CLI behaviour ─────────────────────────────────────────────────────────
 
 function run(args) {
-  const r = spawnSync(process.execPath, [exporter, ...args], { encoding: "utf8" });
+  const r = spawnSync(process.execPath, [exporter, ...args], { encoding: "utf8", timeout: 30000 });
+  if (r.signal === "SIGTERM") fail(`spawnSync timed out (30s) for: ${args.join(" ")}`);
   return { stdout: r.stdout ?? "", stderr: r.stderr ?? "", exitCode: r.status ?? 0 };
 }
 
@@ -209,13 +210,26 @@ if (nvidiaOrphans.length === 0) {
 
 // ── D. Provider skill-scope enforcement ──────────────────────────────────────
 //
-// Cross-provider prefixes that must never appear in a single-provider export.
-// "shared" is intentionally excluded from this list — shared skills are always
-// permitted regardless of the selected provider.
-const RIVAL_PREFIXES = {
-  aws:   ["azure-", "gcp-", "oci-", "alibaba-", "huawei-"],
-  azure: ["aws-",   "gcp-", "oci-", "alibaba-", "huawei-"],
-};
+// Build the rival-provider set from the ACTUAL on-disk skill catalog so new
+// providers are automatically covered without updating a hardcoded list.
+// This replaces the fragile 5-entry RIVAL_PREFIXES approach that missed 20 of
+// 26 providers (kubernetes, terraform, nvidia, ovhcloud, etc.).
+
+const skillsRoot = path.join(repoRoot, "skills");
+const skillProviderDirs = fs.readdirSync(skillsRoot, { withFileTypes: true })
+  .filter((d) => d.isDirectory())
+  .map((d) => d.name);
+
+// Map: skillName → providerDir (mirrors loadSkills() internal logic)
+const skillProviderByName = new Map();
+for (const prov of skillProviderDirs) {
+  const provDir = path.join(skillsRoot, prov);
+  for (const skill of fs.readdirSync(provDir, { withFileTypes: true })) {
+    if (skill.isDirectory() && fs.existsSync(path.join(provDir, skill.name, "SKILL.md"))) {
+      skillProviderByName.set(skill.name, prov);
+    }
+  }
+}
 
 function extractSkillNames(stdout) {
   return (stdout.match(/^export skill: .+$/gm) || [])
@@ -227,13 +241,22 @@ function extractAgentIds(stdout) {
     .map((l) => l.replace(/^export agent: /, "").replace(/ \[provider=[^\]]+\]$/, "").trim());
 }
 
+// Returns skills whose catalog provider does not match expectedProvider and is not "shared".
+function findLeakedSkills(skillNames, expectedProvider) {
+  return skillNames.filter((s) => {
+    const prov = skillProviderByName.get(s);
+    if (!prov) return false; // unknown/orphan skill — can't classify
+    return prov !== expectedProvider && prov !== "shared";
+  });
+}
+
 // D12: AWS-scoped role export — no rival-provider skills in dry-run output.
 {
   const r = run(["--platform", "claude-code", "--role", "cloud-security-engineer", "--provider", "aws", "--dry-run"]);
   const skills = extractSkillNames(r.stdout);
-  const leaked = skills.filter((s) => RIVAL_PREFIXES.aws.some((pfx) => s.startsWith(pfx)));
+  const leaked = findLeakedSkills(skills, "aws");
   if (r.exitCode === 0 && skills.length > 0 && leaked.length === 0) {
-    ok(`D12 aws-scoped role: ${skills.length} skill(s), 0 rival-provider skills leaked`);
+    ok(`D12 aws-scoped role: ${skills.length} skill(s), 0 non-AWS skills leaked (catalog-verified)`);
   } else {
     fail(`D12 ${leaked.length} non-AWS skill(s) leaked: ${leaked.join(", ")} | total=${skills.length} exit=${r.exitCode}`);
   }
@@ -243,9 +266,9 @@ function extractAgentIds(stdout) {
 {
   const r = run(["--platform", "claude-code", "--role", "cloud-security-engineer", "--provider", "azure", "--dry-run"]);
   const skills = extractSkillNames(r.stdout);
-  const leaked = skills.filter((s) => RIVAL_PREFIXES.azure.some((pfx) => s.startsWith(pfx)));
+  const leaked = findLeakedSkills(skills, "azure");
   if (r.exitCode === 0 && skills.length > 0 && leaked.length === 0) {
-    ok(`D13 azure-scoped role: ${skills.length} skill(s), 0 rival-provider skills leaked`);
+    ok(`D13 azure-scoped role: ${skills.length} skill(s), 0 non-Azure skills leaked (catalog-verified)`);
   } else {
     fail(`D13 ${leaked.length} non-Azure skill(s) leaked: ${leaked.join(", ")} | total=${skills.length} exit=${r.exitCode}`);
   }
@@ -255,11 +278,23 @@ function extractAgentIds(stdout) {
 {
   const r = run(["--platform", "claude-code", "--provider", "aws", "--all", "--dry-run"]);
   const skills = extractSkillNames(r.stdout);
-  const leaked = skills.filter((s) => RIVAL_PREFIXES.aws.some((pfx) => s.startsWith(pfx)));
+  const leaked = findLeakedSkills(skills, "aws");
   if (r.exitCode === 0 && leaked.length === 0) {
-    ok(`D14 --provider aws --all: ${skills.length} skill(s), 0 rival-provider skills leaked`);
+    ok(`D14 --provider aws --all: ${skills.length} skill(s), 0 non-AWS skills leaked (catalog-verified)`);
   } else {
     fail(`D14 ${leaked.length} rival skill(s) in standalone provider export: ${leaked.join(", ")}`);
+  }
+}
+
+// D15: --provider "" (empty string) is rejected, not silently treated as no-filter.
+// This is a security regression guard — empty string was falsy in JS and bypassed
+// all provider validation and filtering, exporting ALL providers' content.
+{
+  const r = run(["--platform", "claude-code", "--role", "cloud-security-engineer", "--provider", ""]);
+  if (r.exitCode !== 0) {
+    ok("D15 --provider \"\" is rejected with non-zero exit (falsy bypass guard)");
+  } else {
+    fail(`D15 --provider \"\" should be rejected but exited 0; exported ${(r.stdout.match(/^export agent:/gm)||[]).length} agents`);
   }
 }
 

--- a/tests/test-vfa-export-coverage.test.mjs
+++ b/tests/test-vfa-export-coverage.test.mjs
@@ -288,6 +288,67 @@ function findLeakedSkills(skillNames, expectedProvider) {
   }
 }
 
+// D14c: Full role×provider matrix — every valid (role, provider) combination exports zero
+// rival-provider skills. This is the most exhaustive scope guard in the suite: it exercises
+// the role.skills filter, the per-agent companion_skills filter, and the name-stripping fallback
+// across all combinations where the catalog actually has agents.
+//
+// Skill-only provider dirs (finops, velero, claude) have no catalog agents so they never
+// appear as selectedProvider — their skills being excluded from scoped exports is EXPECTED.
+// The test flags a skill as leaked only when its on-disk provider is a catalog provider
+// that differs from the selected one.
+{
+  // Load all roles from the catalog to drive the matrix — no hardcoded role list.
+  const installRoles = JSON.parse(
+    fs.readFileSync(path.join(repoRoot, "catalog", "install-roles.json"), "utf8")
+  ).roles;
+
+  // Load agent catalog to map agent id → provider
+  const agentProviderById = new Map();
+  const agentDirs = fs.readdirSync(path.join(repoRoot, "agents"), { recursive: true });
+  for (const f of agentDirs) {
+    if (!String(f).endsWith("metadata.json")) continue;
+    const raw = JSON.parse(fs.readFileSync(path.join(repoRoot, "agents", String(f)), "utf8"));
+    if (raw.id && raw.provider) agentProviderById.set(raw.id, raw.provider);
+  }
+
+  // For each role, derive which catalog providers have agents in it.
+  const combos = [];
+  for (const [roleId, role] of Object.entries(installRoles)) {
+    const roleProviders = [...new Set(
+      (role.agents || []).map((id) => agentProviderById.get(id)).filter(Boolean)
+    )];
+    for (const prov of roleProviders) {
+      combos.push({ roleId, prov });
+    }
+  }
+
+  let combosPassed = 0;
+  const combosFailed = [];
+
+  for (const { roleId, prov } of combos) {
+    const r = run(["--platform", "claude-code", "--role", roleId, "--provider", prov, "--dry-run"]);
+    if (r.exitCode !== 0) {
+      // Unexpected failure for a valid combo — treat as failure
+      combosFailed.push(`${roleId}+${prov}(exit=${r.exitCode})`);
+      continue;
+    }
+    const skills = extractSkillNames(r.stdout);
+    const leaked = findLeakedSkills(skills, prov);
+    if (leaked.length === 0) {
+      combosPassed++;
+    } else {
+      combosFailed.push(`${roleId}+${prov}(leaked:${leaked.join(",")})`);
+    }
+  }
+
+  if (combosFailed.length === 0) {
+    ok(`D14c role×provider matrix: ${combosPassed}/${combos.length} combinations clean, 0 skill leaks`);
+  } else {
+    fail(`D14c skill leakage in ${combosFailed.length}/${combos.length} combo(s):\n  ${combosFailed.join("\n  ")}`);
+  }
+}
+
 // D14b: ALL 26 providers — standalone --provider <p> --all exports zero rival skills.
 // D12/D13/D14 cover AWS and Azure explicitly. This loop covers every provider in the
 // catalog so new providers are automatically checked without updating a list.

--- a/tests/test-vfa-export-coverage.test.mjs
+++ b/tests/test-vfa-export-coverage.test.mjs
@@ -288,6 +288,32 @@ function findLeakedSkills(skillNames, expectedProvider) {
   }
 }
 
+// D14b: ALL 26 providers — standalone --provider <p> --all exports zero rival skills.
+// D12/D13/D14 cover AWS and Azure explicitly. This loop covers every provider in the
+// catalog so new providers are automatically checked without updating a list.
+// Providers with no skills (e.g. multi-cloud) trivially pass since leaked === 0.
+{
+  const r0 = run(["--list-providers"]);
+  const allProviders = r0.stdout.trim().split("\n").map((l) => l.split(/\s/)[0]).filter(Boolean);
+  let provPassed = 0;
+  const provFailed = [];
+  for (const prov of allProviders) {
+    const r = run(["--platform", "claude-code", "--provider", prov, "--all", "--dry-run"]);
+    const skills = extractSkillNames(r.stdout);
+    const leaked = findLeakedSkills(skills, prov);
+    if (r.exitCode === 0 && leaked.length === 0) {
+      provPassed++;
+    } else {
+      provFailed.push(`${prov}(leaked:${leaked.join(",")})`);
+    }
+  }
+  if (provFailed.length === 0) {
+    ok(`D14b all-provider scope sweep: ${provPassed}/${allProviders.length} providers clean, 0 skill leaks`);
+  } else {
+    fail(`D14b skill leakage detected in ${provFailed.length} provider(s): ${provFailed.join(" | ")}`);
+  }
+}
+
 // D15: --provider "" (empty string) is rejected with a provider-specific error message.
 // Regression guard — empty string was falsy in JS and bypassed all provider validation,
 // exporting ALL providers' content. Guard also checks error message so an unrelated

--- a/tests/test-vfa-export-coverage.test.mjs
+++ b/tests/test-vfa-export-coverage.test.mjs
@@ -274,27 +274,31 @@ function findLeakedSkills(skillNames, expectedProvider) {
   }
 }
 
-// D14: Standalone --provider aws --all — no rival-provider skills exported.
+// D14: Standalone --provider aws --all — skills ARE exported and no rival-provider skills leak.
+// Previously this assertion was vacuously true when skills.length === 0 (zero leaked from empty
+// set is always true). Now we require at least 1 skill to detect silent regression in skill resolution.
 {
   const r = run(["--platform", "claude-code", "--provider", "aws", "--all", "--dry-run"]);
   const skills = extractSkillNames(r.stdout);
   const leaked = findLeakedSkills(skills, "aws");
-  if (r.exitCode === 0 && leaked.length === 0) {
+  if (r.exitCode === 0 && skills.length > 0 && leaked.length === 0) {
     ok(`D14 --provider aws --all: ${skills.length} skill(s), 0 non-AWS skills leaked (catalog-verified)`);
   } else {
-    fail(`D14 ${leaked.length} rival skill(s) in standalone provider export: ${leaked.join(", ")}`);
+    fail(`D14 skills=${skills.length} (need >0), leaked=${leaked.length}: ${leaked.join(", ")} | exit=${r.exitCode}`);
   }
 }
 
-// D15: --provider "" (empty string) is rejected, not silently treated as no-filter.
-// This is a security regression guard — empty string was falsy in JS and bypassed
-// all provider validation and filtering, exporting ALL providers' content.
+// D15: --provider "" (empty string) is rejected with a provider-specific error message.
+// Regression guard — empty string was falsy in JS and bypassed all provider validation,
+// exporting ALL providers' content. Guard also checks error message so an unrelated
+// failure (e.g. missing role) can't produce a false pass.
 {
   const r = run(["--platform", "claude-code", "--role", "cloud-security-engineer", "--provider", ""]);
-  if (r.exitCode !== 0) {
-    ok("D15 --provider \"\" is rejected with non-zero exit (falsy bypass guard)");
+  const combinedOutput = r.stdout + r.stderr;
+  if (r.exitCode !== 0 && /provider/i.test(combinedOutput)) {
+    ok("D15 --provider \"\" is rejected with non-zero exit and 'provider' in error (falsy bypass guard)");
   } else {
-    fail(`D15 --provider \"\" should be rejected but exited 0; exported ${(r.stdout.match(/^export agent:/gm)||[]).length} agents`);
+    fail(`D15 --provider \"\" should be rejected with 'provider' in error; exit=${r.exitCode} hasProviderMsg=${/provider/i.test(combinedOutput)}`);
   }
 }
 

--- a/tests/test-vfa-export-coverage.test.mjs
+++ b/tests/test-vfa-export-coverage.test.mjs
@@ -518,6 +518,45 @@ function findLeakedSkills(skillNames, expectedProvider) {
   }
 }
 
+// G33: --provider=aws (equals-sign inline form) is accepted and works correctly.
+// Regression guard for util.parseArgs migration — hand-rolled parsers often
+// treat --key=value as an unknown flag and silently call usage(1).
+{
+  const r = run(["--platform", "claude-code", "--role", "cloud-security-engineer", "--provider=aws", "--dry-run"]);
+  const agentCount = (r.stdout.match(/^export agent:/gm) || []).length;
+  if (r.exitCode === 0 && agentCount > 0) {
+    ok(`G33 --provider=aws (equals-sign form) is accepted (${agentCount} agents)`);
+  } else {
+    fail(`G33 --provider=aws inline form rejected; exit=${r.exitCode} agents=${agentCount} stderr=${r.stderr.slice(0, 200)}`);
+  }
+}
+
+// G34: Unicode zero-width space in --provider is rejected by the format regex.
+// U+200B passes String.prototype.trim() in some V8 versions but is not in
+// [a-z0-9-], so the /^[a-z0-9][a-z0-9-]*$/ gate must catch it.
+// (Defense-in-depth: the empty-string guard runs first if trim() strips it.)
+{
+  const zwsp = "​";
+  const r = run(["--platform", "claude-code", "--role", "cloud-security-engineer", "--provider", zwsp]);
+  if (r.exitCode !== 0) {
+    ok("G34 --provider with Unicode zero-width space is rejected (format gate)");
+  } else {
+    fail(`G34 Unicode zero-width in --provider should be rejected; exit=${r.exitCode} agents exported=${(r.stdout.match(/^export agent:/gm)||[]).length}`);
+  }
+}
+
+// G35: Completely unknown flag exits non-zero with an error, not silent usage().
+// util.parseArgs strict mode must surface a real error message, not swallow unknowns.
+{
+  const r = run(["--platform", "claude-code", "--role", "cloud-security-engineer", "--not-a-real-flag"]);
+  const combinedOutput = r.stdout + r.stderr;
+  if (r.exitCode !== 0 && /unknown|not-a-real-flag/i.test(combinedOutput)) {
+    ok("G35 unknown flag exits non-zero with descriptive error");
+  } else {
+    fail(`G35 unknown flag should produce descriptive error; exit=${r.exitCode} output=${combinedOutput.slice(0, 200)}`);
+  }
+}
+
 // ── Summary ─────────────────────────────────────────────────────────────────
 
 if (failures > 0) {

--- a/tests/test-vfa-export-coverage.test.mjs
+++ b/tests/test-vfa-export-coverage.test.mjs
@@ -25,11 +25,41 @@
  *     10. nvidia-model-promotion-gatekeeper-agent is in at least one role.
  *     11. Every NVIDIA agent is in at least one role.
  *
+ *   D. Provider skill-scope enforcement (regression guard for P0 fix)
+ *     12. AWS-scoped role export: zero rival-provider skills in --dry-run output.
+ *     13. Azure-scoped role export: zero rival-provider skills in --dry-run output.
+ *     14. Standalone --provider aws --all: zero rival-provider skills.
+ *
+ *   E. Dry-run completeness
+ *     15. claude-code --dry-run emits both agent and skill lines.
+ *     16. --dry-run --no-skills omits skill lines.
+ *     17. cursor --dry-run emits agent lines but no skill lines (unsupported platform).
+ *     18. --dry-run stderr summary reports skill count on skill-capable platform.
+ *
+ *   F. Full CLI flag surface
+ *     19. --list exits 0 and prints all agents.
+ *     20. --list-roles exits 0 and prints all roles.
+ *     21. --list-providers exits 0 and includes 'aws'.
+ *     22. --agents <single-id> selects exactly that agent.
+ *     23. --agents <id1>,<id2> selects exactly those 2 agents.
+ *     24. --all selects every agent in the catalog.
+ *     25. --platform claude (alias) resolves to claude-code.
+ *     26. --no-skills writes agent file but no skills directory.
+ *     27. --force overwrites existing agent files without error.
+ *
+ *   G. Error / rejection cases
+ *     28. No args → usage text printed, non-zero exit.
+ *     29. Unknown --role → exit non-zero with 'role' in output.
+ *     30. Unknown --platform → exit non-zero with 'platform' in output.
+ *     31. Unknown --agents id → exit non-zero.
+ *     32. --platform with no selector → exit non-zero.
+ *
  * Run: node tests/test-vfa-export-coverage.test.mjs
  */
 
 import { spawnSync } from "node:child_process";
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -175,6 +205,278 @@ if (nvidiaOrphans.length === 0) {
   ok("C11 every NVIDIA agent present in at least one role");
 } else {
   fail(`C11 NVIDIA agents missing from every role: ${nvidiaOrphans.join(", ")}`);
+}
+
+// ── D. Provider skill-scope enforcement ──────────────────────────────────────
+//
+// Cross-provider prefixes that must never appear in a single-provider export.
+// "shared" is intentionally excluded from this list — shared skills are always
+// permitted regardless of the selected provider.
+const RIVAL_PREFIXES = {
+  aws:   ["azure-", "gcp-", "oci-", "alibaba-", "huawei-"],
+  azure: ["aws-",   "gcp-", "oci-", "alibaba-", "huawei-"],
+};
+
+function extractSkillNames(stdout) {
+  return (stdout.match(/^export skill: .+$/gm) || [])
+    .map((l) => l.replace("export skill: ", "").trim());
+}
+
+function extractAgentIds(stdout) {
+  return (stdout.match(/^export agent: .+$/gm) || [])
+    .map((l) => l.replace(/^export agent: /, "").replace(/ \[provider=[^\]]+\]$/, "").trim());
+}
+
+// D12: AWS-scoped role export — no rival-provider skills in dry-run output.
+{
+  const r = run(["--platform", "claude-code", "--role", "cloud-security-engineer", "--provider", "aws", "--dry-run"]);
+  const skills = extractSkillNames(r.stdout);
+  const leaked = skills.filter((s) => RIVAL_PREFIXES.aws.some((pfx) => s.startsWith(pfx)));
+  if (r.exitCode === 0 && skills.length > 0 && leaked.length === 0) {
+    ok(`D12 aws-scoped role: ${skills.length} skill(s), 0 rival-provider skills leaked`);
+  } else {
+    fail(`D12 ${leaked.length} non-AWS skill(s) leaked: ${leaked.join(", ")} | total=${skills.length} exit=${r.exitCode}`);
+  }
+}
+
+// D13: Azure-scoped role export — no rival-provider skills in dry-run output.
+{
+  const r = run(["--platform", "claude-code", "--role", "cloud-security-engineer", "--provider", "azure", "--dry-run"]);
+  const skills = extractSkillNames(r.stdout);
+  const leaked = skills.filter((s) => RIVAL_PREFIXES.azure.some((pfx) => s.startsWith(pfx)));
+  if (r.exitCode === 0 && skills.length > 0 && leaked.length === 0) {
+    ok(`D13 azure-scoped role: ${skills.length} skill(s), 0 rival-provider skills leaked`);
+  } else {
+    fail(`D13 ${leaked.length} non-Azure skill(s) leaked: ${leaked.join(", ")} | total=${skills.length} exit=${r.exitCode}`);
+  }
+}
+
+// D14: Standalone --provider aws --all — no rival-provider skills exported.
+{
+  const r = run(["--platform", "claude-code", "--provider", "aws", "--all", "--dry-run"]);
+  const skills = extractSkillNames(r.stdout);
+  const leaked = skills.filter((s) => RIVAL_PREFIXES.aws.some((pfx) => s.startsWith(pfx)));
+  if (r.exitCode === 0 && leaked.length === 0) {
+    ok(`D14 --provider aws --all: ${skills.length} skill(s), 0 rival-provider skills leaked`);
+  } else {
+    fail(`D14 ${leaked.length} rival skill(s) in standalone provider export: ${leaked.join(", ")}`);
+  }
+}
+
+// ── E. Dry-run completeness ───────────────────────────────────────────────────
+
+// E15: claude-code dry-run emits both agent and skill lines.
+{
+  const r = run(["--platform", "claude-code", "--role", "cloud-security-engineer", "--provider", "aws", "--dry-run"]);
+  const agentCount = (r.stdout.match(/^export agent:/gm) || []).length;
+  const skillCount = (r.stdout.match(/^export skill:/gm) || []).length;
+  if (r.exitCode === 0 && agentCount > 0 && skillCount > 0) {
+    ok(`E15 --dry-run on claude-code emits both agents (${agentCount}) and skills (${skillCount})`);
+  } else {
+    fail(`E15 --dry-run missing lines: agents=${agentCount} skills=${skillCount} exit=${r.exitCode}`);
+  }
+}
+
+// E16: --dry-run --no-skills emits agent lines but no skill lines.
+{
+  const r = run(["--platform", "claude-code", "--role", "cloud-security-engineer", "--provider", "aws", "--dry-run", "--no-skills"]);
+  const agentCount = (r.stdout.match(/^export agent:/gm) || []).length;
+  const skillCount = (r.stdout.match(/^export skill:/gm) || []).length;
+  if (r.exitCode === 0 && agentCount > 0 && skillCount === 0) {
+    ok(`E16 --dry-run --no-skills: ${agentCount} agent line(s), 0 skill lines`);
+  } else {
+    fail(`E16 expected 0 skill lines with --no-skills, got ${skillCount}; agents=${agentCount}`);
+  }
+}
+
+// E17: cursor (skill-unsupported) dry-run shows agent lines but no skill lines.
+{
+  const r = run(["--platform", "cursor", "--role", "cloud-security-engineer", "--provider", "aws", "--dry-run"]);
+  const agentCount = (r.stdout.match(/^export agent:/gm) || []).length;
+  const skillCount = (r.stdout.match(/^export skill:/gm) || []).length;
+  if (r.exitCode === 0 && agentCount > 0 && skillCount === 0) {
+    ok(`E17 cursor --dry-run: ${agentCount} agent line(s), 0 skill lines (skill-unsupported platform)`);
+  } else {
+    fail(`E17 cursor should emit 0 skill lines, got ${skillCount}; agents=${agentCount}`);
+  }
+}
+
+// E18: Dry-run stderr summary reports skill count on skill-capable platform.
+{
+  const r = run(["--platform", "claude-code", "--role", "cloud-security-engineer", "--provider", "aws", "--dry-run"]);
+  if (r.exitCode === 0 && /\d+ skill\(s\)/.test(r.stderr)) {
+    ok("E18 --dry-run stderr summary includes skill count");
+  } else {
+    fail(`E18 --dry-run stderr missing skill count; stderr: ${r.stderr.slice(0, 200)}`);
+  }
+}
+
+// ── F. Full CLI flag surface ──────────────────────────────────────────────────
+
+// F19: --list exits 0 and emits one line per agent.
+{
+  const r = run(["--list"]);
+  const lines = r.stdout.trim().split("\n").filter(Boolean);
+  if (r.exitCode === 0 && lines.length === agents.length) {
+    ok(`F19 --list exits 0 and prints all ${lines.length} agents`);
+  } else {
+    fail(`F19 --list: expected ${agents.length} lines, got ${lines.length}; exit=${r.exitCode}`);
+  }
+}
+
+// F20: --list-roles exits 0 and emits one line per role.
+{
+  const r = run(["--list-roles"]);
+  const roleCount = Object.keys(rolesDoc.roles).length;
+  const lines = r.stdout.trim().split("\n").filter(Boolean);
+  if (r.exitCode === 0 && lines.length === roleCount) {
+    ok(`F20 --list-roles exits 0 and prints all ${lines.length} roles`);
+  } else {
+    fail(`F20 --list-roles: expected ${roleCount} lines, got ${lines.length}; exit=${r.exitCode}`);
+  }
+}
+
+// F21: --list-providers exits 0 and includes 'aws'.
+{
+  const r = run(["--list-providers"]);
+  if (r.exitCode === 0 && r.stdout.includes("aws")) {
+    ok("F21 --list-providers exits 0 and includes 'aws'");
+  } else {
+    fail(`F21 --list-providers: exit=${r.exitCode} stdout=${r.stdout.slice(0, 100)}`);
+  }
+}
+
+// F22: --agents <single-id> selects exactly that agent.
+{
+  const targetId = "aws-iam-least-privilege-review-agent";
+  const r = run(["--platform", "claude-code", "--agents", targetId, "--dry-run"]);
+  const ids = extractAgentIds(r.stdout);
+  if (r.exitCode === 0 && ids.length === 1 && ids[0] === targetId) {
+    ok(`F22 --agents <single-id> selects exactly 1 agent`);
+  } else {
+    fail(`F22 expected [${targetId}], got [${ids.join(", ")}]; exit=${r.exitCode}`);
+  }
+}
+
+// F23: --agents <id1>,<id2> selects exactly those two agents.
+{
+  const id1 = "aws-iam-least-privilege-review-agent";
+  const id2 = "azure-rbac-review-agent";
+  const r = run(["--platform", "claude-code", "--agents", `${id1},${id2}`, "--dry-run"]);
+  const ids = new Set(extractAgentIds(r.stdout));
+  if (r.exitCode === 0 && ids.size === 2 && ids.has(id1) && ids.has(id2)) {
+    ok(`F23 --agents <id1>,<id2> selects exactly those 2 agents`);
+  } else {
+    fail(`F23 expected [${id1}, ${id2}], got [${[...ids].join(", ")}]; exit=${r.exitCode}`);
+  }
+}
+
+// F24: --all selects every agent in the catalog.
+{
+  const r = run(["--platform", "claude-code", "--all", "--dry-run"]);
+  const agentCount = (r.stdout.match(/^export agent:/gm) || []).length;
+  if (r.exitCode === 0 && agentCount === agents.length) {
+    ok(`F24 --all selects all ${agentCount} agents`);
+  } else {
+    fail(`F24 --all: expected ${agents.length} agents, got ${agentCount}; exit=${r.exitCode}`);
+  }
+}
+
+// F25: Platform alias --platform claude resolves to claude-code.
+{
+  const r = run(["--platform", "claude", "--role", "cloud-security-engineer", "--provider", "aws", "--dry-run"]);
+  const agentCount = (r.stdout.match(/^export agent:/gm) || []).length;
+  if (r.exitCode === 0 && agentCount > 0) {
+    ok(`F25 --platform claude alias resolves to claude-code (${agentCount} agents)`);
+  } else {
+    fail(`F25 --platform claude alias failed; exit=${r.exitCode} agents=${agentCount}`);
+  }
+}
+
+// F26: --no-skills writes agent file but skips skills directory (real write).
+{
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vfa-test-noskills-"));
+  try {
+    const r = run(["--platform", "claude-code", "--agents", "aws-iam-least-privilege-review-agent", "--repo", tmpDir, "--no-skills"]);
+    const agentsDir = path.join(tmpDir, ".claude", "agents");
+    const skillsDir = path.join(tmpDir, ".claude", "skills");
+    if (r.exitCode === 0 && fs.existsSync(agentsDir) && !fs.existsSync(skillsDir)) {
+      ok("F26 --no-skills writes agent file but skips .claude/skills directory");
+    } else {
+      fail(`F26 --no-skills: exit=${r.exitCode} agentsDir=${fs.existsSync(agentsDir)} skillsDir=${fs.existsSync(skillsDir)}`);
+    }
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+}
+
+// F27: --force overwrites existing agent files without error.
+{
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vfa-test-force-"));
+  try {
+    const args = ["--platform", "claude-code", "--agents", "aws-iam-least-privilege-review-agent", "--repo", tmpDir, "--no-skills"];
+    run(args); // first write
+    const r2 = run([...args, "--force"]); // overwrite with --force
+    if (r2.exitCode === 0) {
+      ok("F27 --force overwrites existing files without error");
+    } else {
+      fail(`F27 --force: exit=${r2.exitCode}\nstderr: ${r2.stderr.slice(0, 300)}`);
+    }
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+}
+
+// ── G. Error / rejection cases ────────────────────────────────────────────────
+
+// G28: No args → usage text printed to stderr, non-zero exit.
+{
+  const r = run([]);
+  if (r.exitCode !== 0 && /usage/i.test(r.stderr)) {
+    ok("G28 no args → usage text printed to stderr, non-zero exit");
+  } else {
+    fail(`G28 expected non-zero exit with usage in stderr; exit=${r.exitCode} hasUsage=${/usage/i.test(r.stderr)}`);
+  }
+}
+
+// G29: Unknown --role → exit non-zero with 'role' in output.
+{
+  const r = run(["--platform", "claude-code", "--role", "not-a-real-role-xyz"]);
+  if (r.exitCode !== 0 && /role/i.test(r.stderr + r.stdout)) {
+    ok("G29 unknown --role exits non-zero with 'role' in output");
+  } else {
+    fail(`G29 expected non-zero for unknown role; exit=${r.exitCode} stderr=${r.stderr.slice(0, 100)}`);
+  }
+}
+
+// G30: Unknown --platform → exit non-zero with 'platform' in output.
+{
+  const r = run(["--platform", "definitely-not-a-platform", "--role", "cloud-security-engineer"]);
+  if (r.exitCode !== 0 && /platform/i.test(r.stderr + r.stdout)) {
+    ok("G30 unknown --platform exits non-zero with 'platform' in output");
+  } else {
+    fail(`G30 expected non-zero for unknown platform; exit=${r.exitCode}`);
+  }
+}
+
+// G31: Unknown --agents id → exit non-zero.
+{
+  const r = run(["--platform", "claude-code", "--agents", "totally-not-a-real-agent-id-999"]);
+  if (r.exitCode !== 0) {
+    ok("G31 unknown --agents id exits non-zero");
+  } else {
+    fail(`G31 expected non-zero for unknown agent id; exit=${r.exitCode}`);
+  }
+}
+
+// G32: --platform with no selector → exit non-zero.
+{
+  const r = run(["--platform", "claude-code"]);
+  if (r.exitCode !== 0) {
+    ok("G32 --platform with no selector exits non-zero");
+  } else {
+    fail(`G32 expected non-zero when no selector given; exit=${r.exitCode}`);
+  }
 }
 
 // ── Summary ─────────────────────────────────────────────────────────────────

--- a/tests/test-vfa-export-coverage.test.mjs
+++ b/tests/test-vfa-export-coverage.test.mjs
@@ -375,6 +375,70 @@ function findLeakedSkills(skillNames, expectedProvider) {
   }
 }
 
+// D14d: All 323 invalid role×provider combinations are rejected with non-zero exit.
+// These are (role, provider) pairs where the catalog has NO agents from that provider
+// in that role. The CLI must fail fast with "No agents found" rather than silently
+// exporting 0 agents or crashing with an unhandled exception.
+//
+// This completes the matrix: D14c proves valid combos export correctly scoped skills;
+// D14d proves invalid combos are explicitly rejected, not silently degraded.
+{
+  // Build the valid-combo set from the catalog — same derivation as D14c.
+  const installRolesAll = JSON.parse(
+    fs.readFileSync(path.join(repoRoot, "catalog", "install-roles.json"), "utf8")
+  ).roles;
+  const agentProvByIdAll = new Map();
+  for (const f of fs.readdirSync(path.join(repoRoot, "agents"), { recursive: true })) {
+    if (!String(f).endsWith("metadata.json")) continue;
+    const raw = JSON.parse(fs.readFileSync(path.join(repoRoot, "agents", String(f)), "utf8"));
+    if (raw.id && raw.provider) agentProvByIdAll.set(raw.id, raw.provider);
+  }
+  const validComboSet = new Set();
+  for (const [roleId, role] of Object.entries(installRolesAll)) {
+    for (const id of role.agents || []) {
+      const prov = agentProvByIdAll.get(id);
+      if (prov) validComboSet.add(`${roleId}+${prov}`);
+    }
+  }
+
+  // Get all catalog providers (same source as --list-providers)
+  const allProvidersD14d = run(["--list-providers"]).stdout.trim()
+    .split("\n").map((l) => l.split(/\s/)[0]).filter(Boolean);
+
+  // Collect all invalid combos
+  const invalidCombos = [];
+  for (const roleId of Object.keys(installRolesAll)) {
+    for (const prov of allProvidersD14d) {
+      if (!validComboSet.has(`${roleId}+${prov}`)) {
+        invalidCombos.push({ roleId, prov });
+      }
+    }
+  }
+
+  let invalidPassed = 0;
+  const invalidFailed = [];
+
+  for (const { roleId, prov } of invalidCombos) {
+    const r = run(["--platform", "claude-code", "--role", roleId, "--provider", prov, "--dry-run"]);
+    const combinedOut = r.stdout + r.stderr;
+    if (r.exitCode !== 0 && /no agents found/i.test(combinedOut)) {
+      invalidPassed++;
+    } else if (r.exitCode === 0) {
+      // Silently exported 0 agents — the dangerous case; no error surfaced
+      invalidFailed.push(`${roleId}+${prov}(silently exited 0)`);
+    } else {
+      // Exited non-zero but without the expected "No agents found" message
+      invalidFailed.push(`${roleId}+${prov}(exit=${r.exitCode} but no 'No agents found' in output)`);
+    }
+  }
+
+  if (invalidFailed.length === 0) {
+    ok(`D14d invalid role×provider combos: ${invalidPassed}/${invalidCombos.length} correctly rejected with "No agents found"`);
+  } else {
+    fail(`D14d ${invalidFailed.length} invalid combo(s) not properly rejected:\n  ${invalidFailed.join("\n  ")}`);
+  }
+}
+
 // D15: --provider "" (empty string) is rejected with a provider-specific error message.
 // Regression guard — empty string was falsy in JS and bypassed all provider validation,
 // exporting ALL providers' content. Guard also checks error message so an unrelated


### PR DESCRIPTION
## v2.0.0 — Zero-Trust Scope Enforcement

> **MAJOR RELEASE — 4 breaking changes. See breaking changes section before merging.**

---

## ⚠️ Breaking Changes

### 1. `--provider <p>` now strictly scopes skills across all resolution paths
Previously only `role.skills` was provider-filtered. The `companion_skills` array and the name-stripping fallback were unscoped — an AWS agent could declare `companion_skills: ["azure-skill"]` and it would silently appear in an `--provider aws` export.

**All 3 skill resolution paths now enforce the provider gate.** Consumers relying on `--provider aws` to also receive cross-cloud role skills must drop `--provider` or use separate per-provider invocations.

### 2. `--provider ""` is now a hard error (exit 1)
Empty-string `--provider` previously normalised to `null` (falsy bypass), silently disabling all scope filtering. It now throws with a descriptive error before any catalog access. Automation scripts that passed `--provider ""` as a no-op will break.

### 3. Symlink destinations rejected unconditionally
`copyFile()` calls `lstatSync` on the destination before any write and throws if a symlink exists there. Applies even with `--force`. Workflows pre-creating symlinks at export destinations must remove them.

### 4. Unknown CLI flags produce a descriptive error, not generic usage output
Parser migrated to `util.parseArgs` (Node.js built-in, stable v22). Unknown flags exit 1 with the flag name in the error message. Scripts parsing stderr for legacy strings may need updating.

---

## Security fixes (all resolved)

| Severity | Finding | Status |
|----------|---------|--------|
| CRITICAL | `--provider ""` falsy bypass — all scope disabled | Fixed + D15 test |
| CRITICAL | per-agent `companion_skills` skipped provider filter entirely | Fixed + D14c matrix |
| HIGH | Rival-skill detection: 5 hardcoded prefixes vs 26 real providers | Catalog-driven scan |
| HIGH | GitHub Actions `@v4` mutable tags on both CI workflows | SHA-pinned to v6 |
| HIGH | CI skills-dir assertion was silent false-pass | Separate assertion step |
| MEDIUM | `!meta` promoted missing skills through scope gate | Excluded with `continue` |
| MEDIUM | `/tmp` hardcoded in both workflows (race/symlink) | `${{ runner.temp }}` throughout |
| MEDIUM | No `set -euo pipefail` in CI bash steps | Added to every step |
| MEDIUM | `ls *.tgz \| head -n1` non-deterministic (stale artifacts) | Asserts exactly 1 .tgz |
| LOW | `--provider=aws` equals-sign form silently rejected | `util.parseArgs` handles natively |
| LOW | Unicode zero-width in `--provider` not regression-tested | G34 test added |
| TOCTOU | Destination symlink could redirect write post-`assertWithin()` | `lstatSync` on dest + comment |

---

## Test coverage: 11 → 38 assertions

| Test | What it covers |
|------|---------------|
| D14c | 93/93 valid role×provider combinations: zero skill leakage across all combos |
| D14d | 323/323 invalid role×provider combinations: correctly rejected with "No agents found" |
| D14b | 26/26 providers in `--all` sweep: zero leaked skills |
| G33 | `--provider=aws` inline equals-sign form accepted |
| G34 | Unicode U+200B in `--provider` rejected by format regex |
| G35 | Unknown flag produces error with flag name in message |

The matrix is self-updating — new roles and providers added to the catalog are swept automatically.

---

## Version

`package.json` bumped `1.9.0 → 2.0.0`. All versioned artifacts synced via `release-prepare.mjs`:
- `.claude-plugin/plugin.json`, `.cursor-plugin/plugin.json`, `.codex-plugin/plugin.json`
- `.github/plugin/marketplace.json`
- `SECURITY.md` — major boundary: previous minor shown as `1.x`, floor as `< 2.0.0`

The commit footer `BREAKING CHANGE:` (×4) will cause semantic-release to produce a major version bump when this PR merges to master.

---

## Checklist

- [x] `node tests/test-vfa-export-coverage.test.mjs` — 38/38 pass
- [x] `npm run validate` — all 18 gates pass
- [ ] `packed-artifact-smoke` CI job runs clean
- [ ] `provider-scope-regression` CI job runs clean

https://claude.ai/code/session_01MU74RPDzmiUJiy765KKSZx
