### PR TITLE
chore(vfa-tui): gitignore stray ~ test artifact dir

### DIFF
--- a/tools/vfa-tui/.gitignore
+++ b/tools/vfa-tui/.gitignore
@@ -1,1 +1,4 @@
 /target/
+
+# Stray artifact dir created when tests resolve a literal "~" HOME path
+/~/


### PR DESCRIPTION
Closing — this targeted master, but vfa-tui is being removed from master (#87). The gitignore fix is folded into #88 (into develop). The failing codespell check here was a false positive anyway (`serde::ser` is valid Rust).