### PR TITLE
fix(vfa-tui): sync provider enum + gitignore + release version-check (into develop)

### DIFF
--- a/.github/workflows/vfa-tui-release.yml
+++ b/.github/workflows/vfa-tui-release.yml
@@ -37,12 +37,9 @@ jobs:
 
       - name: Verify release tag matches Cargo.toml version
         run: |
-          version=$(python3 - <<'PY'
-          import pathlib, tomllib
-          print(tomllib.loads(pathlib.Path("Cargo.toml").read_text())["package"]["version"])
-          PY
-          )
-          tag="${{ github.event.inputs.tag || github.ref_name }}"
+          version=$(python3 -c "import tomllib; print(tomllib.load(open('Cargo.toml','rb'))['package']['version'])")
+          tag="${{ inputs.tag || github.ref_name }}"
+          echo "Cargo.toml version: ${version}, tag: ${tag}"
           test "${tag}" = "vfa-tui-v${version}"
 
       - name: Format check

--- a/tools/vfa-tui/.gitignore
+++ b/tools/vfa-tui/.gitignore
@@ -1,1 +1,4 @@
 /target/
+
+# Stray artifact dir created when tests resolve a literal "~" HOME path
+/~/

--- a/tools/vfa-tui/src/models/provider.rs
+++ b/tools/vfa-tui/src/models/provider.rs
@@ -38,15 +38,18 @@ pub enum Provider {
     CertManager,
     Cilium,
     Claude,
+    Databricks,
     Falco,
     Fluxcd,
     Istio,
     Kyverno,
     Marketing,
+    Microsoft,
     Nvidia,
     Opentelemetry,
     Prometheus,
     Sigstore,
+    Snowflake,
     Velero,
 }
 


### PR DESCRIPTION
Closing — consolidated into **#89** so there's a single PR into develop. The provider-enum sync and `/~/` gitignore from this PR are now part of #89 (along with the release-plz automation). No work lost.