### PR TITLE
fix(release): use --no-auth flag to force OIDC instead of token auth

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -253,12 +253,23 @@ jobs:
 
           # Use npx npm@latest to run the latest npm (11.x+) which has native
           # OIDC trusted-publisher support. Node 24 bundles npm 10.x which lacks
-          # this support and falls back to the empty _authToken, causing 404.
+          # this support.
+          #
+          # setup-node writes _authToken to .npmrc, even though NODE_AUTH_TOKEN
+          # is unset (so the line is empty). npm 11.x interprets ANY _authToken
+          # entry as "use token auth" and bypasses OIDC. Even after stripping,
+          # npm might read config from multiple locations. Using --no-auth tells
+          # npm to skip token auth validation entirely and rely on OIDC.
+          #
           # npm@latest is pre-cached by the "Pre-cache npm@latest for OIDC publish"
           # step to avoid download delays. Prereq: trusted publisher configured
           # on npmjs.com for owner=raishin repo=vanguard-frontier-agentic
           # workflow=release.yml environment=npm-deployment-master.
-          if ! npx npm@latest publish --access public --provenance; then
+          if ! npx npm@latest publish \
+               --registry https://registry.npmjs.org \
+               --access public \
+               --provenance \
+               --no-auth; then
             echo "::error::npm publish failed. Confirm npmjs.com trusted publisher is configured:" \
               "owner=raishin repo=vanguard-frontier-agentic workflow=release.yml environment=npm-deployment-master." \
               "See docs/npm-oidc-trusted-publishing.md"


### PR DESCRIPTION
## Problem

The `_authToken=` line in `.npmrc` (written by setup-node with an unset NODE_AUTH_TOKEN) causes npm to bypass OIDC and attempt token auth, which fails with 404.

Strip attempts have failed because:
- npm's config resolution reads from multiple files/locations
- NPM_CONFIG_USERCONFIG export may not work reliably
- Even after stripping, npm might read other config sources

## Solution

Use the `--no-auth` flag on npm publish to explicitly skip token auth validation. Combined with `--registry` set explicitly, this forces npm to use OIDC token exchange regardless of .npmrc contents.

```bash
npx npm@latest publish \
  --registry https://registry.npmjs.org \
  --access public \
  --provenance \
  --no-auth
```

## Test

This will be tested by the next release workflow run. If `--no-auth` is not recognized by npm 11.x, the error will be clear and immediate.

---
_Generated by [Claude Code](https://claude.ai/code/session_01A6Ki8QHhfHozRxMZ2dpyAr)_