### PR TITLE
fix: use npx npm@^11.5.1 for OIDC trusted publishing

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vanguard-frontier-agentic",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "Cloud and zero-trust agentic workflow marketplace for skills, agents, rules, MCP references, and compliance-aware architecture.",
   "author": {
     "name": "Raishin",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vanguard-frontier-agentic",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "Cloud and zero-trust agentic workflow marketplace for skills, agents, rules, MCP references, and compliance-aware architecture.",
   "author": {
     "name": "Raishin",

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,11 +64,9 @@ jobs:
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          # Node 24 ships with npm >= 11.5.1 which is required for OIDC trusted
-          # publishing to work natively during `npm publish`. Node 22 ships with
-          # npm 10.x whose OIDC support is incomplete: it reads the empty
-          # _authToken written by setup-node's .npmrc and fails with ENEEDAUTH
-          # instead of falling through to the OIDC exchange.
+          # Node 24 bundles npm 10.x. npm >= 11.5.1 is required for native
+          # OIDC trusted-publisher support; the publish step uses
+          # `npx npm@^11.5.1 publish` to avoid a global install.
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
           package-manager-cache: false  # never cache in release builds
@@ -92,6 +90,7 @@ jobs:
         run: |
           echo "::group::Auth method"
           echo "Publishing via: npm trusted publisher (OIDC — no long-lived token)"
+          echo "npm version: $(npm --version)"
           echo "GITHUB_TOKEN scopes (probe): contents=write expected for this job"
           echo "id-token:write granted: true (required for OIDC exchange)"
           echo "::endgroup::"
@@ -173,19 +172,21 @@ jobs:
 
           echo "::group::OIDC publish diagnostics"
           echo "Package: @raishin/vanguard-frontier-agentic@$POST_VERSION"
-          echo "npm version: $(npm --version)"
+          echo "Bundled npm version: $(npm --version)"
           echo "OIDC token available: $([ -n "$ACTIONS_ID_TOKEN_REQUEST_URL" ] && echo yes || echo 'NO — id-token:write may be missing')"
           echo "registry-url .npmrc:"
           cat ~/.npmrc 2>/dev/null || echo "(no .npmrc found)"
           echo "::endgroup::"
 
-          # Node 24 ships npm >= 11.5.1 which handles the OIDC token exchange
-          # natively during `npm publish` when ACTIONS_ID_TOKEN_REQUEST_URL is
-          # set and the npmjs.com trusted publisher is registered. No NPM_TOKEN
-          # required. Prereq: trusted publisher configured at npmjs.com for
-          # owner=raishin repo=vanguard-frontier-agentic workflow=release.yml
+          # Use npx to run npm >= 11.5.1 for the publish. Node 24 bundles npm
+          # 10.x which lacks native OIDC trusted-publisher support; running the
+          # bundled npm falls back to the empty _authToken written by setup-node
+          # and the registry PUT returns 404. npx npm@^11.5.1 downloads the
+          # required version on first use without a global install. Prereq:
+          # trusted publisher configured on npmjs.com for owner=raishin
+          # repo=vanguard-frontier-agentic workflow=release.yml
           # environment=npm-deployment-master.
-          if ! npm publish --access public --provenance; then
+          if ! npx --yes npm@^11.5.1 publish --access public --provenance; then
             echo "::error::npm publish failed. Confirm npmjs.com trusted publisher is configured:" \
               "owner=raishin repo=vanguard-frontier-agentic workflow=release.yml environment=npm-deployment-master." \
               "See docs/npm-oidc-trusted-publishing.md"

--- a/catalog/asset-integrity.json
+++ b/catalog/asset-integrity.json
@@ -20296,7 +20296,7 @@
     },
     {
       "tree": ".claude-plugin",
-      "aggregate_sha256": "6304d5642cb4f6ab8f077cb0a64247e0ce97111c058a305e4eb31103cff34fdf",
+      "aggregate_sha256": "4960b24cf24bf203f3c9b484d59ead6acaae6d0be315e45f86ae9529c03b2151",
       "files": [
         {
           "path": ".claude-plugin/README.md",
@@ -20310,14 +20310,14 @@
         },
         {
           "path": ".claude-plugin/plugin.json",
-          "sha256": "07732ba9450e36f2ba00946c2e76e03848d421375be85656a0d7efe3603547a9",
+          "sha256": "145bcb565425ea31820539329142e433547d75ef09ce097bf5b8a8c0ba1b9f53",
           "bytes": 39327
         }
       ]
     },
     {
       "tree": ".cursor-plugin",
-      "aggregate_sha256": "372d7ecdae6dd156c45725537c3c2d42cc8d4434e7ada154e51176f8c7c95077",
+      "aggregate_sha256": "b1a7074f138f0f6dca908826d52caff08cf4d6e92adfcb09f7d9297fc405d929",
       "files": [
         {
           "path": ".cursor-plugin/README.md",
@@ -20326,7 +20326,7 @@
         },
         {
           "path": ".cursor-plugin/plugin.json",
-          "sha256": "8a0529005061265fc800a0da8622421ecc7e84fe299f72e92acf773dd02fe87d",
+          "sha256": "84bfe3349b3dd23b1fe4ab95ce69fa9a8dea6c408c120d770d7721bb03e2bd6d",
           "bytes": 37173
         }
       ]
@@ -25572,5 +25572,5 @@
       "bytes": 4523
     }
   ],
-  "aggregate_sha256": "8b09e5394e7e8e8bdf755993831829d43dac4df40255bd40fd5bb4bef9426be4"
+  "aggregate_sha256": "4025feef6cf70580df4cfc1cb67b3f022999210367abd82b8344382c1ea705b3"
 }


### PR DESCRIPTION
## Summary

- Node 24 bundles npm 10.x, which lacks native OIDC token exchange support for npm trusted publishing
- Running `npm publish` with the bundled version falls back to the empty `_authToken` written by `setup-node`, causing the registry PUT to return 404
- Switch to `npx --yes npm@^11.5.1 publish --access public --provenance` so npm >= 11.5.1 is used without requiring a global install
- Update the `setup-node` comment to accurately reflect the npm version situation
- Surface the bundled npm version in the OIDC publish diagnostics group

## Root Cause

The release workflow previously stated _"Node 24 ships with npm >= 11.5.1"_ — this is incorrect. Node 24 bundles npm 10.9.x. npm's native OIDC trusted-publisher token exchange was introduced in npm 11.5.1. Without it, `npm publish` falls back to the `.npmrc` `_authToken` (empty when no `NPM_TOKEN` secret is set), and npmjs.com returns `E404` on the PUT.

The Sigstore provenance step succeeded in the failing run because it uses a separate OIDC audience (`sigstore`), confirming the token itself was valid — only the npm OIDC exchange was broken.

## Test plan

- [ ] Trigger the release workflow on master (or via `workflow_dispatch`) and confirm the "Publish to npm via OIDC trusted publisher" step completes without E404
- [ ] Verify `npx --yes npm@^11.5.1` downloads npm 11.x and surfaces it in the diagnostics group
- [ ] Confirm the published version appears on npmjs.com

---
_Generated by [Claude Code](https://claude.ai/code/session_01A6Ki8QHhfHozRxMZ2dpyAr)_