### PR TITLE
ci(release): add OIDC publish diagnostics and actionable error message

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,15 +170,27 @@ jobs:
           if [ "$REPUBLISH" = "true" ]; then
             echo "Republish mode: publishing current version $POST_VERSION to npm."
           fi
-          echo "Publishing @raishin/vanguard-frontier-agentic@$POST_VERSION via OIDC trusted publisher"
+
+          echo "::group::OIDC publish diagnostics"
+          echo "Package: @raishin/vanguard-frontier-agentic@$POST_VERSION"
           echo "npm version: $(npm --version)"
+          echo "OIDC token available: $([ -n "$ACTIONS_ID_TOKEN_REQUEST_URL" ] && echo yes || echo 'NO — id-token:write may be missing')"
+          echo "registry-url .npmrc:"
+          cat ~/.npmrc 2>/dev/null || echo "(no .npmrc found)"
+          echo "::endgroup::"
+
           # Node 24 ships npm >= 11.5.1 which handles the OIDC token exchange
           # natively during `npm publish` when ACTIONS_ID_TOKEN_REQUEST_URL is
           # set and the npmjs.com trusted publisher is registered. No NPM_TOKEN
           # required. Prereq: trusted publisher configured at npmjs.com for
           # owner=raishin repo=vanguard-frontier-agentic workflow=release.yml
           # environment=npm-deployment-master.
-          npm publish --access public --provenance
+          if ! npm publish --access public --provenance; then
+            echo "::error::npm publish failed. Confirm npmjs.com trusted publisher is configured:" \
+              "owner=raishin repo=vanguard-frontier-agentic workflow=release.yml environment=npm-deployment-master." \
+              "See docs/npm-oidc-trusted-publishing.md"
+            exit 1
+          fi
 
       # After semantic-release publishes to npm, the working tree holds the
       # newly bumped version. `npm pack` here produces a tarball that is

--- a/catalog/asset-integrity.json
+++ b/catalog/asset-integrity.json
@@ -25563,7 +25563,7 @@
     },
     {
       "path": "package.json",
-      "sha256": "17840e19f87b94a4fec79fccc56c3e0b6bd6c5c6223070a8326330b18d0166d1",
+      "sha256": "84e1836bfae08bcd4c12f5e372ae825987c635b52f6b627059be61e49273ac9a",
       "bytes": 5340
     },
     {
@@ -25572,5 +25572,5 @@
       "bytes": 4523
     }
   ],
-  "aggregate_sha256": "f78a9772cd969639c4069b337cc17446862b02437d3147d815dd57c4975bd63e"
+  "aggregate_sha256": "8b09e5394e7e8e8bdf755993831829d43dac4df40255bd40fd5bb4bef9426be4"
 }


### PR DESCRIPTION
## Summary

- Adds an `::group::OIDC publish diagnostics` block to the publish step that surfaces npm version, OIDC token availability, and the `.npmrc` registry entry — making root-cause analysis faster when a publish fails
- Wraps `npm publish` in an explicit error handler that prints a clear actionable message pointing to the npmjs.com trusted publisher setup (owner/repo/workflow/environment)
- Rebased onto current master, incorporating the Node 24 upgrade, `republish` input, and dry-run safety guard from PRs #44–#46

## Test plan

- [x] `npm run validate` passes locally
- [ ] Verify diagnostics group appears in Actions log on next release run

https://claude.ai/code/session_01A6Ki8QHhfHozRxMZ2dpyAr

---
_Generated by [Claude Code](https://claude.ai/code/session_01A6Ki8QHhfHozRxMZ2dpyAr)_