### PR TITLE
improve: pre-cache npm@latest for OIDC publish reliability

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vanguard-frontier-agentic",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "Cloud and zero-trust agentic workflow marketplace for skills, agents, rules, MCP references, and compliance-aware architecture.",
   "author": {
     "name": "Raishin",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vanguard-frontier-agentic",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "Cloud and zero-trust agentic workflow marketplace for skills, agents, rules, MCP references, and compliance-aware architecture.",
   "author": {
     "name": "Raishin",

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,11 +65,17 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           # Node 24 bundles npm 10.x. npm >= 11.5.1 is required for native
-          # OIDC trusted-publisher support; the publish step uses
-          # `npx npm@^11.5.1 publish` to avoid a global install.
+          # OIDC trusted-publisher token exchange. setup-node's registry-url
+          # configures .npmrc with the npm registry.
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
-          package-manager-cache: false  # never cache in release builds
+          package-manager-cache: false
+
+      # Pre-download npm@latest before the publish step so it's cached and ready.
+      # This ensures GitHub Actions' npx can use it without network delays
+      # during the publish attempt.
+      - name: Pre-cache npm@latest for OIDC publish
+        run: npx --yes npm@latest --version 2>&1 | head -1
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
@@ -173,20 +179,20 @@ jobs:
           echo "::group::OIDC publish diagnostics"
           echo "Package: @raishin/vanguard-frontier-agentic@$POST_VERSION"
           echo "Bundled npm version: $(npm --version)"
+          echo "npx cached npm version: $(npx npm --version 2>/dev/null || echo 'not yet cached')"
           echo "OIDC token available: $([ -n "$ACTIONS_ID_TOKEN_REQUEST_URL" ] && echo yes || echo 'NO — id-token:write may be missing')"
           echo "registry-url .npmrc:"
           cat ~/.npmrc 2>/dev/null || echo "(no .npmrc found)"
           echo "::endgroup::"
 
-          # Use npx to run npm >= 11.5.1 for the publish. Node 24 bundles npm
-          # 10.x which lacks native OIDC trusted-publisher support; running the
-          # bundled npm falls back to the empty _authToken written by setup-node
-          # and the registry PUT returns 404. npx npm@^11.5.1 downloads the
-          # required version on first use without a global install. Prereq:
-          # trusted publisher configured on npmjs.com for owner=raishin
-          # repo=vanguard-frontier-agentic workflow=release.yml
-          # environment=npm-deployment-master.
-          if ! npx --yes npm@^11.5.1 publish --access public --provenance; then
+          # Use npx npm@latest to run the latest npm (11.x+) which has native
+          # OIDC trusted-publisher support. Node 24 bundles npm 10.x which lacks
+          # this support and falls back to the empty _authToken, causing 404.
+          # npm@latest is pre-cached by the "Pre-cache npm@latest for OIDC publish"
+          # step to avoid download delays. Prereq: trusted publisher configured
+          # on npmjs.com for owner=raishin repo=vanguard-frontier-agentic
+          # workflow=release.yml environment=npm-deployment-master.
+          if ! npx npm@latest publish --access public --provenance; then
             echo "::error::npm publish failed. Confirm npmjs.com trusted publisher is configured:" \
               "owner=raishin repo=vanguard-frontier-agentic workflow=release.yml environment=npm-deployment-master." \
               "See docs/npm-oidc-trusted-publishing.md"

--- a/catalog/asset-integrity.json
+++ b/catalog/asset-integrity.json
@@ -20296,7 +20296,7 @@
     },
     {
       "tree": ".claude-plugin",
-      "aggregate_sha256": "8cbb7f4fca052f1916e0a4c3d19f7f34e2124a78c3d85c70af52692063bb32c5",
+      "aggregate_sha256": "f36a890ce3361ca8e2d005ab8411fb86676e5167e7854924189c67fb61b9cbda",
       "files": [
         {
           "path": ".claude-plugin/README.md",
@@ -20310,14 +20310,14 @@
         },
         {
           "path": ".claude-plugin/plugin.json",
-          "sha256": "145bcb565425ea31820539329142e433547d75ef09ce097bf5b8a8c0ba1b9f53",
+          "sha256": "8d564676c22a4d825ffe459af1687b9bc611c1e10b6f596aeae0030c1d764823",
           "bytes": 39327
         }
       ]
     },
     {
       "tree": ".cursor-plugin",
-      "aggregate_sha256": "b1a7074f138f0f6dca908826d52caff08cf4d6e92adfcb09f7d9297fc405d929",
+      "aggregate_sha256": "86c2a1db182ae16a6c2b63a0f3f2ddac549c02738bfca13469ee20ebbd4b6b27",
       "files": [
         {
           "path": ".cursor-plugin/README.md",
@@ -20326,7 +20326,7 @@
         },
         {
           "path": ".cursor-plugin/plugin.json",
-          "sha256": "84bfe3349b3dd23b1fe4ab95ce69fa9a8dea6c408c120d770d7721bb03e2bd6d",
+          "sha256": "32abeba815346e5b3c7f85384f9b00a4bd56cbbd19fb317f2bc13792f5d46fe1",
           "bytes": 37173
         }
       ]
@@ -25563,7 +25563,7 @@
     },
     {
       "path": "package.json",
-      "sha256": "84e1836bfae08bcd4c12f5e372ae825987c635b52f6b627059be61e49273ac9a",
+      "sha256": "19de8d746569c24feed3e6604881ced73bfaf227b7567959550ff6fa49421aff",
       "bytes": 5340
     },
     {
@@ -25572,5 +25572,5 @@
       "bytes": 4523
     }
   ],
-  "aggregate_sha256": "0be430a02d20debf7d204f6f45a46ef1fc494866f53cefac8e856903c5224a82"
+  "aggregate_sha256": "8426c7b8caac1c7b74df9b03e98640d46c66c507621515f7959290f66c74842e"
 }


### PR DESCRIPTION
## Summary

Improve reliability of npm OIDC trusted publishing by pre-caching npm@latest before the publish attempt.

- Add "Pre-cache npm@latest for OIDC publish" step that runs `npx --yes npm@latest --version` to ensure npm 11.x is cached locally
- Switch from `npx npm@^11.5.1` to `npx npm@latest` for simpler version targeting
- Add diagnostics showing both the bundled npm version and the cached npm version available to npx
- This avoids network delays and download failures during the critical publish step

## Context

The 2.4.2 release showed that `npx npm@^11.5.1 publish` still failed with HTTP 404, suggesting:
1. npx wasn't downloading npm 11.x correctly in the runner
2. Or there's a race condition with npx downloading during the publish attempt

Pre-caching npm@latest before the publish step ensures it's available immediately without network overhead.

---
_Generated by [Claude Code](https://claude.ai/code/session_01A6Ki8QHhfHozRxMZ2dpyAr)_