### PR TITLE
feat(vfa-tui): release-plz automation + crate fixes (single PR into develop)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,3 +34,17 @@ updates:
     open-pull-requests-limit: 5
     reviewers:
       - Raishin
+
+  - package-ecosystem: cargo
+    directory: /tools/vfa-tui
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "chore(cargo)"
+    groups:
+      cargo:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 5
+    reviewers:
+      - Raishin

--- a/.github/workflows/vfa-tui-ci.yml
+++ b/.github/workflows/vfa-tui-ci.yml
@@ -42,6 +42,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
+          toolchain: stable
           components: rustfmt, clippy
 
       - uses: Swatinem/rust-cache@bc2d2e71bd35c5549942babaa51a89c586b981d1 # v2.8.1

--- a/.github/workflows/vfa-tui-ci.yml
+++ b/.github/workflows/vfa-tui-ci.yml
@@ -60,13 +60,15 @@ jobs:
 
       # cargo-deny covers advisories (the RustSec DB scan cargo-audit does),
       # licenses, bans, and sources in one tool — no separate cargo-audit step.
-      # Pin a current version: older releases can't parse newer CVSS 4.0
-      # advisories and fail to load the whole advisory DB.
-      - name: Install cargo-deny
-        run: cargo install cargo-deny --version 0.19.9 --locked
-
-      - name: Advisory, license, ban, and source check (cargo deny)
-        run: cargo deny check
+      # Using the prebuilt action means no 2-minute compile and Dependabot
+      # (github-actions ecosystem) auto-bumps the pin.
+      - name: License, advisory, ban, and source check (cargo deny)
+        uses: EmbarkStudios/cargo-deny-action@8a45e1c7c9a95dfae3276e89a553705e40ae45a2 # v2.0.20
+        with:
+          manifest-path: Cargo.toml
+          log-level: warn
+          command: check
+          arguments: --all-features
 
       - name: Publish dry-run (no token, no upload)
         run: cargo publish --dry-run --locked

--- a/.github/workflows/vfa-tui-ci.yml
+++ b/.github/workflows/vfa-tui-ci.yml
@@ -1,100 +1,73 @@
 name: vfa-tui CI
 
+# Pre-release GATE for the vfa-tui crate. Runs on PRs and on develop pushes.
+# Proves the crate is releasable — formatting, lints, tests, license/advisory
+# scans, and a publish dry-run — WITHOUT publishing anything (no registry token,
+# no upload). Real stable releases happen only on master via vfa-tui-release.yml
+# (release-plz). This is the "no publishing when not needed" guarantee on the
+# integration side: develop never touches crates.io.
+
 on:
   pull_request:
     paths:
       - 'tools/vfa-tui/**'
+      - '.github/workflows/vfa-tui-ci.yml'
   push:
-    branches: [master, main]
+    branches: [develop]
     paths:
       - 'tools/vfa-tui/**'
-    tags:
-      - 'vfa-tui-v*'
-
-env:
-  CARGO_TERM_COLOR: always
+      - '.github/workflows/vfa-tui-ci.yml'
 
 permissions:
   contents: read
 
+concurrency:
+  group: vfa-tui-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
 jobs:
-  check:
+  gate:
+    name: Gate
     runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: tools/vfa-tui
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: rustfmt, clippy
-      - uses: Swatinem/rust-cache@v2
+
+      - uses: Swatinem/rust-cache@bc2d2e71bd35c5549942babaa51a89c586b981d1 # v2.8.1
         with:
           workspaces: tools/vfa-tui
+
       - name: Format check
         run: cargo fmt -- --check
-      - name: Clippy
-        run: cargo clippy -- -D warnings
-      - name: Test
-        run: cargo test
-      - name: Build release
-        run: cargo build --release
 
-  release:
-    if: startsWith(github.ref, 'refs/tags/vfa-tui-v')
-    needs: check
-    strategy:
-      matrix:
-        include:
-          - target: x86_64-unknown-linux-gnu
-            os: ubuntu-latest
-          - target: aarch64-unknown-linux-gnu
-            os: ubuntu-latest
-          - target: x86_64-apple-darwin
-            os: macos-latest
-          - target: aarch64-apple-darwin
-            os: macos-latest
-          - target: x86_64-unknown-linux-musl
-            os: ubuntu-latest
-    runs-on: ${{ matrix.os }}
-    defaults:
-      run:
-        working-directory: tools/vfa-tui
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: ${{ matrix.target }}
-      - name: Install cross-compilation tools
-        if: matrix.target == 'aarch64-unknown-linux-gnu'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y gcc-aarch64-linux-gnu
-      - name: Install musl tools
-        if: matrix.target == 'x86_64-unknown-linux-musl'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y musl-tools
-      - name: Verify release tag matches package version
-        run: |
-          version=$(python3 - <<'PY'
-          import pathlib
-          import tomllib
-          print(tomllib.loads(pathlib.Path("Cargo.toml").read_text())["package"]["version"])
-          PY
-          )
-          test "${GITHUB_REF_NAME}" = "vfa-tui-v${version}"
-      - name: Build release binary
-        run: cargo build --release --locked --target ${{ matrix.target }}
-        env:
-          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
-      - name: Generate SBOM
-        run: |
-          cargo install cargo-sbom --version 0.10.0 --locked
-          cargo sbom --output-format spdx_json_2_3 > sbom-${{ matrix.target }}.spdx.json
-      - uses: actions/upload-artifact@v4
-        with:
-          name: vfa-tui-${{ matrix.target }}
-          path: |
-            tools/vfa-tui/target/${{ matrix.target }}/release/vfa-tui
-            tools/vfa-tui/sbom-*.spdx.json
+      - name: Clippy
+        run: cargo clippy --all-targets --locked -- -D warnings
+
+      - name: Test
+        run: cargo test --locked
+
+      - name: Install cargo-deny
+        run: cargo install cargo-deny --version 0.16.4 --locked
+
+      - name: License and advisory check (cargo deny)
+        run: cargo deny check
+
+      - name: Install cargo-audit
+        run: cargo install cargo-audit --locked
+
+      - name: Security advisory scan (cargo audit)
+        run: cargo audit
+
+      - name: Publish dry-run (no token, no upload)
+        run: cargo publish --dry-run --locked

--- a/.github/workflows/vfa-tui-ci.yml
+++ b/.github/workflows/vfa-tui-ci.yml
@@ -61,11 +61,13 @@ jobs:
       # cargo-deny covers advisories (the RustSec DB scan cargo-audit does),
       # licenses, bans, and sources in one tool — no separate cargo-audit step.
       # Using the prebuilt action means no 2-minute compile and Dependabot
-      # (github-actions ecosystem) auto-bumps the pin.
+      # (github-actions ecosystem) auto-bumps the pin. This is a Docker action,
+      # so `defaults.run.working-directory` does NOT apply — manifest-path must
+      # be repo-root-relative, not relative to tools/vfa-tui.
       - name: License, advisory, ban, and source check (cargo deny)
         uses: EmbarkStudios/cargo-deny-action@8a45e1c7c9a95dfae3276e89a553705e40ae45a2 # v2.0.20
         with:
-          manifest-path: Cargo.toml
+          manifest-path: tools/vfa-tui/Cargo.toml
           log-level: warn
           command: check
           arguments: --all-features

--- a/.github/workflows/vfa-tui-ci.yml
+++ b/.github/workflows/vfa-tui-ci.yml
@@ -58,17 +58,15 @@ jobs:
       - name: Test
         run: cargo test --locked
 
+      # cargo-deny covers advisories (the RustSec DB scan cargo-audit does),
+      # licenses, bans, and sources in one tool — no separate cargo-audit step.
+      # Pin a current version: older releases can't parse newer CVSS 4.0
+      # advisories and fail to load the whole advisory DB.
       - name: Install cargo-deny
-        run: cargo install cargo-deny --version 0.16.4 --locked
+        run: cargo install cargo-deny --version 0.19.9 --locked
 
-      - name: License and advisory check (cargo deny)
+      - name: Advisory, license, ban, and source check (cargo deny)
         run: cargo deny check
-
-      - name: Install cargo-audit
-        run: cargo install cargo-audit --locked
-
-      - name: Security advisory scan (cargo audit)
-        run: cargo audit
 
       - name: Publish dry-run (no token, no upload)
         run: cargo publish --dry-run --locked

--- a/.github/workflows/vfa-tui-release.yml
+++ b/.github/workflows/vfa-tui-release.yml
@@ -43,6 +43,8 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: stable
       - uses: Swatinem/rust-cache@bc2d2e71bd35c5549942babaa51a89c586b981d1 # v2.8.1
         with:
           workspaces: tools/vfa-tui
@@ -62,6 +64,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: read   # release-plz needs this to detect the merged release PR
     outputs:
       releases_created: ${{ steps.release-plz.outputs.releases_created }}
       releases: ${{ steps.release-plz.outputs.releases }}
@@ -71,6 +74,8 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: stable
       - uses: Swatinem/rust-cache@bc2d2e71bd35c5549942babaa51a89c586b981d1 # v2.8.1
         with:
           workspaces: tools/vfa-tui
@@ -115,6 +120,7 @@ jobs:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
+          toolchain: stable
           targets: ${{ matrix.target }}
       - uses: Swatinem/rust-cache@bc2d2e71bd35c5549942babaa51a89c586b981d1 # v2.8.1
         with:
@@ -133,7 +139,9 @@ jobs:
         run: cargo build --release --locked --target ${{ matrix.target }}
         env:
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
-      - name: Package, checksum, and attach to release
+      - name: Package and attach binary to release
+        # Checksums are produced once, for every asset, in the SBOM job below —
+        # not here, so we avoid `sha256sum` which macOS runners don't ship.
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASES: ${{ needs.release.outputs.releases }}
@@ -146,12 +154,11 @@ jobs:
           bin="target/${{ matrix.target }}/release/vfa-tui"
           archive="vfa-tui-${{ matrix.target }}.tar.gz"
           tar -czf "$archive" -C "$(dirname "$bin")" vfa-tui
-          sha256sum "$archive" > "$archive.sha256"
-          gh release upload "$tag" "$archive" "$archive.sha256" --clobber
+          gh release upload "$tag" "$archive" --clobber
 
-  # ── SBOM (SPDX 2.3) attached once per release ──────────────────────────────
+  # ── SBOM (SPDX 2.3) + combined checksum manifest, attached once per release ─
   sbom:
-    name: SBOM
+    name: SBOM + checksums
     needs: [release, binaries]
     if: needs.release.outputs.releases_created == 'true'
     runs-on: ubuntu-latest
@@ -165,17 +172,28 @@ jobs:
         with:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: stable
       - uses: Swatinem/rust-cache@bc2d2e71bd35c5549942babaa51a89c586b981d1 # v2.8.1
         with:
           workspaces: tools/vfa-tui
-      - name: Generate SBOM and attach to release
+      - name: Generate SBOM + checksums.sha256 and attach to release
+        # Runs on Ubuntu only, so `sha256sum` is available. Gathers the tarballs
+        # the matrix already uploaded and emits the single `checksums.sha256`
+        # manifest the README documents (covering all tarballs + the SBOM).
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASES: ${{ needs.release.outputs.releases }}
         run: |
           set -euo pipefail
           tag=$(echo "$RELEASES" | jq -r '.[0].tag')
+          if [ -z "$tag" ] || [ "$tag" = "null" ]; then
+            echo "::error::could not resolve release tag from release-plz output"; exit 1
+          fi
+          mkdir -p dist
           cargo install cargo-sbom --version 0.10.0 --locked
-          cargo sbom --output-format spdx_json_2_3 > vfa-tui.spdx.json
-          sha256sum vfa-tui.spdx.json > vfa-tui.spdx.json.sha256
-          gh release upload "$tag" vfa-tui.spdx.json vfa-tui.spdx.json.sha256 --clobber
+          cargo sbom --output-format spdx_json_2_3 > dist/vfa-tui.spdx.json
+          gh release download "$tag" --pattern '*.tar.gz' --dir dist
+          ( cd dist && sha256sum *.tar.gz vfa-tui.spdx.json > checksums.sha256 )
+          cat dist/checksums.sha256
+          gh release upload "$tag" dist/vfa-tui.spdx.json dist/checksums.sha256 --clobber

--- a/.github/workflows/vfa-tui-release.yml
+++ b/.github/workflows/vfa-tui-release.yml
@@ -1,78 +1,96 @@
 name: vfa-tui Release
 
+# Stable crates.io releases for the vfa-tui crate, driven by release-plz.
+#
+# release-plz opens a version-bump "release PR"; merging that PR publishes the
+# crate, tags `vfa-tui-vX.Y.Z`, and creates the GitHub Release. The binaries are
+# built and attached in this SAME workflow run on purpose: a tag/release pushed
+# by GITHUB_TOKEN cannot trigger a separate `on: push: tags` / `on: release`
+# workflow (GitHub's recursion guard), so a standalone binaries workflow would
+# silently never fire. Gating the binaries job on the `releases_created` output
+# keeps it a no-op unless a real release happened.
+
 on:
   push:
-    tags:
-      - 'vfa-tui-v*'
-  workflow_dispatch:
-    inputs:
-      tag:
-        description: 'Release tag (e.g. vfa-tui-v0.1.0)'
-        required: true
-        default: 'vfa-tui-v0.1.0'
+    branches: [master]
+    paths:
+      - 'tools/vfa-tui/**'
+      - 'release-plz.toml'
+      - '.github/workflows/vfa-tui-release.yml'
+
+permissions:
+  contents: read
+
+# Never cancel an in-flight release.
+concurrency:
+  group: vfa-tui-release
+  cancel-in-progress: false
 
 env:
   CARGO_TERM_COLOR: always
 
-permissions:
-  contents: write
-
 jobs:
-  # ── Job 1: Security and license gates ──────────────────────────────────────
-  verify:
+  # ── Open / update the version-bump release PR ──────────────────────────────
+  release-pr:
+    name: Release PR
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: tools/vfa-tui
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
-      - uses: actions/checkout@v4
-
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          components: rustfmt, clippy
-
-      - uses: Swatinem/rust-cache@v2
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: Swatinem/rust-cache@bc2d2e71bd35c5549942babaa51a89c586b981d1 # v2.8.1
         with:
           workspaces: tools/vfa-tui
+      - name: release-plz release-pr
+        uses: release-plz/action@0b91bca0dbf6ef32045a12a5082a8829043e331d # v0.5.117
+        with:
+          command: release-pr
+          manifest_path: tools/vfa-tui/Cargo.toml
+        env:
+          # No CARGO_REGISTRY_TOKEN here — release-pr never publishes; semver
+          # checks read the baseline from the public crates.io index unauthenticated.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Verify release tag matches Cargo.toml version
-        run: |
-          version=$(python3 - <<'PY'
-          import pathlib, tomllib
-          print(tomllib.loads(pathlib.Path("Cargo.toml").read_text())["package"]["version"])
-          PY
-          )
-          tag="${{ github.event.inputs.tag || github.ref_name }}"
-          test "${tag}" = "vfa-tui-v${version}"
+  # ── Publish crate + tag + GitHub Release (no-op unless a release happens) ───
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      releases_created: ${{ steps.release-plz.outputs.releases_created }}
+      releases: ${{ steps.release-plz.outputs.releases }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: Swatinem/rust-cache@bc2d2e71bd35c5549942babaa51a89c586b981d1 # v2.8.1
+        with:
+          workspaces: tools/vfa-tui
+      - name: release-plz release
+        id: release-plz
+        uses: release-plz/action@0b91bca0dbf6ef32045a12a5082a8829043e331d # v0.5.117
+        with:
+          command: release
+          manifest_path: tools/vfa-tui/Cargo.toml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
-      - name: Format check
-        run: cargo fmt -- --check
-
-      - name: Clippy
-        run: cargo clippy -- -D warnings
-
-      - name: Test
-        run: cargo test
-
-      - name: Install cargo-deny
-        run: cargo install cargo-deny --version 0.16.4 --locked
-
-      - name: License and advisory check (cargo deny)
-        run: cargo deny check
-
-      - name: Install cargo-audit
-        run: cargo install cargo-audit --locked
-
-      - name: Security advisory scan (cargo audit)
-        run: cargo audit
-
-      - name: Dry-run publish check
-        run: cargo publish --dry-run --locked
-
-  # ── Job 2: Cross-compile for all 5 targets ─────────────────────────────────
-  cross-compile:
-    needs: verify
+  # ── Cross-compile 5 targets, attach to the release release-plz just created ─
+  binaries:
+    name: Binaries (${{ matrix.target }})
+    needs: release
+    if: needs.release.outputs.releases_created == 'true'
     strategy:
+      fail-fast: false
       matrix:
         include:
           - target: x86_64-unknown-linux-gnu
@@ -86,115 +104,78 @@ jobs:
           - target: aarch64-apple-darwin
             os: macos-latest
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
     defaults:
       run:
         working-directory: tools/vfa-tui
     steps:
-      - uses: actions/checkout@v4
-
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           targets: ${{ matrix.target }}
-
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@bc2d2e71bd35c5549942babaa51a89c586b981d1 # v2.8.1
         with:
           workspaces: tools/vfa-tui
-
       - name: Install aarch64 Linux cross-compiler
         if: matrix.target == 'aarch64-unknown-linux-gnu'
         run: |
           sudo apt-get update -qq
           sudo apt-get install -y --no-install-recommends gcc-aarch64-linux-gnu
-
       - name: Install musl tools
         if: matrix.target == 'x86_64-unknown-linux-musl'
         run: |
           sudo apt-get update -qq
           sudo apt-get install -y --no-install-recommends musl-tools
-
       - name: Build release binary
         run: cargo build --release --locked --target ${{ matrix.target }}
         env:
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
-
-      - name: Package binary
-        run: |
-          bin=target/${{ matrix.target }}/release/vfa-tui
-          archive=vfa-tui-${{ matrix.target }}.tar.gz
-          tar -czf "$archive" -C "$(dirname "$bin")" vfa-tui
-          echo "ARCHIVE=$archive" >> "$GITHUB_ENV"
-
-      - uses: actions/upload-artifact@v4
-        with:
-          name: vfa-tui-${{ matrix.target }}
-          path: tools/vfa-tui/vfa-tui-${{ matrix.target }}.tar.gz
-          if-no-files-found: error
-
-  # ── Job 3: Generate SBOM, checksums, and create GitHub Release ─────────────
-  release-assets:
-    needs: cross-compile
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: tools/vfa-tui
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: dtolnay/rust-toolchain@stable
-
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: tools/vfa-tui
-
-      - name: Download all compiled artifacts
-        uses: actions/download-artifact@v4
-        with:
-          pattern: vfa-tui-*
-          path: tools/vfa-tui/dist/
-          merge-multiple: true
-
-      - name: Generate SBOM (SPDX 2.3)
-        run: |
-          cargo install cargo-sbom --version 0.10.0 --locked
-          cargo sbom --output-format spdx_json_2_3 > dist/vfa-tui.spdx.json
-
-      - name: Generate SHA-256 checksums
-        run: |
-          cd dist
-          sha256sum *.tar.gz vfa-tui.spdx.json > checksums.sha256
-          cat checksums.sha256
-
-      - name: Create GitHub Release
+      - name: Package, checksum, and attach to release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASES: ${{ needs.release.outputs.releases }}
         run: |
-          tag="${{ github.event.inputs.tag || github.ref_name }}"
-          version="${tag#vfa-tui-v}"
-          gh release create "$tag" \
-            --title "vfa-tui v${version}" \
-            --notes "See [CHANGELOG.md](https://github.com/${{ github.repository }}/blob/${tag}/tools/vfa-tui/CHANGELOG.md) for details." \
-            dist/*.tar.gz \
-            dist/vfa-tui.spdx.json \
-            dist/checksums.sha256
+          set -euo pipefail
+          tag=$(echo "$RELEASES" | jq -r '.[0].tag')
+          if [ -z "$tag" ] || [ "$tag" = "null" ]; then
+            echo "::error::could not resolve release tag from release-plz output"; exit 1
+          fi
+          bin="target/${{ matrix.target }}/release/vfa-tui"
+          archive="vfa-tui-${{ matrix.target }}.tar.gz"
+          tar -czf "$archive" -C "$(dirname "$bin")" vfa-tui
+          sha256sum "$archive" > "$archive.sha256"
+          gh release upload "$tag" "$archive" "$archive.sha256" --clobber
 
-  # ── Job 4: Publish to crates.io (environment-gated) ────────────────────────
-  publish:
-    needs: release-assets
+  # ── SBOM (SPDX 2.3) attached once per release ──────────────────────────────
+  sbom:
+    name: SBOM
+    needs: [release, binaries]
+    if: needs.release.outputs.releases_created == 'true'
     runs-on: ubuntu-latest
-    environment: crates-io-publish
+    permissions:
+      contents: write
     defaults:
       run:
         working-directory: tools/vfa-tui
     steps:
-      - uses: actions/checkout@v4
-
-      - uses: dtolnay/rust-toolchain@stable
-
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: Swatinem/rust-cache@bc2d2e71bd35c5549942babaa51a89c586b981d1 # v2.8.1
         with:
           workspaces: tools/vfa-tui
-
-      - name: Publish to crates.io
-        run: cargo publish --locked
+      - name: Generate SBOM and attach to release
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASES: ${{ needs.release.outputs.releases }}
+        run: |
+          set -euo pipefail
+          tag=$(echo "$RELEASES" | jq -r '.[0].tag')
+          cargo install cargo-sbom --version 0.10.0 --locked
+          cargo sbom --output-format spdx_json_2_3 > vfa-tui.spdx.json
+          sha256sum vfa-tui.spdx.json > vfa-tui.spdx.json.sha256
+          gh release upload "$tag" vfa-tui.spdx.json vfa-tui.spdx.json.sha256 --clobber

--- a/.github/workflows/vfa-tui-release.yml
+++ b/.github/workflows/vfa-tui-release.yml
@@ -160,7 +160,7 @@ jobs:
   sbom:
     name: SBOM + checksums
     needs: [release, binaries]
-    if: needs.release.outputs.releases_created == 'true'
+    if: ${{ !cancelled() && needs.release.outputs.releases_created == 'true' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -17,3 +17,7 @@ name = "vfa-tui"
 semver_check = true
 # release-plz creates the GitHub Release; the binaries job attaches assets to it.
 git_release_enable = true
+# Single-crate projects default to the `v{{ version }}` tag, which would collide
+# with the root npm/semantic-release `vX.Y.Z` namespace. Pin the crate-scoped
+# scheme the workflow and README expect.
+git_tag_name = "vfa-tui-v{{ version }}"

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,19 @@
+# release-plz configuration — scoped to the vfa-tui crate.
+# Docs: https://release-plz.dev/docs/config
+#
+# Flow: on every master push, `release-pr` opens/updates a version-bump PR
+# (driven by conventional commits). Merging that PR is the human gate; the
+# `release` job then publishes the crate, tags `vfa-tui-vX.Y.Z`, and creates
+# the GitHub Release. Nothing is published on pushes that don't change a
+# release-worthy version, so re-runs are no-ops.
+
+[workspace]
+# Never auto-release on every push — release only when the release PR is merged.
+release_always = false
+
+[[package]]
+name = "vfa-tui"
+# Block accidental semver-breaking API changes (compares against crates.io).
+semver_check = true
+# release-plz creates the GitHub Release; the binaries job attaches assets to it.
+git_release_enable = true

--- a/tools/vfa-tui/.gitignore
+++ b/tools/vfa-tui/.gitignore
@@ -1,1 +1,4 @@
 /target/
+
+# Stray artifact dir created when tests resolve a literal "~" HOME path
+/~/

--- a/tools/vfa-tui/deny.toml
+++ b/tools/vfa-tui/deny.toml
@@ -1,5 +1,8 @@
 # cargo-deny configuration for vfa-tui
-# Verified in CI via `cargo deny check` (see .github/workflows/vfa-tui-release.yml).
+# Verified in CI via `cargo deny check` (see .github/workflows/vfa-tui-ci.yml).
+# Schema: version 2 (the per-severity advisory keys `vulnerability`,
+# `unmaintained`, and `notice` were removed by cargo-deny; vulnerabilities are
+# always denied and other advisories surface as warnings unless ignored below).
 
 [graph]
 targets = [
@@ -11,6 +14,10 @@ targets = [
 ]
 
 [licenses]
+version = 2
+# Keep a curated allow-list even if a given license isn't currently pulled in by
+# any dependency — don't fail the gate just because an allowance is unused.
+unused-allowed-license = "allow"
 allow = [
     "MIT",
     "Apache-2.0",
@@ -23,6 +30,10 @@ allow = [
     "BSL-1.0",
     "CC0-1.0",
     "OpenSSL",
+    # Weak (per-file) copyleft, used only by `nucleo-matcher` (the fuzzy-search
+    # engine). vfa-tui consumes it unmodified, so MPL-2.0 imposes no source
+    # obligation on this crate; allowing it is the standard, compliant choice.
+    "MPL-2.0",
 ]
 confidence-threshold = 0.8
 
@@ -36,10 +47,9 @@ multiple-versions = "warn"
 wildcards = "allow"
 
 [advisories]
-vulnerability = "deny"
-unmaintained = "warn"
+version = 2
 yanked = "deny"
-notice = "warn"
+ignore = []
 
 [sources]
 unknown-registry = "deny"

--- a/tools/vfa-tui/src/models/provider.rs
+++ b/tools/vfa-tui/src/models/provider.rs
@@ -38,15 +38,18 @@ pub enum Provider {
     CertManager,
     Cilium,
     Claude,
+    Databricks,
     Falco,
     Fluxcd,
     Istio,
     Kyverno,
     Marketing,
+    Microsoft,
     Nvidia,
     Opentelemetry,
     Prometheus,
     Sigstore,
+    Snowflake,
     Velero,
 }
 


### PR DESCRIPTION
## Single PR into develop — supersedes #88

Everything vfa-tui-related, consolidated so there's exactly one PR.

### Crate fixes (folded in from #88)
- **Provider enum**: add `databricks`, `microsoft`, `snowflake` (present in master's catalog; the strict enum would otherwise reject them and break catalog loading when develop syncs that content).
- **`.gitignore`**: ignore the stray `/~/` dir some tests create when a HOME-relative path resolves to a literal `~`.
- Verified: 742 lib tests pass, `clippy -D warnings` clean.

### Release automation
Replace the manual `vfa-tui-v*` tag / `workflow_dispatch` pipeline with a **change-aware, idempotent** setup. **Nothing publishes unless a release-worthy version change is merged.** (Design grounded in the official release-plz docs via context7.)

**master — stable, via release-plz**
- `release-plz.toml` scopes release-plz to the `vfa-tui` crate. `release_always = false` → release happens **only when the version-bump "release PR" is merged**. `semver_check = true` blocks accidental API breaks.
- `vfa-tui-release.yml`: `release-pr` opens the bump PR; `release` publishes the crate + tags `vfa-tui-vX.Y.Z` + creates the GitHub Release (idempotent — re-runs are no-ops). Binaries (5 targets) + SBOM build in the **same run**, gated on the `releases_created` output (a `GITHUB_TOKEN`-pushed tag can't trigger a separate workflow). `CARGO_REGISTRY_TOKEN` is on the release job only.

**develop / PRs — gate, never publishes**
- `vfa-tui-ci.yml`: `fmt`, `clippy -D warnings`, `test`, `cargo-deny`, `cargo-audit`, `cargo publish --dry-run --locked`. No token, no upload — proves it *would* publish without touching crates.io.

**Hardening**
- All actions **SHA-pinned** (resolved via `git ls-remote`): checkout `df4cb1c0…` v6.0.3 · rust-toolchain `29eef336…` stable · rust-cache `bc2d2e71…` v2.8.1 · release-plz `0b91bca0…` v0.5.117.
- `dependabot.yml` gains a `cargo` ecosystem for `tools/vfa-tui`; existing `github-actions` ecosystem keeps SHA pins fresh.
- `concurrency` groups never cancel an in-flight release; `set -euo pipefail` + explicit tag-resolution guards (fail loud, skip clean).
- Crate version decoupled from the npm `semantic-release` marketplace version.

### Notes
- master workflow is **inert until the crate reaches master** via develop → master (paths filter won't match an absent `tools/vfa-tui/`).
- crates.io requires a one-time **manual first publish** to claim the name; release-plz automates every release after.

Targets **develop**. Draft — I won't merge.