### PR TITLE
ci(vfa-tui): bump rust-cache v2.8.1 → v2.9.1 (node20 → node24)

### DIFF
--- a/.github/workflows/vfa-tui-ci.yml
+++ b/.github/workflows/vfa-tui-ci.yml
@@ -45,7 +45,7 @@ jobs:
           toolchain: stable
           components: rustfmt, clippy
 
-      - uses: Swatinem/rust-cache@bc2d2e71bd35c5549942babaa51a89c586b981d1 # v2.8.1
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: tools/vfa-tui
 

--- a/.github/workflows/vfa-tui-release.yml
+++ b/.github/workflows/vfa-tui-release.yml
@@ -45,7 +45,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           toolchain: stable
-      - uses: Swatinem/rust-cache@bc2d2e71bd35c5549942babaa51a89c586b981d1 # v2.8.1
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: tools/vfa-tui
       - name: release-plz release-pr
@@ -76,7 +76,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           toolchain: stable
-      - uses: Swatinem/rust-cache@bc2d2e71bd35c5549942babaa51a89c586b981d1 # v2.8.1
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: tools/vfa-tui
       - name: release-plz release
@@ -122,7 +122,7 @@ jobs:
         with:
           toolchain: stable
           targets: ${{ matrix.target }}
-      - uses: Swatinem/rust-cache@bc2d2e71bd35c5549942babaa51a89c586b981d1 # v2.8.1
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: tools/vfa-tui
       - name: Install aarch64 Linux cross-compiler
@@ -174,7 +174,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           toolchain: stable
-      - uses: Swatinem/rust-cache@bc2d2e71bd35c5549942babaa51a89c586b981d1 # v2.8.1
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: tools/vfa-tui
       - name: Generate SBOM + checksums.sha256 and attach to release


### PR DESCRIPTION
## Summary

- Bumps `Swatinem/rust-cache` from `bc2d2e71` (v2.8.1) to `c19371144` (v2.9.1) across all 5 occurrences in `vfa-tui-ci.yml` and `vfa-tui-release.yml`
- v2.8.1 targets Node.js 20, which GitHub Actions is deprecating (forced to run on Node.js 24 with a warning)
- v2.9.1 declares `using: node24` — eliminates the deprecation warning that appeared on every Gate run after PR #89 merged

## Test plan

- [ ] Gate passes on `develop` with no Node.js 20 deprecation warning
- [ ] No other workflow behaviour changes (rust-cache API is stable across this range)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VRZ31oTeTbb5LEdCdVTedK)_