### PR TITLE
fix(release): strip empty _authToken from .npmrc to unblock OIDC publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,6 +71,27 @@ jobs:
           registry-url: "https://registry.npmjs.org"
           package-manager-cache: false
 
+      # CRITICAL: setup-node with `registry-url` writes
+      #   //registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}
+      # to ~/.npmrc. With OIDC trusted publishing, NODE_AUTH_TOKEN is
+      # intentionally unset, so the line expands to `_authToken=` (empty value).
+      # npm 11.x sees ANY _authToken entry and short-circuits the OIDC token
+      # exchange, then PUTs the tarball with an empty Authorization header.
+      # npmjs.com responds with HTTP 404 to unauthenticated writes on existing
+      # scoped packages (documented behavior — not a true "not found").
+      # Stripping the _authToken line forces npm to take the OIDC code path.
+      - name: Strip empty _authToken from .npmrc for OIDC publish
+        run: |
+          if [ -f ~/.npmrc ]; then
+            echo "Before strip:"
+            cat ~/.npmrc
+            sed -i '/_authToken/d' ~/.npmrc
+            echo "After strip:"
+            cat ~/.npmrc
+          else
+            echo "No .npmrc found (no strip needed)"
+          fi
+
       # Pre-download npm@latest before the publish step so it's cached and ready.
       # This ensures GitHub Actions' npx can use it without network delays
       # during the publish attempt.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,25 +71,42 @@ jobs:
           registry-url: "https://registry.npmjs.org"
           package-manager-cache: false
 
-      # CRITICAL: setup-node with `registry-url` writes
+      # CRITICAL: setup-node@v6 with `registry-url` writes
       #   //registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}
-      # to ~/.npmrc. With OIDC trusted publishing, NODE_AUTH_TOKEN is
-      # intentionally unset, so the line expands to `_authToken=` (empty value).
-      # npm 11.x sees ANY _authToken entry and short-circuits the OIDC token
-      # exchange, then PUTs the tarball with an empty Authorization header.
-      # npmjs.com responds with HTTP 404 to unauthenticated writes on existing
-      # scoped packages (documented behavior — not a true "not found").
-      # Stripping the _authToken line forces npm to take the OIDC code path.
-      - name: Strip empty _authToken from .npmrc for OIDC publish
+      # to ${RUNNER_TEMP}/.npmrc and exports NPM_CONFIG_USERCONFIG pointing
+      # at that file (see actions/setup-node v6.4.0 src/authutil.ts). It does
+      # NOT write to ~/.npmrc — targeting the wrong path leaves the poisoned
+      # entry in npm's active userconfig.
+      #
+      # With OIDC trusted publishing, NODE_AUTH_TOKEN is intentionally unset,
+      # so npm reads the line as `_authToken=` (empty value). npm 11.x sees
+      # ANY _authToken entry and short-circuits the OIDC token exchange, then
+      # PUTs the tarball with an empty Authorization header. npmjs.com responds
+      # with HTTP 404 to unauthenticated writes on existing scoped packages
+      # (documented behavior — not a true "not found"). Stripping the
+      # _authToken line forces npm to take the OIDC code path.
+      - name: Strip empty _authToken from active .npmrc for OIDC publish
         run: |
-          if [ -f ~/.npmrc ]; then
+          # NPM_CONFIG_USERCONFIG is the file npm actually reads. setup-node@v6
+          # sets it to ${RUNNER_TEMP}/.npmrc; fall back to ~/.npmrc only when
+          # setup-node was bypassed.
+          NPMRC_PATH="${NPM_CONFIG_USERCONFIG:-$HOME/.npmrc}"
+          echo "Active npmrc path: $NPMRC_PATH"
+          if [ -f "$NPMRC_PATH" ]; then
             echo "Before strip:"
-            cat ~/.npmrc
-            sed -i '/_authToken/d' ~/.npmrc
+            cat "$NPMRC_PATH"
+            sed -i '/_authToken/d' "$NPMRC_PATH"
             echo "After strip:"
-            cat ~/.npmrc
+            cat "$NPMRC_PATH"
           else
-            echo "No .npmrc found (no strip needed)"
+            echo "No .npmrc found at $NPMRC_PATH (no strip needed)"
+          fi
+          # Also strip ~/.npmrc defensively in case a future setup-node version
+          # changes its config location or both files end up in npm's resolution
+          # chain. Cheap insurance against silent regressions.
+          if [ -f "$HOME/.npmrc" ] && [ "$HOME/.npmrc" != "$NPMRC_PATH" ]; then
+            echo "Also stripping ~/.npmrc defensively:"
+            sed -i '/_authToken/d' "$HOME/.npmrc"
           fi
 
       # Pre-download npm@latest before the publish step so it's cached and ready.
@@ -202,8 +219,10 @@ jobs:
           echo "Bundled npm version: $(npm --version)"
           echo "npx cached npm version: $(npx npm --version 2>/dev/null || echo 'not yet cached')"
           echo "OIDC token available: $([ -n "$ACTIONS_ID_TOKEN_REQUEST_URL" ] && echo yes || echo 'NO — id-token:write may be missing')"
-          echo "registry-url .npmrc:"
-          cat ~/.npmrc 2>/dev/null || echo "(no .npmrc found)"
+          NPMRC_PATH="${NPM_CONFIG_USERCONFIG:-$HOME/.npmrc}"
+          echo "Active npmrc path: $NPMRC_PATH"
+          echo "registry-url .npmrc contents:"
+          cat "$NPMRC_PATH" 2>/dev/null || echo "(no .npmrc found at $NPMRC_PATH)"
           echo "::endgroup::"
 
           # Use npx npm@latest to run the latest npm (11.x+) which has native

--- a/docs/npm-oidc-trusted-publishing.md
+++ b/docs/npm-oidc-trusted-publishing.md
@@ -89,7 +89,9 @@ three GitHub Releases were tagged but never reached the npm registry, which
 remained at v2.3.0.
 
 `actions/setup-node@v6` with `registry-url: https://registry.npmjs.org` writes
-the following to `~/.npmrc`:
+the following line to `${RUNNER_TEMP}/.npmrc` **and exports
+`NPM_CONFIG_USERCONFIG`** pointing at that file (see setup-node v6.4.0
+`src/authutil.ts`). It does **not** write to `~/.npmrc`:
 
 ```
 //registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}
@@ -114,19 +116,27 @@ exchanges the OIDC token directly with Sigstore (different audience), not
 through npmjs.com — so log output shows a signed provenance statement
 immediately followed by `npm error code E404`.
 
-**Lesson:** after `setup-node` configures the registry, strip the poisoned
-`_authToken` line so npm reaches the OIDC exchange:
+**Lesson:** strip the poisoned `_authToken` line from the file npm actually
+reads. That file is `${NPM_CONFIG_USERCONFIG}` when setup-node is used —
+**not** `~/.npmrc`. Stripping the wrong path silently leaves the broken
+line in npm's active userconfig and the 404 persists:
 
 ```yaml
-- name: Strip empty _authToken from .npmrc for OIDC publish
+- name: Strip empty _authToken from active .npmrc for OIDC publish
   run: |
-    if [ -f ~/.npmrc ]; then
-      sed -i '/_authToken/d' ~/.npmrc
+    NPMRC_PATH="${NPM_CONFIG_USERCONFIG:-$HOME/.npmrc}"
+    if [ -f "$NPMRC_PATH" ]; then
+      sed -i '/_authToken/d' "$NPMRC_PATH"
+    fi
+    # Defensive: also strip ~/.npmrc when it differs from the active config.
+    if [ -f "$HOME/.npmrc" ] && [ "$HOME/.npmrc" != "$NPMRC_PATH" ]; then
+      sed -i '/_authToken/d' "$HOME/.npmrc"
     fi
 ```
 
 The `azu/setup-npm-trusted-publish` action linked above performs this same
-strip internally — that is its primary purpose, not version management.
+strip on the active config internally — that is its primary purpose, not
+version management.
 
 ## Working pattern
 

--- a/docs/npm-oidc-trusted-publishing.md
+++ b/docs/npm-oidc-trusted-publishing.md
@@ -82,6 +82,52 @@ step without touching the global installation.
 
 Reference: [azu/setup-npm-trusted-publish](https://github.com/azu/setup-npm-trusted-publish) (May 2026).
 
+### Empty `_authToken` in `.npmrc` poisons the OIDC code path
+
+This is the failure mode that silently broke v2.4.0, v2.4.1, and v2.4.2 — all
+three GitHub Releases were tagged but never reached the npm registry, which
+remained at v2.3.0.
+
+`actions/setup-node@v6` with `registry-url: https://registry.npmjs.org` writes
+the following to `~/.npmrc`:
+
+```
+//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}
+```
+
+With OIDC trusted publishing, `NODE_AUTH_TOKEN` is intentionally unset. The
+variable interpolation expands to an empty string, leaving:
+
+```
+//registry.npmjs.org/:_authToken=
+```
+
+npm 11.x reads this as "a token IS configured" and short-circuits the OIDC
+token-exchange code path. It then sends the PUT with an empty
+`Authorization: Bearer` header. npmjs.com responds with **HTTP 404** (not
+401/403) for unauthenticated writes to existing scoped packages — a
+documented quirk that makes the failure look like a missing package or
+trusted-publisher misconfiguration.
+
+The Sigstore provenance step still succeeds in this scenario because it
+exchanges the OIDC token directly with Sigstore (different audience), not
+through npmjs.com — so log output shows a signed provenance statement
+immediately followed by `npm error code E404`.
+
+**Lesson:** after `setup-node` configures the registry, strip the poisoned
+`_authToken` line so npm reaches the OIDC exchange:
+
+```yaml
+- name: Strip empty _authToken from .npmrc for OIDC publish
+  run: |
+    if [ -f ~/.npmrc ]; then
+      sed -i '/_authToken/d' ~/.npmrc
+    fi
+```
+
+The `azu/setup-npm-trusted-publish` action linked above performs this same
+strip internally — that is its primary purpose, not version management.
+
 ## Working pattern
 
 Derived from npm docs, semantic-release docs, and azu/setup-npm-trusted-publish.


### PR DESCRIPTION
## Root cause

`actions/setup-node@v6` with `registry-url: https://registry.npmjs.org` writes this line to **`${RUNNER_TEMP}/.npmrc`** and exports **`NPM_CONFIG_USERCONFIG`** pointing at that file (see setup-node v6.4.0 `src/authutil.ts`). It does **not** touch `~/.npmrc`:

```
//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}
```

With OIDC trusted publishing, `NODE_AUTH_TOKEN` is intentionally unset — the variable expands to empty:

```
//registry.npmjs.org/:_authToken=
```

**npm 11.x reads this as "a token is configured" and short-circuits the OIDC token-exchange code path.** It then sends the PUT with an empty `Authorization: Bearer` header. npmjs.com responds with **HTTP 404** (not 401/403) for unauthenticated writes to existing scoped packages — a documented quirk that disguises the auth failure as a missing package.

The Sigstore provenance step still succeeds because it exchanges the OIDC token directly with Sigstore (different audience), not through npmjs.com. That's why every failure log shows a signed provenance statement immediately followed by `npm error code E404`.

## Evidence

- **v2.3.0** (published via `NPM_TOKEN`, before OIDC migration): present on npm
- **v2.4.0, v2.4.1, v2.4.2** (after OIDC migration): GitHub Releases tagged, npm registry still at 2.3.0
- All three failures showed identical `404 PUT @raishin%2fvanguard-frontier-agentic` despite trusted publisher being correctly configured on npmjs.com

## Fix

Strip the `_authToken` line from **the file npm actually reads**, which is `${NPM_CONFIG_USERCONFIG}` when setup-node is used — not `~/.npmrc`:

```yaml
- name: Strip empty _authToken from active .npmrc for OIDC publish
  run: |
    NPMRC_PATH="${NPM_CONFIG_USERCONFIG:-$HOME/.npmrc}"
    if [ -f "$NPMRC_PATH" ]; then
      sed -i '/_authToken/d' "$NPMRC_PATH"
    fi
    # Defensive: also strip ~/.npmrc when it differs from the active config.
    if [ -f "$HOME/.npmrc" ] && [ "$HOME/.npmrc" != "$NPMRC_PATH" ]; then
      sed -i '/_authToken/d' "$HOME/.npmrc"
    fi
```

This is what `azu/setup-npm-trusted-publish` (referenced in our docs) does internally — that action's primary purpose is active-config `.npmrc` cleanup, not version management.

## Iteration history on this PR

- **Initial commit (7d5c6bb)**: stripped `~/.npmrc` — was incorrect because setup-node@v6 writes to `${RUNNER_TEMP}/.npmrc`, leaving the poisoned line in npm's active userconfig.
- **Follow-up commit (5e7868a)**: targets `${NPM_CONFIG_USERCONFIG}` so the strip applies to the file npm actually reads, with `~/.npmrc` as a defensive fallback. Verified via context7 against setup-node v6.4.0 source.

Per codex review feedback on this PR (P1 + P2 threads).

## Changes

- `.github/workflows/release.yml`: strip the active `${NPM_CONFIG_USERCONFIG}` config + defensive `~/.npmrc` strip, with before/after diagnostic output
- `docs/npm-oidc-trusted-publishing.md`: corrected remediation snippet and explicit note that setup-node@v6 writes to `${RUNNER_TEMP}/.npmrc`, not `~/.npmrc`

## Supersedes

PRs #45, #46, #48, #49 attempted but did not fix the actual root cause.

## Test plan

- [ ] Merge to master and observe the next release run
- [ ] Verify diagnostic output shows `_authToken` removed from the file pointed at by `$NPM_CONFIG_USERCONFIG`
- [ ] Confirm npm registry receives the new version

---
_Generated by [Claude Code](https://claude.ai/code/session_01A6Ki8QHhfHozRxMZ2dpyAr)_