### PR TITLE
fix(vfa-tui): correct tomllib call in release version check

### DIFF
--- a/.github/workflows/vfa-tui-release.yml
+++ b/.github/workflows/vfa-tui-release.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Verify release tag matches Cargo.toml version
         run: |
-          version=$(python3 -c "import tomllib; print(tomllib.loads(open('Cargo.toml','rb').read())['package']['version'])")
+          version=$(python3 -c "import tomllib; print(tomllib.load(open('Cargo.toml','rb'))['package']['version'])")
           tag="${{ inputs.tag || github.ref_name }}"
           echo "Cargo.toml version: ${version}, tag: ${tag}"
           test "${tag}" = "vfa-tui-v${version}"


### PR DESCRIPTION
## Root cause

The `verify` job's "Verify release tag matches Cargo.toml version" step failed with:

```
TypeError: a bytes-like object is required, not 'str'
```

`tomllib.loads()` expects a **`str`**, but the step passed **bytes** from `open('Cargo.toml','rb').read()`.

## Fix

Use `tomllib.load()` (singular) with the binary file handle — the correct API for reading a TOML file opened in binary mode. Verified locally: outputs `0.1.0`.

This was the next failure after PR #83 fixed the missing `tools/vfa-tui` directory. After merge, re-trigger `vfa-tui Release` via `workflow_dispatch` with `tag: vfa-tui-v0.1.0`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VRZ31oTeTbb5LEdCdVTedK)_