### PR TITLE
ci(release): fix OIDC token exchange endpoint — use uppercase %2F in package name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,10 +136,9 @@ jobs:
           PACKAGE_NAME: "@raishin/vanguard-frontier-agentic"
         run: |
           set -uo pipefail
-          # npm uses npa.escapedName which only encodes '/' → '%2f' and
-          # preserves '@'. encodeURIComponent also encodes '@' → '%40'
-          # which causes "package not found" from the registry.
-          ESCAPED_NAME=$(node -p "process.env.PACKAGE_NAME.replace('/', '%2f')")
+          # npm uses npa.escapedName which encodes '/' → '%2F' (uppercase)
+          # and preserves '@'. We need uppercase %2F for the registry endpoint.
+          ESCAPED_NAME=$(node -p "process.env.PACKAGE_NAME.replace('/', '%2F')")
 
           AUDIENCE="npm:registry.npmjs.org"
           ID_TOKEN_URL="${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=${AUDIENCE}"


### PR DESCRIPTION
## Summary

Fixes the 404 error in the OIDC token exchange step revealed by the improved logging in PR #38.

**Root cause**: The npm registry endpoint requires uppercase `%2F` in the scoped package name, not lowercase `%2f`. The URL was:
```
https://registry.npmjs.org/-/npm/v1/oidc/token/exchange/package/@raishin%2fvanguard-frontier-agentic
```
Should be:
```
https://registry.npmjs.org/-/npm/v1/oidc/token/exchange/package/@raishin%2Fvanguard-frontier-agentic
```

**Fix**: Change `.replace('/', '%2f')` to `.replace('/', '%2F')` to match the registry's expectations.

## Test plan

- [ ] Merge and re-run Release workflow
- [ ] Confirm OIDC token exchange succeeds (no 404)
- [ ] Verify npm token is minted and passed to semantic-release
- [ ] Confirm Release step completes without `EINVALIDNPMTOKEN`

https://claude.ai/code/session_01RhaZCGmpzmVNVvwGYhFYm9

---
_Generated by [Claude Code](https://claude.ai/code/session_01RhaZCGmpzmVNVvwGYhFYm9)_