### PR TITLE
ci(release): complete npm OIDC trusted publishing — npmPublish:false + npm@latest + lessons doc

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,6 +141,9 @@ jobs:
           # plugin failures (auth errors, push errors, etc).
           npx semantic-release --debug $DRY_FLAG
 
+      - name: Publish to npm via OIDC trusted publisher
+        run: npm publish
+
       # After semantic-release publishes to npm, the working tree holds the
       # newly bumped version. `npm pack` here produces a tarball that is
       # byte-identical to the one already published to the npm registry

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,7 +142,13 @@ jobs:
           npx semantic-release --debug $DRY_FLAG
 
       - name: Publish to npm via OIDC trusted publisher
-        run: npm publish
+        run: |
+          POST_VERSION="$(node -p "require('./package.json').version")"
+          if [ "$POST_VERSION" = "$PRE_VERSION" ]; then
+            echo "No version bump detected; skipping npm publish."
+            exit 0
+          fi
+          npm publish --access public --provenance
 
       # After semantic-release publishes to npm, the working tree holds the
       # newly bumped version. `npm pack` here produces a tarball that is

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,6 +108,15 @@ jobs:
           python3 tests/validate-no-lifecycle-scripts.py
           python3 tests/validate-links.py --offline
 
+      # Upgrade npm to latest before any publish step.
+      # OIDC trusted publishing requires npm CLI >= 11.5.1.
+      # Node 22 ships an older bundled npm; upgrade here to guarantee support.
+      - name: Upgrade npm to latest
+        run: |
+          echo "Bundled npm version: $(npm -v)"
+          npm install -g npm@latest
+          echo "Updated npm version: $(npm -v)"
+
       - name: Install dependencies
         run: npm ci
 

--- a/.releaserc.js
+++ b/.releaserc.js
@@ -82,8 +82,10 @@ module.exports = {
         // OIDC trusted publishing: when ACTIONS_ID_TOKEN_REQUEST_URL is set
         // (GitHub Actions with id-token: write), npm CLI automatically performs
         // OIDC token exchange without requiring NPM_TOKEN.
-        // Setting pkgRoot to '.' tells semantic-release to look here for package.json.
-        // The publish step will rely on OIDC exchange, not token verification.
+        // Disable npm plugin's publish and verifyConditions steps (which require
+        // a token). We handle publishing separately via 'npm publish' in the
+        // workflow after semantic-release completes versioning.
+        npmPublish: false,
       },
     ],
     [

--- a/catalog/asset-integrity.json
+++ b/catalog/asset-integrity.json
@@ -23743,9 +23743,9 @@
     },
     {
       "path": ".releaserc.js",
-      "sha256": "c2e619c2f66e89f9d8300b025cf7ebb8033ec2febcf37044a44921fec36b3c8d",
-      "bytes": 4394
+      "sha256": "0a3ea162eba937464571497352998fa7219c27f9571256d94437be1affe1b868",
+      "bytes": 4478
     }
   ],
-  "aggregate_sha256": "9201c719e38cc9b57f927deee920df5c297e4182d4d46b2784f681101434d6e8"
+  "aggregate_sha256": "42cd8722fe2a061012d3964d3a5478b2bd5464bb9cd76e7812d8704e6b8d184a"
 }

--- a/docs/npm-oidc-trusted-publishing.md
+++ b/docs/npm-oidc-trusted-publishing.md
@@ -1,0 +1,150 @@
+# npm OIDC Trusted Publishing — Lessons Learned
+
+This document records the decisions, dead ends, and working pattern reached
+during the migration from a long-lived `NPM_TOKEN` secret to npm's OIDC
+trusted publishing for the `@raishin/vanguard-frontier-agentic` package.
+
+## What OIDC trusted publishing is
+
+npm trusted publishing creates a trust relationship between npmjs.com and a
+specific GitHub Actions workflow. When the workflow runs, the npm CLI exchanges
+a short-lived GitHub OIDC identity token for a granular publish token scoped to
+one package. No long-lived secret is stored in GitHub Secrets.
+
+Prerequisites (configured once on npmjs.com per package):
+
+- Owner, repository, workflow file name, and GitHub Actions environment name
+  must all match the registered trusted publisher entry.
+- For this repo: owner `raishin`, repo `vanguard-frontier-agentic`,
+  workflow `release.yml`, environment `npm-deployment-master`.
+
+## What did NOT work and why
+
+### Manual OIDC token exchange script
+
+Early attempts replicated npm's internal exchange manually via curl:
+
+```
+POST https://registry.npmjs.org/-/npm/v1/oidc/token/exchange/package/@raishin%2Fvanguard-frontier-agentic
+```
+
+This consistently returned HTTP 404. Root causes:
+
+1. The endpoint is npm's internal API, not a stable public contract.
+2. The package must already exist on the registry before the exchange works.
+3. URL encoding was tricky: `@` must be preserved and `/` must be uppercase
+   `%2F` — `encodeURIComponent` produces `%40` (wrong) and lowercase `%2f` also
+   fails.
+
+**Lesson:** do not replicate what npm CLI already does internally. The curl
+exchange approach is fragile, version-dependent, and unnecessary.
+
+### Placeholder NPM_TOKEN (`npm_oidc_placeholder`)
+
+Setting `NPM_TOKEN` to a dummy string (e.g. `"<npm-oidc-placeholder>"`) to satisfy `@semantic-release/npm`'s
+`verifyConditions` step caused `EINVALIDNPMTOKEN` because the registry validates
+the token on the `/-/whoami` call that `verifyConditions` makes before publish.
+
+**Lesson:** a fake token will always be rejected. Do not set NPM_TOKEN to a
+non-functional value.
+
+### `set -euo pipefail` in the exchange script
+
+Using `set -e` caused the shell to exit silently before the error message was
+printed when `curl` returned a non-zero status, making failures invisible.
+
+**Lesson:** use `set -uo pipefail` (without `-e`) and add explicit `|| { echo
+error; exit 1; }` after each command that must not fail silently.
+
+### `@semantic-release/npm` verifyConditions with OIDC
+
+`@semantic-release/npm`'s `verifyConditions` lifecycle step calls `npm whoami`
+(registry auth check) before the prepare/publish steps. With OIDC, no token
+exists at that point — the CLI only mints one during `npm publish`. This caused
+`EINVALIDNPMTOKEN` regardless of whether `NPM_TOKEN` was set or not.
+
+**Lesson:** set `npmPublish: false` in the `@semantic-release/npm` plugin config
+to skip both `verifyConditions` and the plugin's own `publish` step. Then run
+`npm publish` manually in a separate workflow step after semantic-release
+completes the version bump, changelog, and git tag.
+
+### npm CLI version too old
+
+Node 22 ships a bundled npm that may be below the v11.5.1 threshold required for
+OIDC trusted publishing to work natively. Running `npm publish` with an older CLI
+silently falls back to token auth, which then fails with no token present.
+
+**Lesson:** always run `npm install -g npm@latest` before any `npm publish` step
+in a release workflow. Reference: [azu/setup-npm-trusted-publish](https://github.com/azu/setup-npm-trusted-publish) (May 2026).
+
+## Working pattern
+
+Derived from npm docs, semantic-release docs, and azu/setup-npm-trusted-publish.
+
+### `.releaserc.js` — disable npm plugin publish
+
+```js
+["@semantic-release/npm", { npmPublish: false }],
+```
+
+This skips `verifyConditions` (token check) and the plugin's own publish step.
+semantic-release still handles the version bump in `package.json`.
+
+### `.github/workflows/release.yml` — key requirements
+
+```yaml
+jobs:
+  release:
+    environment: npm-deployment-master   # must match npmjs.com trusted publisher
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+      id-token: write        # required for OIDC
+      attestations: write
+
+    steps:
+      - uses: actions/setup-node@...
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"   # configures .npmrc
+
+      - name: Upgrade npm to latest
+        run: npm install -g npm@latest   # must be >= 11.5.1 for OIDC
+
+      # ... validate, npm ci, semantic-release ...
+
+      - name: Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # No NPM_TOKEN — OIDC handles auth during npm publish below
+        run: npx semantic-release --debug
+
+      - name: Publish to npm via OIDC trusted publisher
+        run: |
+          POST_VERSION="$(node -p "require('./package.json').version")"
+          if [ "$POST_VERSION" = "$PRE_VERSION" ]; then
+            echo "No version bump; skipping npm publish."
+            exit 0
+          fi
+          npm publish --access public --provenance
+```
+
+### Why this works
+
+- `registry-url` in `setup-node` writes an `.npmrc` pointing at the registry
+  without a token, which npm CLI replaces with the OIDC-minted token at publish
+  time.
+- `id-token: write` allows the runner to request a GitHub OIDC identity token.
+- The `environment: npm-deployment-master` claim is embedded in the identity
+  token and validated by npmjs.com against the registered trusted publisher.
+- `npm publish --provenance` attaches a Sigstore attestation linking the tarball
+  to the exact workflow run that produced it.
+- No `NPM_TOKEN` secret is stored anywhere.
+
+## References
+
+- [npm Trusted Publishers docs](https://docs.npmjs.com/trusted-publishers)
+- [semantic-release GitHub Actions recipe](https://semantic-release.gitbook.io/semantic-release/recipes/ci-configurations/github-actions)
+- [azu/setup-npm-trusted-publish](https://github.com/azu/setup-npm-trusted-publish)
+- npm CLI issue: [Allow publishing initial version with OIDC](https://github.com/npm/cli/issues/8544)


### PR DESCRIPTION
## Summary

Completes the npm OIDC trusted publishing migration started in #40. Three changes remain after that merge:

### 1. `npmPublish: false` in `.releaserc.js`
`@semantic-release/npm`'s `verifyConditions` calls `npm whoami` before publish. With OIDC there is no pre-existing token at that point — the CLI only mints one during `npm publish`. Setting `npmPublish: false` skips both `verifyConditions` and the plugin's own publish step. semantic-release still handles the version bump, changelog, and git tag.

### 2. Manual `npm publish` step in `release.yml`
After semantic-release completes, a dedicated step runs `npm publish --access public --provenance`. npm CLI performs the OIDC token exchange automatically here. The step is guarded: it exits early if no version bump was detected.

### 3. `npm install -g npm@latest` before publish
Node 22 ships a bundled npm that may be below v11.5.1 — the minimum required for OIDC trusted publishing. Discovered via [azu/setup-npm-trusted-publish](https://github.com/azu/setup-npm-trusted-publish) (May 2026). Without this upgrade, npm silently falls back to token auth and fails with no token present.

### 4. `docs/npm-oidc-trusted-publishing.md`
Lessons-learned document covering every dead end (manual curl exchange, placeholder token, old npm CLI, `verifyConditions` conflict) and the working pattern with references.

## Test plan

- [ ] Release workflow runs on merge to master
- [ ] `Upgrade npm to latest` step shows npm >= 11.5.1
- [ ] semantic-release completes without `EINVALIDNPMTOKEN`
- [ ] `Publish to npm via OIDC trusted publisher` step succeeds
- [ ] Package appears on npmjs.com with provenance attestation
- [ ] No `NPM_TOKEN` secret used anywhere in the run

---
_Generated by [Claude Code](https://claude.ai/code/session_01RhaZCGmpzmVNVvwGYhFYm9)_