### PR TITLE
docs: document v2.4.x npm publication gap and OIDC fix resolution

### DIFF
--- a/docs/npm-oidc-trusted-publishing.md
+++ b/docs/npm-oidc-trusted-publishing.md
@@ -202,6 +202,49 @@ jobs:
   to the exact workflow run that produced it.
 - No `NPM_TOKEN` secret is stored anywhere.
 
+## Known Issue: v2.4.x npm publication gap
+
+**Status:** Fixed as of v2.5.0 (May 2026).
+
+Versions **2.4.0, 2.4.1, 2.4.2, 2.4.3, and 2.4.4** were tagged in GitHub and
+GitHub Releases were created, but these versions **never reached the npm registry**.
+The npm registry remained at v2.3.0 while these GitHub tags accumulated.
+
+### Root cause
+
+All five releases failed due to the empty `_authToken` poisoning issue documented
+above. Each CI run hit the HTTP 404 (misidentified as a trusted-publisher config
+error) and exited without publishing. The fix was implemented after v2.4.4 was
+already tagged, so the backlog of unpublished GitHub Releases was not retroactively
+pushed to npm.
+
+### Resolution
+
+- v2.5.0 and all subsequent releases are now published to npm successfully using
+  the fixed workflow (auto-fix `_authToken` stripping + npm@^11.5.1 + `--provenance`).
+- The 2.4.x versions remain as GitHub Releases only and are not available on npm.
+  They should **not** be used for production — always upgrade to v2.5.0+.
+
+### If backfilling 2.4.x to npm is needed
+
+To manually publish any of the v2.4.x releases to npm (if desired for archival):
+
+```bash
+git checkout v2.4.4
+npm publish --access public --provenance
+# Repeat for v2.4.3, v2.4.2, v2.4.1, v2.4.0 if needed
+```
+
+This requires:
+- npm CLI >= 11.5.1 installed locally
+- Valid OIDC trusted publisher registration on npmjs.com (same as CI workflow)
+- GitHub OIDC token available (works in Actions; on local machines, requires
+  manual OIDC token exchange or fallback to long-lived token)
+
+This is a low-priority backfill since users were blocked from using 2.4.x anyway
+due to the registry gap. Focus should remain on keeping 2.5.0+ releases flowing
+to npm without interruption.
+
 ## References
 
 - [npm Trusted Publishers docs](https://docs.npmjs.com/trusted-publishers)


### PR DESCRIPTION
## Summary

Documents the v2.4.x npm publication gap that occurred during the OIDC trusted publishing migration.

**Issue:** Versions 2.4.0–2.4.4 were tagged in GitHub with GitHub Releases created, but never published to npm due to the empty `_authToken` poisoning issue (documented in detail below).

**Resolution:** The fix was implemented in PR #56 (auto-fix asset integrity + npm@^11.5.1 + provenance). v2.5.0 published successfully on May 21, 2026. All future releases will work correctly.

## Documentation Changes

- **File:** `docs/npm-oidc-trusted-publishing.md`
- **New Section:** "Known Issue: v2.4.x npm publication gap"
- **Covers:**
  - Root cause (empty `_authToken` poisoning)
  - Impact (2.4.x unavailable on npm, npm registry stayed at v2.3.0)
  - Resolution status (v2.5.0+ working)
  - Optional backfill instructions if historical archival is needed

## Context

This documents the outcome of the OIDC migration work:
- PR #56: Added auto-fix stale asset integrity + manifest:write:all parallel script
- Release workflow improvements: Proper `_authToken` stripping, npm@^11.5.1 pinning, provenance flag
- v2.5.0 successfully published to npm with OIDC on May 21, 2026

## Test Plan

- [x] Documentation is accurate and actionable
- [x] Provides clear explanation for users encountering 2.4.x versions in GitHub but not npm
- [x] Includes recovery path if backfill is desired

https://claude.ai/code/session_01A6Ki8QHhfHozRxMZ2dpyAr

---
_Generated by [Claude Code](https://claude.ai/code/session_01A6Ki8QHhfHozRxMZ2dpyAr)_