### PR TITLE
fix(vfa-tui): harden release matrix — aarch64 libc + checksum completeness

### DIFF
--- a/.github/workflows/vfa-tui-release.yml
+++ b/.github/workflows/vfa-tui-release.yml
@@ -28,6 +28,12 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
+  # Number of binary targets in the `binaries` matrix below. The SBOM job asserts
+  # it collected exactly this many tarballs before writing checksums.sha256, so a
+  # silently-failed target (the matrix is fail-fast: false, and macOS runners lack
+  # `sha256sum`) hard-fails the release instead of shipping an incomplete manifest.
+  # Keep in sync with the `binaries` matrix.
+  VFA_RELEASE_TARGET_COUNT: "5"
 
 jobs:
   # ── Open / update the version-bump release PR ──────────────────────────────
@@ -127,9 +133,13 @@ jobs:
           workspaces: tools/vfa-tui
       - name: Install aarch64 Linux cross-compiler
         if: matrix.target == 'aarch64-unknown-linux-gnu'
+        # libc6-dev-arm64-cross is required, not just the compiler: vfa-tui pulls in
+        # rusqlite → libsqlite3-sys, which compiles bundled SQLite C source. Without
+        # the aarch64 libc headers the C build falls back to the host /usr/include
+        # and dies on `bits/libc-header-start.h`, failing the whole target.
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -y --no-install-recommends gcc-aarch64-linux-gnu
+          sudo apt-get install -y --no-install-recommends gcc-aarch64-linux-gnu libc6-dev-arm64-cross
       - name: Install musl tools
         if: matrix.target == 'x86_64-unknown-linux-musl'
         run: |
@@ -194,6 +204,15 @@ jobs:
           cargo install cargo-sbom --version 0.10.0 --locked
           cargo sbom --output-format spdx_json_2_3 > dist/vfa-tui.spdx.json
           gh release download "$tag" --pattern '*.tar.gz' --dir dist
+          # The binaries matrix is fail-fast: false and runs partly on macOS (no
+          # sha256sum), so a failed platform would otherwise vanish silently from
+          # the manifest. Require the full set before checksumming.
+          found=$(find dist -maxdepth 1 -name '*.tar.gz' | wc -l)
+          if [ "$found" -ne "$VFA_RELEASE_TARGET_COUNT" ]; then
+            echo "::error::expected $VFA_RELEASE_TARGET_COUNT platform tarballs but found $found — a binary target likely failed; refusing to publish an incomplete checksum manifest"
+            find dist -maxdepth 1 -name '*.tar.gz' -printf '  %f\n' || true
+            exit 1
+          fi
           ( cd dist && sha256sum *.tar.gz vfa-tui.spdx.json > checksums.sha256 )
           cat dist/checksums.sha256
           gh release upload "$tag" dist/vfa-tui.spdx.json dist/checksums.sha256 --clobber


### PR DESCRIPTION
## Context

While reviewing PR #92 (which brings the vfa-tui release pipeline to master), I ran a **local dry-run of the binary build matrix** — something `cargo publish --dry-run` never exercises, since the cross-compile / SBOM / checksum / release-upload steps only fire on a master push. That surfaced two issues, fixed here on `develop` (the canonical copy of the workflow, which flows to master via #92).

> The codespell `ser` ignore discussed on #92 is already present on `develop`, so it's not duplicated here.

## Fix 1 — `aarch64-unknown-linux-gnu` build failure (release-blocking) 🔴

`vfa-tui → rusqlite → libsqlite3-sys` compiles **bundled SQLite C source**. The aarch64 cross step installed only `gcc-aarch64-linux-gnu` (the compiler), **not the target libc headers**. Without them the C build falls back to the host `/usr/include` and dies:

```
libsqlite3-sys: /usr/include/stdio.h:28:10: fatal error:
  bits/libc-header-start.h: No such file or directory
error: failed to run custom build command for `libsqlite3-sys v0.30.1`
```

**Reproduced locally**, then confirmed the fix: adding `libc6-dev-arm64-cross` makes the target build a valid aarch64 ELF with only the linker set (exactly as the workflow configures it):

```
target/aarch64-unknown-linux-gnu/release/vfa-tui:
  ELF 64-bit LSB pie executable, ARM aarch64 ... for GNU/Linux 3.7.0
```

On the first real release merge, this target would have **failed to build**. Now it won't.

## Fix 2 — silent checksum-manifest gap 🟠

The `binaries` matrix is `fail-fast: false` and runs partly on macOS (no `sha256sum`), so `checksums.sha256` is produced once in the Ubuntu `sbom` job from whatever tarballs were uploaded. A failed platform would **drop out of the manifest silently** — a green-looking release missing a binary.

Added a count assertion with a single source of truth (`env.VFA_RELEASE_TARGET_COUNT = "5"`, kept in sync with the matrix). If the SBOM job collects fewer tarballs than expected, it now **hard-fails** instead of publishing a short manifest. This is defense-in-depth and pairs with Fix 1 (which removes the most likely cause of a missing target).

## Local verification

| Target | Result |
|---|---|
| `x86_64-unknown-linux-gnu` | ✅ build (8.74 MB) |
| `x86_64-unknown-linux-musl` | ✅ build (8.63 MB) |
| `aarch64-unknown-linux-gnu` | ✅ build after fix (8.36 MB, valid ARM ELF) |
| `x86_64-apple-darwin` / `aarch64-apple-darwin` | ⚪ unprovable off a macOS runner |
| `cargo-sbom` | ✅ SPDX-2.3, 290 packages |
| `checksums.sha256` | ✅ correct shape |

Scope: `vfa-tui-release.yml` only. YAML validated; guard logic `bash -n` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VRZ31oTeTbb5LEdCdVTedK)_