### PR TITLE
ci(release): use npx npm@^11 publish — fix broken global npm upgrade on runners

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,15 +108,6 @@ jobs:
           python3 tests/validate-no-lifecycle-scripts.py
           python3 tests/validate-links.py --offline
 
-      # Upgrade npm to latest before any publish step.
-      # OIDC trusted publishing requires npm CLI >= 11.5.1.
-      # Node 22 ships an older bundled npm; upgrade here to guarantee support.
-      - name: Upgrade npm to latest
-        run: |
-          echo "Bundled npm version: $(npm -v)"
-          npm install -g npm@latest
-          echo "Updated npm version: $(npm -v)"
-
       - name: Install dependencies
         run: npm ci
 
@@ -157,7 +148,11 @@ jobs:
             echo "No version bump detected; skipping npm publish."
             exit 0
           fi
-          npm publish --access public --provenance
+          # Use npx to run npm@^11 directly — avoids the broken global
+          # `npm install -g npm@latest` on runners where the bundled npm
+          # (10.x) has a missing promise-retry dep in @npmcli/arborist.
+          # OIDC trusted publishing requires npm CLI >= 11.5.1.
+          npx --yes npm@^11 publish --access public --provenance
 
       # After semantic-release publishes to npm, the working tree holds the
       # newly bumped version. `npm pack` here produces a tarball that is

--- a/docs/npm-oidc-trusted-publishing.md
+++ b/docs/npm-oidc-trusted-publishing.md
@@ -74,8 +74,13 @@ Node 22 ships a bundled npm that may be below the v11.5.1 threshold required for
 OIDC trusted publishing to work natively. Running `npm publish` with an older CLI
 silently falls back to token auth, which then fails with no token present.
 
-**Lesson:** always run `npm install -g npm@latest` before any `npm publish` step
-in a release workflow. Reference: [azu/setup-npm-trusted-publish](https://github.com/azu/setup-npm-trusted-publish) (May 2026).
+**Lesson:** do not use `npm install -g npm@latest` to upgrade — on GitHub Actions
+runners the bundled npm 10.x has a broken `@npmcli/arborist` dependency
+(`MODULE_NOT_FOUND: promise-retry`) that causes the self-upgrade to fail. Instead,
+use `npx --yes npm@^11 publish` which downloads npm 11 on demand for the publish
+step without touching the global installation.
+
+Reference: [azu/setup-npm-trusted-publish](https://github.com/azu/setup-npm-trusted-publish) (May 2026).
 
 ## Working pattern
 
@@ -109,9 +114,6 @@ jobs:
           node-version: "22"
           registry-url: "https://registry.npmjs.org"   # configures .npmrc
 
-      - name: Upgrade npm to latest
-        run: npm install -g npm@latest   # must be >= 11.5.1 for OIDC
-
       # ... validate, npm ci, semantic-release ...
 
       - name: Release
@@ -127,7 +129,9 @@ jobs:
             echo "No version bump; skipping npm publish."
             exit 0
           fi
-          npm publish --access public --provenance
+          # npx npm@^11 avoids the broken global npm install on runners;
+          # downloads npm 11 on demand. OIDC requires npm >= 11.5.1.
+          npx --yes npm@^11 publish --access public --provenance
 ```
 
 ### Why this works


### PR DESCRIPTION
## What failed

The `Upgrade npm to latest` step in PR #41 crashed on the runner:

```
Bundled npm version: 10.9.7
npm error code MODULE_NOT_FOUND
npm error Cannot find module 'promise-retry'
npm error Require stack:
npm error - .../node_modules/@npmcli/arborist/lib/arborist/rebuild.js
```

npm 10.9.7 (bundled with Node 22 on the runner) has a broken `@npmcli/arborist` dependency that prevents it from upgrading itself with `npm install -g npm@latest`.

## Fix

Remove the global upgrade step entirely. Instead, run the publish command via:

```yaml
npx --yes npm@^11 publish --access public --provenance
```

`npx` downloads npm 11 on demand and uses it for the single publish invocation — no global install needed, no broken dep chain. OIDC trusted publishing requires npm >= 11.5.1; npm@^11 satisfies that.

## Also updated

`docs/npm-oidc-trusted-publishing.md` — lessons doc updated with this finding so future maintainers don't repeat the broken global upgrade approach.

## Test plan

- [ ] `Upgrade npm to latest` step is gone
- [ ] `Publish to npm via OIDC trusted publisher` uses `npx --yes npm@^11 publish`
- [ ] Release workflow completes without `MODULE_NOT_FOUND` error
- [ ] npm publish succeeds via OIDC

---
_Generated by [Claude Code](https://claude.ai/code/session_01RhaZCGmpzmVNVvwGYhFYm9)_