### PR TITLE
ci(release): fix npm OIDC token exchange — correct package name escaping

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,7 +136,10 @@ jobs:
           PACKAGE_NAME: "@raishin/vanguard-frontier-agentic"
         run: |
           set -euo pipefail
-          ESCAPED_NAME=$(node -p "encodeURIComponent(process.env.PACKAGE_NAME)")
+          # npm uses npa.escapedName which only encodes '/' → '%2f' and
+          # preserves '@'. encodeURIComponent also encodes '@' → '%40'
+          # which causes "package not found" from the registry.
+          ESCAPED_NAME=$(node -p "process.env.PACKAGE_NAME.replace('/', '%2f')")
 
           AUDIENCE="npm:registry.npmjs.org"
           ID_TOKEN_URL="${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=${AUDIENCE}"


### PR DESCRIPTION
## Summary

Follows up on #34 (npm trusted publishing migration). Fixes two separate failures in the Release workflow:

1. **`EINVALIDNPMTOKEN`** — `@semantic-release/npm` v13 calls `npm whoami` during `verifyConditions` before `npm publish` fires, so the built-in OIDC exchange is too late. Fix: add a `Mint npm token via OIDC trusted publisher` step that does the exchange first and passes the real token as `NPM_TOKEN`.

2. **`OIDC token exchange error - package not found`** — `encodeURIComponent` encodes `@` → `%40`, but npm CLI's `npa.escapedName` only encodes `/` → `%2f` and preserves `@`. The registry lookup path `@raishin%2fvanguard-frontier-agentic` is correct; `%40raishin%2Fvanguard-frontier-agentic` is not. Fix: use `.replace('/', '%2f')` to match npm's escaping exactly.

## How the OIDC exchange works

```
1. Request GitHub OIDC ID token
   audience = npm:registry.npmjs.org
   curl $ACTIONS_ID_TOKEN_REQUEST_URL&audience=npm:registry.npmjs.org

2. Exchange at npm registry
   POST https://registry.npmjs.org/-/npm/v1/oidc/token/exchange/package/@raishin%2fvanguard-frontier-agentic
   Authorization: Bearer <id_token>
   → returns short-lived granular publish token

3. Pass as NPM_TOKEN to Release step (masked)
```

No long-lived secret stored in GitHub Secrets.

## Test plan

- [ ] Merge and confirm the Release workflow completes without `EINVALIDNPMTOKEN` or `package not found`
- [ ] Verify npm registry shows new version with provenance attached

https://claude.ai/code/session_01RhaZCGmpzmVNVvwGYhFYm9

---
_Generated by [Claude Code](https://claude.ai/code/session_01RhaZCGmpzmVNVvwGYhFYm9)_