### PR TITLE
fix(release): pass --tag to npm publish for prerelease channels

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -310,8 +310,24 @@ jobs:
             echo "Republish mode: publishing current version $POST_VERSION to npm."
           fi
 
+          # Derive the npm dist-tag from the version's prerelease channel.
+          # npm 11.x REFUSES to publish a prerelease without an explicit --tag
+          # ("You must specify a tag using --tag when publishing a prerelease
+          # version"). Stable releases publish to `latest`; alpha/beta/rc
+          # prereleases publish to their own channel so they never displace
+          # the stable `latest` tag. This mirrors the .releaserc.js prerelease
+          # config (develop → alpha).
+          case "$POST_VERSION" in
+            *-alpha*) NPM_DIST_TAG="alpha" ;;
+            *-beta*)  NPM_DIST_TAG="beta" ;;
+            *-rc*)    NPM_DIST_TAG="rc" ;;
+            *-*)      NPM_DIST_TAG="next" ;;
+            *)        NPM_DIST_TAG="latest" ;;
+          esac
+
           echo "::group::OIDC publish diagnostics"
           echo "Package: @raishin/vanguard-frontier-agentic@$POST_VERSION"
+          echo "npm dist-tag: $NPM_DIST_TAG"
           echo "Bundled npm version: $(npm --version)"
           echo "npx cached npm version: $(npx npm --version 2>/dev/null || echo 'not yet cached')"
           echo "OIDC token available: $([ -n "$ACTIONS_ID_TOKEN_REQUEST_URL" ] && echo yes || echo 'NO — id-token:write may be missing')"
@@ -337,6 +353,7 @@ jobs:
           # environment=npm-deployment-master.
           if ! npx --yes npm@^11.5.1 publish \
                --registry https://registry.npmjs.org \
+               --tag "$NPM_DIST_TAG" \
                --access public \
                --provenance; then
             echo "::error::npm publish failed. Confirm npmjs.com trusted publisher is configured:" \


### PR DESCRIPTION
## Problem

The develop (alpha) release publishes a **prerelease** version (`3.0.0-alpha.2`). The workflow's manual OIDC `npm publish` step failed with:

```
npm error You must specify a tag using --tag when publishing a prerelease version.
```

npm 11.x **refuses to publish a prerelease version without an explicit `--tag`** (so a prerelease can't silently land on `latest`). The publish command had no `--tag`:

```bash
npx --yes npm@^11.5.1 publish \
     --registry https://registry.npmjs.org \
     --access public \
     --provenance
```

This is why **master (stable → `latest`) releases always worked**, but develop's alpha channel failed the moment it reached the real npm publish.

## Symptom chain it resolves

For `3.0.0-alpha.2`, semantic-release created the git tag + GitHub Release successfully, but the npm publish step failed — so npm's `alpha` dist-tag was stuck at `3.0.0-alpha.1`.

## Fix

Derive the dist-tag from the version's prerelease identifier and pass `--tag`:

```bash
case "$POST_VERSION" in
  *-alpha*) NPM_DIST_TAG="alpha" ;;
  *-beta*)  NPM_DIST_TAG="beta" ;;
  *-rc*)    NPM_DIST_TAG="rc" ;;
  *-*)      NPM_DIST_TAG="next" ;;
  *)        NPM_DIST_TAG="latest" ;;
esac
# ...
npx --yes npm@^11.5.1 publish --registry ... --tag "$NPM_DIST_TAG" --access public --provenance
```

- **Stable** (`X.Y.Z`) → `latest` (unchanged behavior).
- **Prereleases** publish to their own channel (`alpha`/`beta`/`rc`/`next`) so they never displace stable `latest`.
- Mirrors `.releaserc.js` (`develop` → `prerelease: "alpha"`).

## Verification plan

After merge, re-run the Release workflow on develop with `republish=true`:
- semantic-release sees `v3.0.0-alpha.2` already tagged → no new commit/tag (no duplicate churn).
- `npm publish --tag alpha` succeeds → npm `alpha` dist-tag advances to `3.0.0-alpha.2`.

## Notes
- Asset-integrity manifest regenerated — unchanged (workflow files aren't in its tracked set).

---
_Generated by [Claude Code](https://claude.ai/code/session_015FrcoNnjFR5Mv2R9hLabT5)_