### PR TITLE
fix(release): prevent npm publish when dry-run is enabled

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,6 +156,11 @@ jobs:
         run: |
           POST_VERSION="$(node -p "require('./package.json').version")"
           REPUBLISH="${{ github.event.inputs.republish }}"
+          DRY_RUN="${{ github.event.inputs.dry_run }}"
+          if [ "$DRY_RUN" = "true" ]; then
+            echo "Dry-run mode enabled; skipping npm publish."
+            exit 0
+          fi
           if [ "$POST_VERSION" = "$PRE_VERSION" ] && [ "$REPUBLISH" != "true" ]; then
             echo "No version bump detected; skipping npm publish."
             echo "To re-publish an existing GitHub Release that failed to reach npm,"


### PR DESCRIPTION
## Problem

When both `dry_run=true` and `republish=true` are set via workflow dispatch, the npm publish step would still execute. This violates the expected safety: dry-run mode should skip all state-changing operations.

## Fix

Add an explicit check at the start of the publish step to skip npm publish whenever `dry_run=true`, regardless of other input flags.

```bash
if [ "$DRY_RUN" = "true" ]; then
  echo "Dry-run mode enabled; skipping npm publish."
  exit 0
fi
```

This ensures that dry-run mode is unconditionally safe and prevents conflicting inputs from causing unintended registry operations.

## Test plan

- [x] `npm run validate` passes
- [ ] Test with `dry_run=true` and `republish=true` — confirm no npm publish occurs
- [ ] Test with `dry_run=false` and `republish=true` — confirm npm publish proceeds

---
_Generated by [Claude Code](https://claude.ai/code/session_01A6Ki8QHhfHozRxMZ2dpyAr)_