### PR TITLE
feat(vfa-tui): Task 15 — Light/Dark mode with system detection

### DIFF
--- a/.kiro/specs/rust-tui-v2/IMPLEMENTATION-STATUS.md
+++ b/.kiro/specs/rust-tui-v2/IMPLEMENTATION-STATUS.md
@@ -202,6 +202,33 @@ integration tests (13.3–13.6 added in the backfill + pre-existing 77) are gree
 | 13.6 | ✅ | (tests only) | `tests/integration/sqlite_persistence.rs` — write→restart→read, migration to v3, audit append-only trigger enforcement, corrupt-index recovery (6 tests) |
 | 13.7 | ✅ | (tests only) | `tests/property/ui.rs` — P4 (detail formatter includes all required agent fields) |
 
+## Task 15 — Light/Dark Mode with System Detection (2026-06-16)
+
+Implemented and tested (TDD). Deep-checked against Requirement 35 + the design.md
+Theme Engine section; an independent static review confirmed 8/9 acceptance
+criteria PASS with the 35.9 note below.
+
+| Sub-task | Status | Evidence |
+|----------|--------|----------|
+| 15.1 — `terminal-light` dep + theme enums + detection | ✅ | `Cargo.toml` (`terminal-light = "1"`); `src/ui/theme.rs` — `ThemeMode {Dark,Light}`, `ThemePreference {Auto,Dark,Light}`, `detect_system_theme()` (`terminal_light::luma()` > 0.6 → Light), `parse_colorfgbg()` (bg ≥ 7 → Light), `classify_theme()` pure resolver, fallback Dark. `--theme` flag in `src/cli.rs`. |
+| 15.2 — `Theme` dual-palette refactor | ✅ | `Palette` struct + `dark_palette()`/`light_palette()`; `Theme { mode, palette }`; `Theme::new(no_color, mode)`; `with_color_support()` defaults Dark (back-compat) + `with_color_support_mode()`; `toggle_mode()`; all style methods pull from `self.palette`; `ColorSupport::None` still wins. |
+| 15.3 — Startup wiring + runtime toggle | ✅ | `src/main.rs` resolves `resolve_theme(cli.theme, false)` → `app.theme_mode`; `App.theme_mode` persists for the session; `t` keybinding toggles Dark↔Light + sets `dirty` (outside search mode); help overlay documents `t`. |
+| 15.4 — Tests | ✅ | `src/ui/theme.rs` unit tests (luma threshold, COLORFGBG parsing incl. 3-field + boundary, light/dark palette colors, no-color ignores mode, determinism, runtime toggle) + `prop34_theme_styles_deterministic` proptest over all 6 `(ThemeMode, ColorSupport)` combos; `src/app.rs` tests for `t` toggle + search-mode guard. **21 theme tests green.** |
+
+**Design note (ThemeMode vs tasks.md 15.1):** the design.md contract splits the
+type into a runtime-resolved `ThemeMode {Dark, Light}` plus a CLI-level
+`ThemePreference {Auto, Dark, Light}`, rather than a single enum with a `System`
+variant. The implementation follows design.md (the detailed contract).
+
+**Req 35.9 (headless) — satisfied with caveat:** the enforceable part — headless
+mode must NOT probe the terminal (no OSC 11 query) and defaults to Dark for
+`--theme auto` — is satisfied via `resolve_theme(.., is_headless=true)`. The
+"respect `--theme` for ANSI-colored output" clause is **not applicable**: the
+headless formatters (`src/headless/formats.rs`) are plain-text by design (text
+status indicators, no `Color`/ANSI emission — the TUI owns all colour). There is
+no ANSI output in headless mode to theme, so no consumer was wired (doing so would
+introduce an unused binding under `#![deny(warnings)]`).
+
 ## Remaining follow-ups
 
 All originally-planned next steps (9.1, 11.3, 7.1, 7.3, 11.2, 7.8, and the

--- a/.kiro/specs/rust-tui-v2/tasks.md
+++ b/.kiro/specs/rust-tui-v2/tasks.md
@@ -430,8 +430,8 @@ Dependencies are catalog-live, and CatalogBrowser is the live fallback).
 - [x] 14. Final checkpoint — All tests pass
   - Ensure all tests pass, ask the user if questions arise.
 
-- [ ] 15. Light/Dark Mode with System Detection
-  - [ ] 15.1 Add `terminal-light` dependency and `ThemeMode` enum
+- [x] 15. Light/Dark Mode with System Detection
+  - [x] 15.1 Add `terminal-light` dependency and `ThemeMode` enum
     - Add `terminal-light = "1"` to `tools/vfa-tui/Cargo.toml` dependencies
     - Add a `--theme` CLI flag to `src/cli.rs` (`Cli` struct) accepting values: `auto` (default), `dark`, `light`
     - Define `ThemeMode` enum in `src/ui/theme.rs`: `Dark`, `Light`, `System` (resolved at startup)
@@ -439,7 +439,7 @@ Dependencies are catalog-live, and CatalogBrowser is the live fallback).
     - Also check `COLORFGBG` env var as secondary heuristic (format `fg;bg`, bg ≥ 7 → Light) when `terminal-light` detection fails
     - _Requirements: 29.1–29.4 (accessibility), 16.1 (presentation)_
 
-  - [ ] 15.2 Refactor `Theme` struct to support dual palettes
+  - [x] 15.2 Refactor `Theme` struct to support dual palettes
     - Add a `mode: ThemeMode` field (resolved — always `Dark` or `Light`, never `System` at runtime) to `Theme`
     - Update `Theme::new()` to accept the resolved `ThemeMode` alongside `no_color`
     - Update `Theme::with_color_support()` to accept an optional `ThemeMode` (default `Dark` for backward compat)
@@ -450,7 +450,7 @@ Dependencies are catalog-live, and CatalogBrowser is the live fallback).
     - Ensure `ColorSupport::None` still takes precedence (no colors regardless of mode)
     - _Requirements: 16.6 (visual distinction), 18.1 (determinism)_
 
-  - [ ] 15.3 Wire theme mode through application startup
+  - [x] 15.3 Wire theme mode through application startup
     - In `src/main.rs` / `src/app.rs`, resolve `--theme` flag: `auto` → call `detect_system_theme()`, `dark` → `ThemeMode::Dark`, `light` → `ThemeMode::Light`
     - Pass resolved `ThemeMode` to `Theme::new()`
     - Ensure headless mode respects `--theme` for ANSI-colored table/markdown output (or ignores when `--no-color`)
@@ -458,7 +458,7 @@ Dependencies are catalog-live, and CatalogBrowser is the live fallback).
     - Store current theme mode in `App` state so toggle persists for the session
     - _Requirements: 34.1 (event loop), 16.3 (keybinding)_
 
-  - [ ] 15.4 Write tests for theme detection and palettes
+  - [x] 15.4 Write tests for theme detection and palettes
     - Unit test: `detect_system_theme()` returns `Dark` when `terminal-light` fails (mock/fallback path)
     - Unit test: `COLORFGBG` parsing — `"0;15"` → Light, `"15;0"` → Dark, missing → fallback
     - Unit test: `Theme` with `ThemeMode::Light` + `ColorSupport::TrueColor256` returns light palette colors

--- a/tools/vfa-tui/Cargo.lock
+++ b/tools/vfa-tui/Cargo.lock
@@ -299,6 +299,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "coolor"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "980c2afde4af43d6a05c5be738f9eae595cff86dce1f38f88b95058a98c027f3"
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1917,6 +1923,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "terminal-light"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6f76be906d875a0ce764c52a055858c24847cb7dc674d3a5ad8cf7e3dd4ee9f"
+dependencies = [
+ "coolor",
+ "crossterm 0.29.0",
+ "thiserror 1.0.69",
+ "xterm-query",
+]
+
+[[package]]
 name = "terminfo"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2311,6 +2329,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tempfile",
+ "terminal-light",
  "thiserror 2.0.18",
  "tokio",
  "toml",
@@ -2935,6 +2954,16 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "xterm-query"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "292c33df434fde4ecd87a7afecdfa1681a3d29567fc69c774a0d83d32c095331"
+dependencies = [
+ "nix",
+ "thiserror 1.0.69",
 ]
 
 [[package]]

--- a/tools/vfa-tui/Cargo.toml
+++ b/tools/vfa-tui/Cargo.toml
@@ -25,6 +25,7 @@ toml = "0.8"
 sha2 = "0.10"
 chrono = { version = "0.4", features = ["serde"] }
 futures = "0.3"
+terminal-light = "1"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/tools/vfa-tui/src/app.rs
+++ b/tools/vfa-tui/src/app.rs
@@ -15,7 +15,7 @@ use crate::subprocess::{SubprocessExecutor, SubprocessHandle};
 
 use crate::ui::layout::compute_layout;
 use crate::ui::nav::{NavigationState, View, SIDEBAR_SECTIONS};
-use crate::ui::theme::Theme;
+use crate::ui::theme::{Theme, ThemeMode};
 use crate::ui::widgets::{
     audit_log, coverage_grid, dep_graph, detail, help_bar, list_view, output, search, status_bar,
     violations,
@@ -75,6 +75,10 @@ pub struct App {
     pub session_id: Uuid,
     pub should_quit: bool,
     pub no_color: bool,
+    /// Resolved theme mode (Dark/Light) for the session; toggled at runtime
+    /// via the `t` keybinding (Req 35.6). Defaults to Dark; `main` overrides
+    /// it from the `--theme` flag / system detection.
+    pub theme_mode: ThemeMode,
     pub workspace_root: PathBuf,
     /// Name of the currently running validation gate (for status tracking).
     /// When set, prevents concurrent execution of the same gate.
@@ -119,6 +123,7 @@ impl App {
             session_id,
             should_quit: false,
             no_color,
+            theme_mode: ThemeMode::Dark,
             workspace_root,
             running_gate: None,
             running_gate_start: None,
@@ -174,6 +179,16 @@ impl App {
             }
             KeyCode::Char('?') => {
                 self.show_help_overlay = true;
+            }
+            KeyCode::Char('t') => {
+                // Runtime light/dark toggle (Req 35.6). Search mode is handled
+                // earlier and returns before reaching this match, so `t` is only
+                // a toggle outside of search.
+                self.theme_mode = match self.theme_mode {
+                    ThemeMode::Dark => ThemeMode::Light,
+                    ThemeMode::Light => ThemeMode::Dark,
+                };
+                self.dirty = true;
             }
             KeyCode::Char('p') if self.nav.current_view == View::AgentList => {
                 self.cycle_provider_filter();
@@ -1027,7 +1042,7 @@ impl App {
         use crate::ui::nav::Tab;
         use ratatui::layout::{Constraint, Direction, Layout};
 
-        let theme = Theme::new(self.no_color);
+        let theme = Theme::new(self.no_color, self.theme_mode);
         let area = frame.area();
 
         // Split into: tab bar (3 rows), body (flexible), status (1), help (1).
@@ -2083,6 +2098,7 @@ impl App {
             Line::from(""),
             Line::from(Span::styled("General", theme.help_overlay_section())),
             Line::from("  ?             Toggle this help overlay"),
+            Line::from("  t             Toggle light / dark theme"),
             Line::from("  q             Quit"),
             Line::from("  Ctrl+C        Quit"),
             Line::from(""),
@@ -2259,6 +2275,33 @@ mod tests {
         };
         app.handle_key_event(key);
         assert!(app.should_quit);
+    }
+
+    #[test]
+    fn app_t_toggles_theme_mode() {
+        // Req 35.6 / Task 15.3: `t` toggles the session theme mode and marks
+        // the UI dirty so it re-renders with the new palette.
+        let mut app = make_app();
+        assert_eq!(app.theme_mode, ThemeMode::Dark);
+        app.dirty = false;
+
+        app.handle_key_event(key_event(KeyCode::Char('t')));
+        assert_eq!(app.theme_mode, ThemeMode::Light);
+        assert!(app.dirty, "theme toggle must set dirty flag");
+
+        app.handle_key_event(key_event(KeyCode::Char('t')));
+        assert_eq!(app.theme_mode, ThemeMode::Dark);
+    }
+
+    #[test]
+    fn app_t_does_not_toggle_theme_in_search_mode() {
+        // In search mode, `t` is literal search input, not a theme toggle.
+        let mut app = make_app();
+        app.handle_key_event(key_event(KeyCode::Char('/')));
+        assert!(app.search_active);
+        app.handle_key_event(key_event(KeyCode::Char('t')));
+        assert_eq!(app.theme_mode, ThemeMode::Dark);
+        assert_eq!(app.search_query, "t");
     }
 
     #[test]

--- a/tools/vfa-tui/src/cli.rs
+++ b/tools/vfa-tui/src/cli.rs
@@ -544,4 +544,38 @@ mod tests {
         let cli = ok(&["vfa-tui", "--log-level", "debug"]);
         assert_eq!(cli.log_level, LogLevel::Debug);
     }
+
+    // -----------------------------------------------------------------------
+    // --theme (Req 35.3)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn theme_flag_defaults_to_auto() {
+        assert_eq!(ok(&["vfa-tui"]).theme, ThemePreference::Auto);
+    }
+
+    #[test]
+    fn theme_flag_parses_all_variants() {
+        assert_eq!(ok(&["vfa-tui", "--theme", "auto"]).theme, ThemePreference::Auto);
+        assert_eq!(ok(&["vfa-tui", "--theme", "dark"]).theme, ThemePreference::Dark);
+        assert_eq!(
+            ok(&["vfa-tui", "--theme", "light"]).theme,
+            ThemePreference::Light
+        );
+    }
+
+    #[test]
+    fn theme_flag_invalid_exits_2() {
+        let err = parse(&["vfa-tui", "--theme", "sepia"]).unwrap_err();
+        assert_eq!(err.exit_code(), 2, "invalid theme should give exit code 2");
+    }
+
+    #[test]
+    fn theme_and_no_color_are_independent() {
+        // A user can pass both; --no-color wins at render time, but the theme
+        // preference still parses to its own field.
+        let cli = ok(&["vfa-tui", "--no-color", "--theme", "light"]);
+        assert!(cli.no_color);
+        assert_eq!(cli.theme, ThemePreference::Light);
+    }
 }

--- a/tools/vfa-tui/src/cli.rs
+++ b/tools/vfa-tui/src/cli.rs
@@ -556,8 +556,14 @@ mod tests {
 
     #[test]
     fn theme_flag_parses_all_variants() {
-        assert_eq!(ok(&["vfa-tui", "--theme", "auto"]).theme, ThemePreference::Auto);
-        assert_eq!(ok(&["vfa-tui", "--theme", "dark"]).theme, ThemePreference::Dark);
+        assert_eq!(
+            ok(&["vfa-tui", "--theme", "auto"]).theme,
+            ThemePreference::Auto
+        );
+        assert_eq!(
+            ok(&["vfa-tui", "--theme", "dark"]).theme,
+            ThemePreference::Dark
+        );
         assert_eq!(
             ok(&["vfa-tui", "--theme", "light"]).theme,
             ThemePreference::Light

--- a/tools/vfa-tui/src/cli.rs
+++ b/tools/vfa-tui/src/cli.rs
@@ -22,6 +22,7 @@ use std::path::PathBuf;
 use clap::{Parser, ValueEnum};
 
 use crate::models::report::{OutputFormat, ReportType};
+use crate::ui::theme::ThemePreference;
 
 // ---------------------------------------------------------------------------
 // Cli
@@ -71,6 +72,10 @@ pub struct Cli {
     /// Disable colored output (also honoured via NO_COLOR env var).
     #[arg(long)]
     pub no_color: bool,
+
+    /// Color theme mode: `auto` (detect terminal background), `dark`, or `light`.
+    #[arg(long, value_enum, default_value_t = ThemePreference::Auto)]
+    pub theme: ThemePreference,
 
     // -----------------------------------------------------------------------
     // New flags (Req 26.1–26.8)

--- a/tools/vfa-tui/src/main.rs
+++ b/tools/vfa-tui/src/main.rs
@@ -352,8 +352,14 @@ async fn run_tui_async(cli: &Cli, workspace_root: &std::path::Path) -> anyhow::R
     let session_id = uuid::Uuid::new_v4();
     let no_color = cli.is_no_color();
 
+    // Resolve the light/dark theme: `--theme dark|light` forces a palette,
+    // `--theme auto` (default) detects the terminal background (Req 35.1–35.3).
+    // This is the interactive (TUI) path, so detection is permitted.
+    let theme_mode = ui::theme::resolve_theme(cli.theme, false);
+
     // Create app.
     let mut app = app::App::new(catalog, workspace_root.to_path_buf(), session_id, no_color);
+    app.theme_mode = theme_mode;
 
     // Channel: crossterm events sent from blocking task.
     let (tx_event, mut rx_event) = mpsc::channel(256);

--- a/tools/vfa-tui/src/ui/theme.rs
+++ b/tools/vfa-tui/src/ui/theme.rs
@@ -56,39 +56,245 @@ pub fn detect_color_support(no_color: bool) -> ColorSupport {
     ColorSupport::Basic8
 }
 
-/// Theme configuration supporting --no-color mode and 8-color fallback.
+// ---------------------------------------------------------------------------
+// Theme mode + detection (Requirement 35)
+// ---------------------------------------------------------------------------
+
+/// Resolved theme mode — always Dark or Light at runtime (never System/Auto).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ThemeMode {
+    Dark,
+    Light,
+}
+
+/// CLI-level theme preference before resolution (Req 35.3).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+pub enum ThemePreference {
+    /// Detect from terminal background (default).
+    Auto,
+    /// Force dark palette.
+    Dark,
+    /// Force light palette.
+    Light,
+}
+
+/// Parse the `COLORFGBG` environment variable value into a [`ThemeMode`].
 ///
-/// The theme is deterministic: given the same `ColorSupport` level, all style
-/// methods return identical `Style` values (Requirement 18.1).
+/// Format is `fg;bg` (some terminals emit `fg;default;bg`); the **last**
+/// field is the background ANSI colour index. A background index ≥ 7 means a
+/// light terminal (Req 35.2). Returns `None` when the value is empty or the
+/// background field cannot be parsed, so the caller can fall through to the
+/// next heuristic.
+pub fn parse_colorfgbg(value: &str) -> Option<ThemeMode> {
+    let bg_str = value.rsplit(';').next()?.trim();
+    let bg_idx: u8 = bg_str.parse().ok()?;
+    Some(if bg_idx >= 7 {
+        ThemeMode::Light
+    } else {
+        ThemeMode::Dark
+    })
+}
+
+/// Pure classification of detection inputs into a [`ThemeMode`].
+///
+/// Priority (Req 35.1 → 35.2 → fallback):
+/// 1. `luma` from the `terminal-light` OSC 11 query: `> 0.6` → Light, else Dark.
+/// 2. `COLORFGBG` parsing via [`parse_colorfgbg`].
+/// 3. Default to Dark (safe assumption for most developer terminals).
+///
+/// Kept side-effect free so the full decision tree is unit-testable without
+/// touching the terminal or environment.
+fn classify_theme(luma: Option<f32>, colorfgbg: Option<&str>) -> ThemeMode {
+    if let Some(l) = luma {
+        return if l > 0.6 {
+            ThemeMode::Light
+        } else {
+            ThemeMode::Dark
+        };
+    }
+    if let Some(value) = colorfgbg {
+        if let Some(mode) = parse_colorfgbg(value) {
+            return mode;
+        }
+    }
+    ThemeMode::Dark
+}
+
+/// Detect the system theme from terminal background luminance (Req 35.1–35.2).
+///
+/// Primary: `terminal-light` (OSC 11 escape query). Secondary: `COLORFGBG`.
+/// Fallback: Dark. Performs terminal/environment I/O — only call from an
+/// interactive (TUI) startup path, never from headless mode (Req 35.9).
+pub fn detect_system_theme() -> ThemeMode {
+    let luma = terminal_light::luma().ok();
+    let colorfgbg = std::env::var("COLORFGBG").ok();
+    classify_theme(luma, colorfgbg.as_deref())
+}
+
+/// Resolve a CLI [`ThemePreference`] into a concrete [`ThemeMode`] (Req 35.3, 35.9).
+///
+/// `Auto` triggers system detection, except in headless mode where stdin may
+/// not be a TTY — there it defaults to Dark without probing the terminal.
+pub fn resolve_theme(preference: ThemePreference, is_headless: bool) -> ThemeMode {
+    match preference {
+        ThemePreference::Dark => ThemeMode::Dark,
+        ThemePreference::Light => ThemeMode::Light,
+        ThemePreference::Auto => {
+            if is_headless {
+                ThemeMode::Dark
+            } else {
+                detect_system_theme()
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Palette (Requirement 35.4 / 35.5)
+// ---------------------------------------------------------------------------
+
+/// Semantic colour palette — all theme-dependent colours in one place.
+///
+/// Style methods pull from the active palette rather than hardcoding colours,
+/// so a single palette swap re-themes the entire UI.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Palette {
+    /// Primary text.
+    pub fg: Color,
+    /// Secondary/muted text.
+    pub fg_dim: Color,
+    /// `None` = inherit terminal background.
+    pub bg: Option<Color>,
+    /// Alternate background for contrast (status bar, selections).
+    pub bg_alt: Option<Color>,
+    /// Primary accent (focused borders, highlights).
+    pub accent: Color,
+    /// Subdued accent (unfocused, help text).
+    pub accent_dim: Color,
+    /// Pass, installed, current.
+    pub success: Color,
+    /// Outdated, stale, warnings.
+    pub warning: Color,
+    /// Failed, drifted, critical violations.
+    pub error: Color,
+    /// Informational, running, in-progress.
+    pub info: Color,
+    /// Default border colour.
+    pub border: Color,
+    /// Focused panel border.
+    pub border_focused: Color,
+    /// Foreground in selected/highlighted items.
+    pub selection_fg: Color,
+    /// Background in selected/highlighted items.
+    pub selection_bg: Color,
+}
+
+/// Dark palette — optimized for dark terminal backgrounds (Req 35.4).
+pub fn dark_palette() -> Palette {
+    Palette {
+        fg: Color::White,
+        fg_dim: Color::DarkGray,
+        bg: None,
+        bg_alt: Some(Color::White),
+        accent: Color::Cyan,
+        accent_dim: Color::DarkGray,
+        success: Color::Green,
+        warning: Color::Yellow,
+        error: Color::Red,
+        info: Color::Magenta,
+        border: Color::Gray,
+        border_focused: Color::Cyan,
+        selection_fg: Color::Black,
+        selection_bg: Color::LightBlue,
+    }
+}
+
+/// Light palette — optimized for light terminal backgrounds (Req 35.5).
+pub fn light_palette() -> Palette {
+    Palette {
+        fg: Color::Black,
+        fg_dim: Color::DarkGray,
+        bg: None,
+        bg_alt: Some(Color::Black),
+        accent: Color::Blue,
+        accent_dim: Color::Gray,
+        success: Color::Green,
+        warning: Color::Indexed(208), // orange-ish for visibility on light bg
+        error: Color::Red,
+        info: Color::Magenta,
+        border: Color::Gray,
+        border_focused: Color::Blue,
+        selection_fg: Color::White,
+        selection_bg: Color::Blue,
+    }
+}
+
+/// Build the palette for a resolved [`ThemeMode`].
+fn palette_for(mode: ThemeMode) -> Palette {
+    match mode {
+        ThemeMode::Dark => dark_palette(),
+        ThemeMode::Light => light_palette(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Theme
+// ---------------------------------------------------------------------------
+
+/// Theme configuration supporting `--no-color` mode and adaptive light/dark
+/// palettes.
+///
+/// The theme is deterministic: given the same `(ThemeMode, ColorSupport)`,
+/// all style methods return identical `Style` values (Requirement 35.8 /
+/// Property 34). `ColorSupport::None` always takes precedence over the mode —
+/// no colours are emitted regardless of palette (Req 35.7).
 pub struct Theme {
     pub no_color: bool,
     pub color_support: ColorSupport,
+    pub mode: ThemeMode,
+    palette: Palette,
 }
 
 impl Theme {
-    /// Create a new theme with automatic color detection.
-    pub fn new(no_color: bool) -> Self {
+    /// Create a new theme with automatic colour-support detection and an
+    /// explicitly resolved [`ThemeMode`].
+    pub fn new(no_color: bool, mode: ThemeMode) -> Self {
         let color_support = detect_color_support(no_color);
         Self {
             no_color,
             color_support,
+            mode,
+            palette: palette_for(mode),
         }
     }
 
-    /// Create a theme with explicit color support level (useful for testing).
+    /// Create a theme with an explicit colour-support level (useful for
+    /// testing). Defaults to [`ThemeMode::Dark`] for backward compatibility.
     pub fn with_color_support(color_support: ColorSupport) -> Self {
+        Self::with_color_support_mode(color_support, ThemeMode::Dark)
+    }
+
+    /// Create a theme with an explicit colour-support level and mode.
+    pub fn with_color_support_mode(color_support: ColorSupport, mode: ThemeMode) -> Self {
         Self {
             no_color: color_support == ColorSupport::None,
             color_support,
+            mode,
+            palette: palette_for(mode),
         }
     }
 
-    /// Whether to use 256-color palette.
-    fn use_256_colors(&self) -> bool {
-        self.color_support == ColorSupport::TrueColor256
+    /// Toggle between Dark and Light mode at runtime (Req 35.6), rebuilding
+    /// the active palette.
+    pub fn toggle_mode(&mut self) {
+        self.mode = match self.mode {
+            ThemeMode::Dark => ThemeMode::Light,
+            ThemeMode::Light => ThemeMode::Dark,
+        };
+        self.palette = palette_for(self.mode);
     }
 
-    /// Whether any color output is enabled.
+    /// Whether any colour output is enabled.
     fn has_color(&self) -> bool {
         self.color_support != ColorSupport::None
     }
@@ -97,7 +303,7 @@ impl Theme {
         if !self.has_color() {
             Style::default()
         } else {
-            Style::default().fg(Color::White)
+            Style::default().fg(self.palette.fg)
         }
     }
 
@@ -105,10 +311,9 @@ impl Theme {
         if !self.has_color() {
             Style::default().add_modifier(Modifier::REVERSED)
         } else {
-            // Cyan is a basic ANSI color, works in both 8 and 256 color modes
             Style::default()
-                .fg(Color::Black)
-                .bg(Color::Cyan)
+                .fg(self.palette.selection_fg)
+                .bg(self.palette.accent)
                 .add_modifier(Modifier::BOLD)
         }
     }
@@ -117,23 +322,17 @@ impl Theme {
         if !self.has_color() {
             Style::default()
         } else {
-            Style::default().fg(Color::White)
+            Style::default().fg(self.palette.fg)
         }
     }
 
     pub fn list_selected(&self) -> Style {
         if !self.has_color() {
             Style::default().add_modifier(Modifier::REVERSED)
-        } else if self.use_256_colors() {
-            Style::default()
-                .fg(Color::Black)
-                .bg(Color::LightBlue)
-                .add_modifier(Modifier::BOLD)
         } else {
-            // 8-color fallback: use basic blue background
             Style::default()
-                .fg(Color::Black)
-                .bg(Color::Blue)
+                .fg(self.palette.selection_fg)
+                .bg(self.palette.selection_bg)
                 .add_modifier(Modifier::BOLD)
         }
     }
@@ -143,7 +342,7 @@ impl Theme {
             Style::default().add_modifier(Modifier::BOLD)
         } else {
             Style::default()
-                .fg(Color::Yellow)
+                .fg(self.palette.warning)
                 .add_modifier(Modifier::BOLD)
         }
     }
@@ -152,7 +351,7 @@ impl Theme {
         if !self.has_color() {
             Style::default()
         } else {
-            Style::default().fg(Color::White)
+            Style::default().fg(self.palette.fg)
         }
     }
 
@@ -160,20 +359,22 @@ impl Theme {
         if !self.has_color() {
             Style::default().add_modifier(Modifier::REVERSED)
         } else {
-            Style::default().fg(Color::Black).bg(Color::White)
+            // Inverted bar: dark text on light bar (dark mode), and the
+            // reverse in light mode. selection_fg / bg_alt are mirror images
+            // across the two palettes, giving correct contrast in both.
+            let mut style = Style::default().fg(self.palette.selection_fg);
+            if let Some(bg) = self.palette.bg_alt {
+                style = style.bg(bg);
+            }
+            style
         }
     }
 
     pub fn help_bar(&self) -> Style {
         if !self.has_color() {
             Style::default().add_modifier(Modifier::DIM)
-        } else if self.use_256_colors() {
-            Style::default().fg(Color::DarkGray)
         } else {
-            // 8-color: use dim modifier with white
-            Style::default()
-                .fg(Color::White)
-                .add_modifier(Modifier::DIM)
+            Style::default().fg(self.palette.accent_dim)
         }
     }
 
@@ -181,7 +382,9 @@ impl Theme {
         if !self.has_color() {
             Style::default().add_modifier(Modifier::BOLD)
         } else {
-            Style::default().fg(Color::Red).add_modifier(Modifier::BOLD)
+            Style::default()
+                .fg(self.palette.error)
+                .add_modifier(Modifier::BOLD)
         }
     }
 
@@ -190,7 +393,7 @@ impl Theme {
             Style::default().add_modifier(Modifier::UNDERLINED)
         } else {
             Style::default()
-                .fg(Color::Green)
+                .fg(self.palette.success)
                 .add_modifier(Modifier::BOLD)
         }
     }
@@ -198,10 +401,8 @@ impl Theme {
     pub fn border_style(&self) -> Style {
         if !self.has_color() {
             Style::default()
-        } else if self.use_256_colors() {
-            Style::default().fg(Color::Gray)
         } else {
-            Style::default().fg(Color::White)
+            Style::default().fg(self.palette.border)
         }
     }
 
@@ -212,7 +413,7 @@ impl Theme {
             Style::default().add_modifier(Modifier::BOLD)
         } else {
             Style::default()
-                .fg(Color::Cyan)
+                .fg(self.palette.border_focused)
                 .add_modifier(Modifier::BOLD)
         }
     }
@@ -222,12 +423,8 @@ impl Theme {
     pub fn border_unfocused(&self) -> Style {
         if !self.has_color() {
             Style::default().add_modifier(Modifier::DIM)
-        } else if self.use_256_colors() {
-            Style::default().fg(Color::DarkGray)
         } else {
-            Style::default()
-                .fg(Color::White)
-                .add_modifier(Modifier::DIM)
+            Style::default().fg(self.palette.accent_dim)
         }
     }
 
@@ -235,22 +432,18 @@ impl Theme {
     pub fn gate_not_run(&self) -> Style {
         if !self.has_color() {
             Style::default().add_modifier(Modifier::DIM)
-        } else if self.use_256_colors() {
-            Style::default().fg(Color::DarkGray)
         } else {
-            Style::default()
-                .fg(Color::White)
-                .add_modifier(Modifier::DIM)
+            Style::default().fg(self.palette.accent_dim)
         }
     }
 
-    /// Style for validation gate status: Running (yellow).
+    /// Style for validation gate status: Running (warning/yellow).
     pub fn gate_running(&self) -> Style {
         if !self.has_color() {
             Style::default().add_modifier(Modifier::BOLD)
         } else {
             Style::default()
-                .fg(Color::Yellow)
+                .fg(self.palette.warning)
                 .add_modifier(Modifier::BOLD)
         }
     }
@@ -260,7 +453,7 @@ impl Theme {
         if !self.has_color() {
             Style::default()
         } else {
-            Style::default().fg(Color::Green)
+            Style::default().fg(self.palette.success)
         }
     }
 
@@ -269,17 +462,19 @@ impl Theme {
         if !self.has_color() {
             Style::default().add_modifier(Modifier::BOLD)
         } else {
-            Style::default().fg(Color::Red).add_modifier(Modifier::BOLD)
+            Style::default()
+                .fg(self.palette.error)
+                .add_modifier(Modifier::BOLD)
         }
     }
 
-    /// Style for validation gate status: TimedOut (magenta).
+    /// Style for validation gate status: TimedOut (info/magenta).
     pub fn gate_timed_out(&self) -> Style {
         if !self.has_color() {
             Style::default().add_modifier(Modifier::BOLD)
         } else {
             Style::default()
-                .fg(Color::Magenta)
+                .fg(self.palette.info)
                 .add_modifier(Modifier::BOLD)
         }
     }
@@ -289,7 +484,9 @@ impl Theme {
         if !self.has_color() {
             Style::default().add_modifier(Modifier::REVERSED)
         } else {
-            Style::default().fg(Color::Black).bg(Color::Cyan)
+            Style::default()
+                .fg(self.palette.selection_fg)
+                .bg(self.palette.accent)
         }
     }
 
@@ -298,7 +495,7 @@ impl Theme {
         if !self.has_color() {
             Style::default()
         } else {
-            Style::default().fg(Color::Cyan)
+            Style::default().fg(self.palette.accent)
         }
     }
 
@@ -306,12 +503,8 @@ impl Theme {
     pub fn sparkline_empty(&self) -> Style {
         if !self.has_color() {
             Style::default().add_modifier(Modifier::DIM)
-        } else if self.use_256_colors() {
-            Style::default().fg(Color::DarkGray)
         } else {
-            Style::default()
-                .fg(Color::White)
-                .add_modifier(Modifier::DIM)
+            Style::default().fg(self.palette.accent_dim)
         }
     }
 
@@ -321,7 +514,7 @@ impl Theme {
             Style::default().add_modifier(Modifier::BOLD)
         } else {
             Style::default()
-                .fg(Color::Cyan)
+                .fg(self.palette.accent)
                 .add_modifier(Modifier::BOLD)
         }
     }
@@ -332,7 +525,7 @@ impl Theme {
             Style::default().add_modifier(Modifier::BOLD)
         } else {
             Style::default()
-                .fg(Color::Yellow)
+                .fg(self.palette.warning)
                 .add_modifier(Modifier::BOLD)
         }
     }
@@ -341,10 +534,10 @@ impl Theme {
     pub fn completion_highlight(&self) -> Style {
         if !self.has_color() {
             Style::default().add_modifier(Modifier::REVERSED)
-        } else if self.use_256_colors() {
-            Style::default().fg(Color::Black).bg(Color::LightGreen)
         } else {
-            Style::default().fg(Color::Black).bg(Color::Green)
+            Style::default()
+                .fg(self.palette.selection_fg)
+                .bg(self.palette.success)
         }
     }
 
@@ -353,7 +546,7 @@ impl Theme {
         if !self.has_color() {
             Style::default()
         } else {
-            Style::default().fg(Color::White)
+            Style::default().fg(self.palette.fg)
         }
     }
 }
@@ -361,6 +554,7 @@ impl Theme {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use proptest::prelude::*;
 
     #[test]
     fn no_color_mode_uses_no_fg_color() {
@@ -379,13 +573,12 @@ mod tests {
     }
 
     #[test]
-    fn eight_color_mode_uses_basic_colors() {
+    fn eight_color_mode_has_colors() {
         let theme = Theme::with_color_support(ColorSupport::Basic8);
-        // 8-color mode should still have colors
         assert!(theme.sidebar_style().fg.is_some());
         assert!(theme.list_selected().bg.is_some());
-        // list_selected uses Blue (basic) instead of LightBlue (256)
-        assert_eq!(theme.list_selected().bg, Some(Color::Blue));
+        // Dark palette (default) selection background.
+        assert_eq!(theme.list_selected().bg, Some(Color::LightBlue));
     }
 
     #[test]
@@ -393,7 +586,6 @@ mod tests {
         let theme = Theme::with_color_support(ColorSupport::TrueColor256);
         let focused = theme.border_focused();
         let unfocused = theme.border_unfocused();
-        // Focused should be visually distinct
         assert_ne!(focused.fg, unfocused.fg);
     }
 
@@ -402,7 +594,6 @@ mod tests {
         let theme = Theme::with_color_support(ColorSupport::None);
         let focused = theme.border_focused();
         let unfocused = theme.border_unfocused();
-        // In no-color mode, focused uses BOLD, unfocused uses DIM
         assert!(focused.add_modifier.contains(Modifier::BOLD));
         assert!(unfocused.add_modifier.contains(Modifier::DIM));
     }
@@ -414,7 +605,7 @@ mod tests {
 
     #[test]
     fn theme_deterministic_same_support_level() {
-        // Requirement 18.1: same inputs produce same styles
+        // Requirement 35.8: same inputs produce same styles.
         let theme1 = Theme::with_color_support(ColorSupport::TrueColor256);
         let theme2 = Theme::with_color_support(ColorSupport::TrueColor256);
         assert_eq!(theme1.sidebar_style(), theme2.sidebar_style());
@@ -445,9 +636,183 @@ mod tests {
     }
 
     #[test]
-    fn help_bar_8color_uses_dim() {
-        let theme = Theme::with_color_support(ColorSupport::Basic8);
+    fn no_color_help_bar_uses_dim() {
+        let theme = Theme::with_color_support(ColorSupport::None);
         let style = theme.help_bar();
         assert!(style.add_modifier.contains(Modifier::DIM));
+    }
+
+    // -----------------------------------------------------------------------
+    // Task 15.4 — theme detection + palette tests (Requirement 35)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn classify_falls_back_to_dark_when_detection_fails() {
+        // terminal-light failure (None luma) + no COLORFGBG → Dark (Req 35.2).
+        assert_eq!(classify_theme(None, None), ThemeMode::Dark);
+    }
+
+    #[test]
+    fn classify_uses_luma_threshold() {
+        // luma > 0.6 → Light, else Dark (Req 35.1). COLORFGBG ignored when
+        // luma is present.
+        assert_eq!(classify_theme(Some(0.9), Some("15;0")), ThemeMode::Light);
+        assert_eq!(classify_theme(Some(0.61), None), ThemeMode::Light);
+        assert_eq!(classify_theme(Some(0.6), None), ThemeMode::Dark);
+        assert_eq!(classify_theme(Some(0.1), Some("0;15")), ThemeMode::Dark);
+    }
+
+    #[test]
+    fn colorfgbg_parsing() {
+        // "0;15" → bg 15 (≥ 7) → Light; "15;0" → bg 0 → Dark (Req 35.2).
+        assert_eq!(parse_colorfgbg("0;15"), Some(ThemeMode::Light));
+        assert_eq!(parse_colorfgbg("15;0"), Some(ThemeMode::Dark));
+        // Three-field form `fg;default;bg` — last field is the background.
+        assert_eq!(parse_colorfgbg("15;default;0"), Some(ThemeMode::Dark));
+        assert_eq!(parse_colorfgbg("0;default;15"), Some(ThemeMode::Light));
+        // Boundary: index 7 counts as Light.
+        assert_eq!(parse_colorfgbg("0;7"), Some(ThemeMode::Light));
+        assert_eq!(parse_colorfgbg("0;6"), Some(ThemeMode::Dark));
+        // Missing / unparseable → None (caller falls back).
+        assert_eq!(parse_colorfgbg(""), None);
+        assert_eq!(parse_colorfgbg("not;a;number"), None);
+    }
+
+    #[test]
+    fn colorfgbg_used_when_luma_missing() {
+        assert_eq!(classify_theme(None, Some("0;15")), ThemeMode::Light);
+        assert_eq!(classify_theme(None, Some("15;0")), ThemeMode::Dark);
+        // Unparseable COLORFGBG with no luma → Dark fallback.
+        assert_eq!(classify_theme(None, Some("garbage")), ThemeMode::Dark);
+    }
+
+    #[test]
+    fn resolve_theme_explicit_overrides_detection() {
+        // Explicit flags ignore detection entirely (Req 35.3).
+        assert_eq!(resolve_theme(ThemePreference::Dark, false), ThemeMode::Dark);
+        assert_eq!(resolve_theme(ThemePreference::Light, false), ThemeMode::Light);
+        assert_eq!(resolve_theme(ThemePreference::Dark, true), ThemeMode::Dark);
+        assert_eq!(resolve_theme(ThemePreference::Light, true), ThemeMode::Light);
+    }
+
+    #[test]
+    fn resolve_theme_auto_headless_defaults_dark() {
+        // Headless must not probe the terminal — Auto → Dark (Req 35.9).
+        assert_eq!(resolve_theme(ThemePreference::Auto, true), ThemeMode::Dark);
+    }
+
+    #[test]
+    fn light_mode_uses_light_palette_colors() {
+        // Req 35.5: Light mode + colour support returns light palette colours.
+        let theme = Theme::with_color_support_mode(ColorSupport::TrueColor256, ThemeMode::Light);
+        assert_eq!(theme.mode, ThemeMode::Light);
+        assert_eq!(theme.sidebar_style().fg, Some(Color::Black));
+        assert_eq!(theme.border_focused().fg, Some(Color::Blue));
+        assert_eq!(theme.list_selected().bg, Some(Color::Blue));
+    }
+
+    #[test]
+    fn dark_mode_uses_dark_palette_colors() {
+        // Req 35.4: Dark mode + colour support returns dark palette colours.
+        let theme = Theme::with_color_support_mode(ColorSupport::TrueColor256, ThemeMode::Dark);
+        assert_eq!(theme.mode, ThemeMode::Dark);
+        assert_eq!(theme.sidebar_style().fg, Some(Color::White));
+        assert_eq!(theme.border_focused().fg, Some(Color::Cyan));
+        assert_eq!(theme.list_selected().bg, Some(Color::LightBlue));
+    }
+
+    #[test]
+    fn no_color_ignores_mode() {
+        // Req 35.7: ColorSupport::None emits no colours regardless of mode.
+        for mode in [ThemeMode::Dark, ThemeMode::Light] {
+            let theme = Theme::with_color_support_mode(ColorSupport::None, mode);
+            assert_eq!(theme.sidebar_style().fg, None);
+            assert_eq!(theme.list_selected().fg, None);
+            assert_eq!(theme.list_selected().bg, None);
+            assert_eq!(theme.border_focused().fg, None);
+            assert_eq!(theme.gate_passed().fg, None);
+        }
+    }
+
+    #[test]
+    fn runtime_toggle_flips_mode_and_styles() {
+        // Req 35.6: toggling flips the mode and produces different output.
+        let mut theme = Theme::with_color_support_mode(ColorSupport::TrueColor256, ThemeMode::Dark);
+        let dark_fg = theme.sidebar_style().fg;
+        let dark_border = theme.border_focused().fg;
+        theme.toggle_mode();
+        assert_eq!(theme.mode, ThemeMode::Light);
+        assert_ne!(theme.sidebar_style().fg, dark_fg);
+        assert_ne!(theme.border_focused().fg, dark_border);
+        // Toggling back restores the original.
+        theme.toggle_mode();
+        assert_eq!(theme.mode, ThemeMode::Dark);
+        assert_eq!(theme.sidebar_style().fg, dark_fg);
+        assert_eq!(theme.border_focused().fg, dark_border);
+    }
+
+    fn all_styles(theme: &Theme) -> Vec<Style> {
+        vec![
+            theme.sidebar_style(),
+            theme.sidebar_selected(),
+            theme.list_item(),
+            theme.list_selected(),
+            theme.detail_key(),
+            theme.detail_value(),
+            theme.status_bar(),
+            theme.help_bar(),
+            theme.error_style(),
+            theme.search_style(),
+            theme.border_style(),
+            theme.border_focused(),
+            theme.border_unfocused(),
+            theme.gate_not_run(),
+            theme.gate_running(),
+            theme.gate_passed(),
+            theme.gate_failed(),
+            theme.gate_timed_out(),
+            theme.filter_chip(),
+            theme.sparkline_filled(),
+            theme.sparkline_empty(),
+            theme.help_overlay_title(),
+            theme.help_overlay_section(),
+            theme.completion_highlight(),
+            theme.completion_normal(),
+        ]
+    }
+
+    fn mode_strategy() -> impl Strategy<Value = ThemeMode> {
+        prop_oneof![Just(ThemeMode::Dark), Just(ThemeMode::Light)]
+    }
+
+    fn support_strategy() -> impl Strategy<Value = ColorSupport> {
+        prop_oneof![
+            Just(ColorSupport::TrueColor256),
+            Just(ColorSupport::Basic8),
+            Just(ColorSupport::None),
+        ]
+    }
+
+    proptest! {
+        /// Property 34: for any (ThemeMode, ColorSupport), every style method
+        /// returns a valid (non-panicking) Style, and two themes built from the
+        /// same inputs produce bit-identical output (Req 35.8).
+        #[test]
+        fn prop34_theme_styles_deterministic(
+            mode in mode_strategy(),
+            support in support_strategy(),
+        ) {
+            let a = Theme::with_color_support_mode(support, mode);
+            let b = Theme::with_color_support_mode(support, mode);
+            // Constructing + calling every method must not panic, and must match.
+            prop_assert_eq!(all_styles(&a), all_styles(&b));
+            // None support never emits a foreground/background colour.
+            if support == ColorSupport::None {
+                for style in all_styles(&a) {
+                    prop_assert_eq!(style.fg, None);
+                    prop_assert_eq!(style.bg, None);
+                }
+            }
+        }
     }
 }

--- a/tools/vfa-tui/src/ui/theme.rs
+++ b/tools/vfa-tui/src/ui/theme.rs
@@ -88,7 +88,9 @@ pub enum ThemePreference {
 /// Returns `None` when no field is numeric, so the caller can fall through to
 /// the next heuristic.
 pub fn parse_colorfgbg(value: &str) -> Option<ThemeMode> {
-    let bg_idx: u8 = value.rsplit(';').find_map(|f| f.trim().parse::<u8>().ok())?;
+    let bg_idx: u8 = value
+        .rsplit(';')
+        .find_map(|f| f.trim().parse::<u8>().ok())?;
     Some(if bg_idx >= 7 {
         ThemeMode::Light
     } else {
@@ -771,7 +773,7 @@ mod tests {
         // numeric field rather than discarding it.
         assert_eq!(parse_colorfgbg("15;"), Some(ThemeMode::Light));
         assert_eq!(parse_colorfgbg("0;15;"), Some(ThemeMode::Light));
-        // Missing / unparseable → None (caller falls back).
+        // Missing / unparsable → None (caller falls back).
         assert_eq!(parse_colorfgbg(""), None);
         assert_eq!(parse_colorfgbg("not;a;number"), None);
     }
@@ -780,7 +782,7 @@ mod tests {
     fn colorfgbg_used_when_luma_missing() {
         assert_eq!(classify_theme(None, Some("0;15")), ThemeMode::Light);
         assert_eq!(classify_theme(None, Some("15;0")), ThemeMode::Dark);
-        // Unparseable COLORFGBG with no luma → Dark fallback.
+        // Unparsable COLORFGBG with no luma → Dark fallback.
         assert_eq!(classify_theme(None, Some("garbage")), ThemeMode::Dark);
     }
 
@@ -788,9 +790,15 @@ mod tests {
     fn resolve_theme_explicit_overrides_detection() {
         // Explicit flags ignore detection entirely (Req 35.3).
         assert_eq!(resolve_theme(ThemePreference::Dark, false), ThemeMode::Dark);
-        assert_eq!(resolve_theme(ThemePreference::Light, false), ThemeMode::Light);
+        assert_eq!(
+            resolve_theme(ThemePreference::Light, false),
+            ThemeMode::Light
+        );
         assert_eq!(resolve_theme(ThemePreference::Dark, true), ThemeMode::Dark);
-        assert_eq!(resolve_theme(ThemePreference::Light, true), ThemeMode::Light);
+        assert_eq!(
+            resolve_theme(ThemePreference::Light, true),
+            ThemeMode::Light
+        );
     }
 
     #[test]

--- a/tools/vfa-tui/src/ui/theme.rs
+++ b/tools/vfa-tui/src/ui/theme.rs
@@ -80,14 +80,15 @@ pub enum ThemePreference {
 
 /// Parse the `COLORFGBG` environment variable value into a [`ThemeMode`].
 ///
-/// Format is `fg;bg` (some terminals emit `fg;default;bg`); the **last**
-/// field is the background ANSI colour index. A background index ≥ 7 means a
-/// light terminal (Req 35.2). Returns `None` when the value is empty or the
-/// background field cannot be parsed, so the caller can fall through to the
-/// next heuristic.
+/// Format is `fg;bg` (some terminals emit `fg;default;bg`); the background
+/// ANSI colour index is the **last numeric field**. A background index ≥ 7
+/// means a light terminal (Req 35.2). We scan fields from the right and take
+/// the first that parses as a `u8`, so a stray trailing separator (e.g.
+/// `"15;"`, seen on some xterm variants) does not discard a valid index.
+/// Returns `None` when no field is numeric, so the caller can fall through to
+/// the next heuristic.
 pub fn parse_colorfgbg(value: &str) -> Option<ThemeMode> {
-    let bg_str = value.rsplit(';').next()?.trim();
-    let bg_idx: u8 = bg_str.parse().ok()?;
+    let bg_idx: u8 = value.rsplit(';').find_map(|f| f.trim().parse::<u8>().ok())?;
     Some(if bg_idx >= 7 {
         ThemeMode::Light
     } else {
@@ -237,6 +238,56 @@ fn palette_for(mode: ThemeMode) -> Palette {
     }
 }
 
+/// Map a colour that falls outside the basic 8-colour ANSI set to a safe basic
+/// equivalent. Bright (`Light*`) and 256-indexed colours may not render on a
+/// strict 8-colour terminal — e.g. a `LightBlue` selection background can be
+/// dropped entirely, leaving the selected row with no highlight. Basic colours
+/// pass through unchanged.
+fn to_basic8(c: Color) -> Color {
+    match c {
+        Color::LightRed => Color::Red,
+        Color::LightGreen => Color::Green,
+        Color::LightYellow => Color::Yellow,
+        Color::LightBlue => Color::Blue,
+        Color::LightMagenta => Color::Magenta,
+        Color::LightCyan => Color::Cyan,
+        Color::Indexed(208) => Color::Yellow, // light-mode warning orange → nearest basic
+        other => other,
+    }
+}
+
+/// Downgrade every field of a palette to basic colours (for `Basic8` terminals).
+fn downgrade_palette(p: Palette) -> Palette {
+    Palette {
+        fg: to_basic8(p.fg),
+        fg_dim: to_basic8(p.fg_dim),
+        bg: p.bg.map(to_basic8),
+        bg_alt: p.bg_alt.map(to_basic8),
+        accent: to_basic8(p.accent),
+        accent_dim: to_basic8(p.accent_dim),
+        success: to_basic8(p.success),
+        warning: to_basic8(p.warning),
+        error: to_basic8(p.error),
+        info: to_basic8(p.info),
+        border: to_basic8(p.border),
+        border_focused: to_basic8(p.border_focused),
+        selection_fg: to_basic8(p.selection_fg),
+        selection_bg: to_basic8(p.selection_bg),
+    }
+}
+
+/// Build the active palette for a `(mode, color_support)` pair, downgrading
+/// bright/256 colours to basic ones when the terminal only supports 8 colours.
+/// Deterministic in both inputs (Req 35.8).
+fn build_palette(mode: ThemeMode, color_support: ColorSupport) -> Palette {
+    let palette = palette_for(mode);
+    if color_support == ColorSupport::Basic8 {
+        downgrade_palette(palette)
+    } else {
+        palette
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Theme
 // ---------------------------------------------------------------------------
@@ -264,7 +315,7 @@ impl Theme {
             no_color,
             color_support,
             mode,
-            palette: palette_for(mode),
+            palette: build_palette(mode, color_support),
         }
     }
 
@@ -280,7 +331,7 @@ impl Theme {
             no_color: color_support == ColorSupport::None,
             color_support,
             mode,
-            palette: palette_for(mode),
+            palette: build_palette(mode, color_support),
         }
     }
 
@@ -291,7 +342,7 @@ impl Theme {
             ThemeMode::Dark => ThemeMode::Light,
             ThemeMode::Light => ThemeMode::Dark,
         };
-        self.palette = palette_for(self.mode);
+        self.palette = build_palette(self.mode, self.color_support);
     }
 
     /// Whether any colour output is enabled.
@@ -577,8 +628,51 @@ mod tests {
         let theme = Theme::with_color_support(ColorSupport::Basic8);
         assert!(theme.sidebar_style().fg.is_some());
         assert!(theme.list_selected().bg.is_some());
-        // Dark palette (default) selection background.
-        assert_eq!(theme.list_selected().bg, Some(Color::LightBlue));
+    }
+
+    #[test]
+    fn basic8_downgrades_bright_selection_bg() {
+        // Regression: the dark palette's selection background is LightBlue
+        // (ANSI bright), which can be dropped on a strict 8-colour terminal,
+        // making the selected row invisible. On Basic8 it must downgrade to a
+        // basic colour. 256/true-colour keeps the brighter LightBlue.
+        let basic8 = Theme::with_color_support_mode(ColorSupport::Basic8, ThemeMode::Dark);
+        assert_eq!(basic8.list_selected().bg, Some(Color::Blue));
+
+        let rich = Theme::with_color_support_mode(ColorSupport::TrueColor256, ThemeMode::Dark);
+        assert_eq!(rich.list_selected().bg, Some(Color::LightBlue));
+    }
+
+    #[test]
+    fn basic8_downgrades_indexed_warning() {
+        // Light-mode warning is Indexed(208) (orange); not representable on a
+        // basic-8 terminal → must downgrade to a basic colour.
+        let basic8 = Theme::with_color_support_mode(ColorSupport::Basic8, ThemeMode::Light);
+        assert_eq!(basic8.detail_key().fg, Some(Color::Yellow));
+
+        let rich = Theme::with_color_support_mode(ColorSupport::TrueColor256, ThemeMode::Light);
+        assert_eq!(rich.detail_key().fg, Some(Color::Indexed(208)));
+    }
+
+    #[test]
+    fn dark_and_light_palettes_differ_in_color_mode() {
+        // Guards against palette_for / build_palette accidentally returning the
+        // same palette for both modes (which the determinism property alone
+        // would NOT catch).
+        for support in [ColorSupport::TrueColor256, ColorSupport::Basic8] {
+            let dark = Theme::with_color_support_mode(support, ThemeMode::Dark);
+            let light = Theme::with_color_support_mode(support, ThemeMode::Light);
+            assert_ne!(
+                dark.sidebar_style().fg,
+                light.sidebar_style().fg,
+                "dark and light must differ for {support:?}"
+            );
+            assert_ne!(
+                dark.border_focused().fg,
+                light.border_focused().fg,
+                "dark and light accents must differ for {support:?}"
+            );
+        }
     }
 
     #[test]
@@ -673,6 +767,10 @@ mod tests {
         // Boundary: index 7 counts as Light.
         assert_eq!(parse_colorfgbg("0;7"), Some(ThemeMode::Light));
         assert_eq!(parse_colorfgbg("0;6"), Some(ThemeMode::Dark));
+        // Trailing separator (some xterm variants) — fall back to the last
+        // numeric field rather than discarding it.
+        assert_eq!(parse_colorfgbg("15;"), Some(ThemeMode::Light));
+        assert_eq!(parse_colorfgbg("0;15;"), Some(ThemeMode::Light));
         // Missing / unparseable → None (caller falls back).
         assert_eq!(parse_colorfgbg(""), None);
         assert_eq!(parse_colorfgbg("not;a;number"), None);

--- a/tools/vfa-tui/tests/integration/headless_persistence.rs
+++ b/tools/vfa-tui/tests/integration/headless_persistence.rs
@@ -27,6 +27,7 @@ fn make_cli(index_path: &str) -> Cli {
         log_file: None,
         log_level: LogLevel::Info,
         no_color: true,
+        theme: vfa_tui::ui::theme::ThemePreference::Auto,
         registry: "/nonexistent/workspaces.toml".to_string(),
         policies: "/nonexistent/policies.toml".to_string(),
         index_path: index_path.to_string(),

--- a/tools/vfa-tui/tests/integration/tui_tabs.rs
+++ b/tools/vfa-tui/tests/integration/tui_tabs.rs
@@ -11,7 +11,7 @@ use ratatui::Terminal;
 use vfa_tui::app::App;
 use vfa_tui::catalog::store::CatalogStore;
 use vfa_tui::ui::nav::Tab;
-use vfa_tui::ui::theme::Theme;
+use vfa_tui::ui::theme::{Theme, ThemeMode};
 
 fn fixtures_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))
@@ -29,7 +29,7 @@ fn app() -> App {
 fn render_tab_text(tab: Tab) -> String {
     let mut app = app();
     app.nav.current_tab = tab;
-    let theme = Theme::new(true);
+    let theme = Theme::new(true, ThemeMode::Dark);
 
     let backend = TestBackend::new(120, 30);
     let mut terminal = Terminal::new(backend).unwrap();

--- a/tools/vfa-tui/tests/property/ui.rs
+++ b/tools/vfa-tui/tests/property/ui.rs
@@ -8,7 +8,7 @@ use uuid::Uuid;
 use vfa_tui::app::App;
 use vfa_tui::catalog::store::CatalogStore;
 use vfa_tui::models::{Agent, AgentType, ExecutionTier, Harness, Lifecycle, Provider, SourceType};
-use vfa_tui::ui::theme::Theme;
+use vfa_tui::ui::theme::{Theme, ThemeMode};
 use vfa_tui::ui::widgets::detail::{render_agent_detail, AGENT_DETAIL_REQUIRED_LABELS};
 
 fn arbitrary_agent(
@@ -92,7 +92,7 @@ proptest! {
 
         let backend = TestBackend::new(120, 40);
         let mut terminal = Terminal::new(backend).unwrap();
-        let theme = Theme::new(false);
+        let theme = Theme::new(false, ThemeMode::Dark);
 
         terminal.draw(|frame| {
             let area = Rect::new(0, 0, 120, 40);


### PR DESCRIPTION
## Summary

- Implements Task 15 (subtasks 15.1–15.4) from `.kiro/specs/rust-tui-v2`: light/dark mode with terminal system detection, CLI flag, runtime toggle, and headless safety
- Adds `ThemePreference {Auto, Dark, Light}` CLI `--theme` flag parsed by clap; `ThemeMode {Dark, Light}` resolved at startup via OSC 11 luma probe (`terminal-light` crate) with `COLORFGBG` fallback
- Introduces semantic `Palette` struct (14 fields), `dark_palette()`/`light_palette()`, Basic8 downgrade layer (`to_basic8`/`downgrade_palette`/`build_palette`), and `Theme::toggle_mode()` bound to `t` keybinding
- Code-review pass fixed Basic8 terminal regression (LightBlue→Blue), `parse_colorfgbg` trailing-semicolon edge case, and added 14 new tests (Basic8 guards, dark≠light divergence, CLI parse variants)

## Test plan

- [x] `cargo test -p vfa-tui` — 1,748 tests pass, 0 fail
- [x] `cargo clippy -p vfa-tui -- -D warnings` — clean (crate has `#[deny(warnings)]`)
- [x] CLI: `vfa-tui --theme light`, `--theme dark`, `--theme auto` all parse correctly
- [x] `t` keybinding toggles theme mode in normal view; suppressed in search mode
- [x] Headless mode always resolves to Dark (no OSC probe)
- [x] Basic8 terminals receive downgraded palette (no bright/256-indexed colors)
- [x] `detect_system_theme()` falls back gracefully when terminal doesn't support OSC 11

https://claude.ai/code/session_0159VsqQD75QXKRoENpxFjEa

---
_Generated by [Claude Code](https://claude.ai/code/session_0159VsqQD75QXKRoENpxFjEa)_