### PR TITLE
ci(release): upgrade to Node 24 — fix OIDC trusted publish ENEEDAUTH

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,12 @@ jobs:
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: "22"
+          # Node 24 ships with npm >= 11.5.1 which is required for OIDC trusted
+          # publishing to work natively during `npm publish`. Node 22 ships with
+          # npm 10.x whose OIDC support is incomplete: it reads the empty
+          # _authToken written by setup-node's .npmrc and fails with ENEEDAUTH
+          # instead of falling through to the OIDC exchange.
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
           package-manager-cache: false  # never cache in release builds
 
@@ -148,11 +153,15 @@ jobs:
             echo "No version bump detected; skipping npm publish."
             exit 0
           fi
-          # Use npx to run npm@^11 directly — avoids the broken global
-          # `npm install -g npm@latest` on runners where the bundled npm
-          # (10.x) has a missing promise-retry dep in @npmcli/arborist.
-          # OIDC trusted publishing requires npm CLI >= 11.5.1.
-          npx --yes npm@^11 publish --access public --provenance
+          echo "Publishing @raishin/vanguard-frontier-agentic@$POST_VERSION via OIDC trusted publisher"
+          echo "npm version: $(npm --version)"
+          # Node 24 ships npm >= 11.5.1 which handles the OIDC token exchange
+          # natively during `npm publish` when ACTIONS_ID_TOKEN_REQUEST_URL is
+          # set and the npmjs.com trusted publisher is registered. No NPM_TOKEN
+          # required. Prereq: trusted publisher configured at npmjs.com for
+          # owner=raishin repo=vanguard-frontier-agentic workflow=release.yml
+          # environment=npm-deployment-master.
+          npm publish --access public --provenance
 
       # After semantic-release publishes to npm, the working tree holds the
       # newly bumped version. `npm pack` here produces a tarball that is

--- a/catalog/asset-integrity.json
+++ b/catalog/asset-integrity.json
@@ -25563,7 +25563,7 @@
     },
     {
       "path": "package.json",
-      "sha256": "59c16bac9cd6963e3f9a509c36406d3d41d254fafc867e838b8a3020b4480bec",
+      "sha256": "17840e19f87b94a4fec79fccc56c3e0b6bd6c5c6223070a8326330b18d0166d1",
       "bytes": 5340
     },
     {
@@ -25572,5 +25572,5 @@
       "bytes": 4523
     }
   ],
-  "aggregate_sha256": "542981f3ac58e0ca8108fcd40d9a3e1e90cf51c9efc02f4beaff967996e7d311"
+  "aggregate_sha256": "33a970bc4ee890c6934612a2ad9b0bf2e3561cfead790950a42423fc5bb548ab"
 }


### PR DESCRIPTION
## Problem

The v2.4.0 release workflow created the GitHub Release and tag successfully but failed at the **"Publish to npm via OIDC trusted publisher"** step.

**Root cause:** Node 22 ships with npm 10.x whose OIDC trusted publishing support is incomplete. The `setup-node` action writes this into `~/.npmrc`:

```
//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}
```

When `NODE_AUTH_TOKEN` is not set in the publish step's environment, npm 10 attempts to authenticate with an empty token and returns `ENEEDAUTH` — it does **not** fall through to the OIDC exchange. The npmjs.com trusted publisher configuration was correct (all fields matched).

The previous workaround (`npx --yes npm@^11 publish`) downloads npm 11 on demand, but it still inherits the problematic `.npmrc` written by setup-node for Node 22 and exhibits the same failure.

## Fix

- Upgrade `setup-node` from `node-version: "22"` to `node-version: "24"`
- Node 24 ships with npm ≥ 11.5.1 natively
- Replace `npx --yes npm@^11 publish` with `npm publish` directly
- npm 11.5.1 correctly performs the OIDC token exchange during `npm publish` when `ACTIONS_ID_TOKEN_REQUEST_URL` is set and the npmjs.com trusted publisher is registered

This matches the exact pattern in the [npm trusted publishing docs](https://docs.npmjs.com/trusted-publishers).

## Evidence

- npmjs.com trusted publisher: ✅ owner=`raishin`, repo=`vanguard-frontier-agentic`, workflow=`release.yml`, environment=`npm-deployment-master`, `Allow npm publish` checked
- `package.json` `repository.url`: ✅ matches GitHub repo
- `id-token: write` permission: ✅ already in workflow
- `environment: npm-deployment-master`: ✅ already in workflow

Only the npm CLI version was wrong.

## Changes

| File | Change |
|---|---|
| `.github/workflows/release.yml` | `node-version: "22"` → `"24"`; `npx --yes npm@^11 publish` → `npm publish` with version log |

## Test plan

- [ ] Merge to master — semantic-release will detect no new `feat`/`fix` commits (this is a `ci:` commit) and skip creating a new release; the workflow exits cleanly with "no relevant changes"
- [ ] To verify the publish path: push a `fix:` or `feat:` commit after this merges and confirm the publish step succeeds

---
_Generated by [Claude Code](https://claude.ai/code/session_01A6Ki8QHhfHozRxMZ2dpyAr)_