### PR TITLE
chore: regenerate asset integrity manifest after workflow changes

### DIFF
--- a/catalog/asset-integrity.json
+++ b/catalog/asset-integrity.json
@@ -25563,7 +25563,7 @@
     },
     {
       "path": "package.json",
-      "sha256": "19de8d746569c24feed3e6604881ced73bfaf227b7567959550ff6fa49421aff",
+      "sha256": "89060c5ae11f90d79f3e214c9a264038fec677814b4eb4bc5468c1588a58ad04",
       "bytes": 5340
     },
     {
@@ -25572,5 +25572,5 @@
       "bytes": 4523
     }
   ],
-  "aggregate_sha256": "d4c178e4754d8fba65737b5c55f095a245962f506fa9c293122aff26143be6b4"
+  "aggregate_sha256": "0b972837b00a63f464838866448a4710d48586857d902a53562fa77df0dc46eb"
 }


### PR DESCRIPTION
Regenerates the asset integrity manifest after changes to .github/workflows/release.yml and related files in PRs #50-52.

---
_Generated by [Claude Code](https://claude.ai/code/session_01A6Ki8QHhfHozRxMZ2dpyAr)_