### PR TITLE
ci(release): add republish dispatch input — recover v2.4.0 npm publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,12 @@ on:
         default: "false"
         type: choice
         options: ["false", "true"]
+      republish:
+        description: "Re-publish current package.json version to npm without a new semantic-release bump. Use when a GitHub Release was created but npm publish failed."
+        required: false
+        default: "false"
+        type: choice
+        options: ["false", "true"]
 
 # Top-level least-privilege baseline (Scorecard Token-Permissions).
 # Write scopes are granted only on the `release` job that needs them.
@@ -149,9 +155,15 @@ jobs:
       - name: Publish to npm via OIDC trusted publisher
         run: |
           POST_VERSION="$(node -p "require('./package.json').version")"
-          if [ "$POST_VERSION" = "$PRE_VERSION" ]; then
+          REPUBLISH="${{ github.event.inputs.republish }}"
+          if [ "$POST_VERSION" = "$PRE_VERSION" ] && [ "$REPUBLISH" != "true" ]; then
             echo "No version bump detected; skipping npm publish."
+            echo "To re-publish an existing GitHub Release that failed to reach npm,"
+            echo "trigger this workflow with republish=true."
             exit 0
+          fi
+          if [ "$REPUBLISH" = "true" ]; then
+            echo "Republish mode: publishing current version $POST_VERSION to npm."
           fi
           echo "Publishing @raishin/vanguard-frontier-agentic@$POST_VERSION via OIDC trusted publisher"
           echo "npm version: $(npm --version)"


### PR DESCRIPTION
## Problem

v2.4.0 GitHub Release exists but was never published to npm. The fix (Node 24 upgrade) landed in PR #44, but the release workflow's publish step was correctly skipped on that merge because `ci:` commits don't trigger a semantic-release version bump — `PRE_VERSION == POST_VERSION`.

semantic-release won't re-release the existing v2.4.0 tag, so there is no natural trigger to re-run the npm publish for that version.

## Fix

Adds a `republish` workflow dispatch input. When set to `true`, the publish step skips the version-bump guard and publishes the current `package.json` version directly to npm — a targeted recovery path.

```
Actions → Release → Run workflow → republish = true
```

## After merging

Trigger the release workflow with `republish=true` to publish v2.4.0 to npm. The Node 24 OIDC fix is already on master so the publish will succeed.

## Test plan

- [x] `npm run validate` passes
- [ ] Merge → Actions → Release → Run workflow → set `republish=true` → confirm v2.4.0 appears on npmjs.com

---
_Generated by [Claude Code](https://claude.ai/code/session_01A6Ki8QHhfHozRxMZ2dpyAr)_