### PR TITLE
fix(vfa-tui): sync Provider enum with current catalog (databricks, microsoft, snowflake)

### DIFF
--- a/tools/vfa-tui/src/models/provider.rs
+++ b/tools/vfa-tui/src/models/provider.rs
@@ -38,15 +38,18 @@ pub enum Provider {
     CertManager,
     Cilium,
     Claude,
+    Databricks,
     Falco,
     Fluxcd,
     Istio,
     Kyverno,
     Marketing,
+    Microsoft,
     Nvidia,
     Opentelemetry,
     Prometheus,
     Sigstore,
+    Snowflake,
     Velero,
 }
 


### PR DESCRIPTION
## Root cause

After PR #83 (added `tools/vfa-tui`) and PR #84 (fixed the tomllib call), the `verify` job's **Test** step failed with 17 test failures, all cascading from:

```
unknown variant `microsoft`, expected one of `aws`, `azure`, ...
```

The vfa-tui unit tests load the **real** catalog (`catalog/agents.json`, `catalog/skills.json`). Master is now at v2.12.0 and the catalog gained three providers — `databricks`, `microsoft`, `snowflake` — after the vfa-tui feature branch was cut. The strict `Provider` enum rejected them, catalog deserialization failed, and every test depending on a populated catalog failed.

## Fix

Add the three missing variants to the `Provider` enum. This matches the enum's own documented pattern: *"additional variants are included to support the full catalog which has grown beyond the original spec."*

## Verification (local)

- `cargo test` — **742 lib + 10 + 93 integration + 173 property** tests pass, 0 failures (was 725 pass / 17 fail)
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo fmt -- --check` — clean

After merge, re-trigger `vfa-tui Release` via `workflow_dispatch` with `tag: vfa-tui-v0.1.0`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VRZ31oTeTbb5LEdCdVTedK)_