### PR TITLE
ci(release): trigger on develop for alpha prereleases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,11 @@ name: Release
 on:
   push:
     branches:
+      # master → stable releases; develop → alpha prereleases.
+      # Both are configured as release channels in .releaserc.js
+      # (develop carries `prerelease: "alpha"`).
       - master
+      - develop
   # Manual dispatch for forensics/recovery: lets a maintainer re-run the
   # release pipeline without producing a no-op commit. semantic-release
   # is idempotent — if the latest tag already covers HEAD it logs


### PR DESCRIPTION
## What

Add `develop` to the release workflow's `on.push.branches` so develop merges automatically publish **alpha prereleases**, while `master` continues to publish **stable releases**.

## Why

`develop` is already configured as a semantic-release prerelease channel in `.releaserc.js`:

```js
branches: [
  "master",
  { name: "develop", prerelease: "alpha" },
],
```

…but `.github/workflows/release.yml` only triggered on pushes to `master`:

```yaml
on:
  push:
    branches:
      - master
```

So every alpha cut required a manual `workflow_dispatch`. This realigns the workflow trigger with the configured release channels:

- **`develop` → alpha prereleases** (`vX.Y.Z-alpha.N`)
- **`master` → stable releases** (`vX.Y.Z`)

## Change

```yaml
on:
  push:
    branches:
      - master
      - develop
```

## Notes / safety

- semantic-release is idempotent: if the latest tag already covers HEAD it logs "no new version is released", so an extra develop push is a no-op, not a duplicate release.
- The release commit `chore(release): X.Y.Z [skip ci]` carries `[skip ci]`, so the bot's own push back to develop will not re-trigger the workflow (no loop).
- `workflow_dispatch` (dry-run / republish recovery inputs) is retained.
- Asset-integrity manifest regenerated and unchanged — workflow files are not in its tracked set.

## Test plan

- [ ] Merge → push to `develop` triggers the Release job
- [ ] semantic-release computes the next `-alpha.N` and publishes (npm + GitHub Release)
- [ ] A subsequent `chore(release)` commit does **not** re-trigger (verifies `[skip ci]`)

---
_Generated by [Claude Code](https://claude.ai/code/session_015FrcoNnjFR5Mv2R9hLabT5)_