### PR TITLE
ci: skip semantic-release in republish mode; release 2.12.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Cloud and zero-trust agentic workflow marketplace for skills, agents, rules, MCP references, and compliance-aware architecture.",
-    "version": "2.12.0"
+    "version": "2.12.1"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vanguard-frontier-agentic",
-  "version": "2.12.0",
+  "version": "2.12.1",
   "description": "Cloud and zero-trust agentic workflow marketplace for skills, agents, rules, MCP references, and compliance-aware architecture.",
   "author": {
     "name": "Raishin",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vanguard-frontier-agentic",
-  "version": "2.12.0",
+  "version": "2.12.1",
   "description": "Cloud and zero-trust agentic workflow marketplace for skills, agents, rules, MCP references, and compliance-aware architecture.",
   "author": {
     "name": "Raishin",

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/github/copilot-cli/main/schemas/marketplace.schema.json",
   "name": "vanguard-frontier-agentic",
   "description": "Curated marketplace for cloud, zero-trust, and compliance-aware AI workflows — agents, skills, and rules spanning cloud, security, ERP, and platform providers.",
-  "version": "2.12.0",
+  "version": "2.12.1",
   "owner": {
     "name": "Raishin",
     "url": "https://github.com/Raishin"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -266,6 +266,14 @@ jobs:
           upload-release-assets: false
 
       - name: Release
+        # In republish mode we deliberately skip semantic-release: the intent
+        # is to (re)publish the current package.json version to npm without a
+        # new bump/changelog/tag. Running semantic-release here would attempt a
+        # git tag push, which is irrelevant to a republish and can fail
+        # independently (e.g. a repo ruleset restricting tag creation). Gating
+        # it keeps the OIDC npm-publish step below as the sole action in
+        # republish runs.
+        if: ${{ github.event.inputs.republish != 'true' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # No NPM_TOKEN needed: npm CLI v9.6+ automatically performs the

--- a/catalog/asset-integrity.json
+++ b/catalog/asset-integrity.json
@@ -27805,7 +27805,7 @@
     },
     {
       "tree": "plugins",
-      "aggregate_sha256": "1804248a2ec5845ff247ec0b2444629bbe7fd7e37c9b2cf1f5fd09bda5d3ec5f",
+      "aggregate_sha256": "ec7231e46a1893a41afdbf4eba30c01f5ae0a3c6e9edffad03a68f31f9bc6806",
       "files": [
         {
           "path": "plugins/cross-platform-agent-template/.codex-plugin/plugin.json",
@@ -27814,7 +27814,7 @@
         },
         {
           "path": "plugins/vanguard-frontier-agentic/.codex-plugin/plugin.json",
-          "sha256": "0132580250549eb29ddf1c6a189918f09194cc54737ba86431b00bb88f85be46",
+          "sha256": "4c58c9643ebc8bd85f6f77d1fb58067c92fe9b1f424e75bbcc0a8c37731647c4",
           "bytes": 1876
         },
         {
@@ -27826,7 +27826,7 @@
     },
     {
       "tree": ".claude-plugin",
-      "aggregate_sha256": "5b8a61ec1fca02bc050cc39da2e5e8b6932d51e4268069edd8f0052cff3d321f",
+      "aggregate_sha256": "5913ff69bbcf6ba265e29ebb41e71af4ddd0b40d2af2319d58d7da6a8c8ae6a5",
       "files": [
         {
           "path": ".claude-plugin/README.md",
@@ -27835,19 +27835,19 @@
         },
         {
           "path": ".claude-plugin/marketplace.json",
-          "sha256": "6ebc1efe417718a2674196a0d79b615fa3109b88f599243a510731e4fd46c350",
+          "sha256": "58f73a7e1d4a7e0c764e188c71d6fb39a7731a2d59c77cf2eac06ec17fe78aa4",
           "bytes": 835
         },
         {
           "path": ".claude-plugin/plugin.json",
-          "sha256": "d1b4625db033e467570ff80aba925b6a2cac5c982af937be060818b9ca042400",
+          "sha256": "59b52f7c03164c7763e4a82ad48a070d2a5a892e174986109180b9a80b9c1eaf",
           "bytes": 51745
         }
       ]
     },
     {
       "tree": ".cursor-plugin",
-      "aggregate_sha256": "7ba9e61df9cc067f981330d897fc678cf98e3a183e2db81237d6cbabc0305b2e",
+      "aggregate_sha256": "5499a1cb9378136733fa84b3c2c371b30f4326989193f3596b69add831264117",
       "files": [
         {
           "path": ".cursor-plugin/README.md",
@@ -27856,14 +27856,14 @@
         },
         {
           "path": ".cursor-plugin/plugin.json",
-          "sha256": "32d9dd876e37759dbae0b5d040a79902d670e288463254a697afeb1a254d8d2f",
+          "sha256": "e3c2ff225d7ae0341b22946e9bf2c3f570621ca1d02ac64660279d7fdb7c7d4d",
           "bytes": 48926
         }
       ]
     },
     {
       "tree": ".github/plugin",
-      "aggregate_sha256": "55b1cb01783d407dc6b01fa07e076959e01b4bb172a8ed0b6e098c311f773a97",
+      "aggregate_sha256": "6e88755465d98a39217aa172ba056bcf133bb9b03f9691ea5d3296b2a5b9993d",
       "files": [
         {
           "path": ".github/plugin/README.md",
@@ -27872,7 +27872,7 @@
         },
         {
           "path": ".github/plugin/marketplace.json",
-          "sha256": "5f47b70da6ce1f9d52dc827008269caeee6dab42049f7f52578242a76b63edbf",
+          "sha256": "a77bf32ce202858cad4c567bb6110d4400b521f88c6ec75ad7e78f7f32a2f525",
           "bytes": 771
         }
       ]
@@ -34403,7 +34403,7 @@
     },
     {
       "path": "package.json",
-      "sha256": "eb0e9bb352ed3574eee84f2c6880102947cd44d6a8557038256dc6c7c69f334f",
+      "sha256": "703fa0860889734f3e46fa03a6a709f46981c20cff9994a981962e1965c35833",
       "bytes": 5785
     },
     {
@@ -34412,5 +34412,5 @@
       "bytes": 4523
     }
   ],
-  "aggregate_sha256": "3ec69062871677bac99afe056b8fe4479255aac665cce31db1943441b658e02f"
+  "aggregate_sha256": "92a54f7a79473028eabd9d4383634a274e2d812da75cba90acda6170d69f0892"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@raishin/vanguard-frontier-agentic",
-  "version": "2.10.1",
+  "version": "2.12.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@raishin/vanguard-frontier-agentic",
-      "version": "2.10.1",
+      "version": "2.12.1",
       "license": "Apache-2.0",
       "bin": {
         "vfa-export-agents": "scripts/export-marketplace-agents.mjs"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@raishin/vanguard-frontier-agentic",
-  "version": "2.12.0",
+  "version": "2.12.1",
   "description": "Cloud and zero-trust agentic workflow marketplace for skills, agents, rules, MCP references, and compliance-aware architecture.",
   "license": "Apache-2.0",
   "repository": {

--- a/plugins/vanguard-frontier-agentic/.codex-plugin/plugin.json
+++ b/plugins/vanguard-frontier-agentic/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vanguard-frontier-agentic",
-  "version": "2.12.0",
+  "version": "2.12.1",
   "description": "Curated marketplace for cloud and zero-trust AI workflows. 331 agents, 286 skills, and rules across AWS, Azure, OCI, GCP, Alibaba Cloud, Huawei Cloud, Kubernetes, and Terraform.",
   "author": {
     "name": "Raishin",


### PR DESCRIPTION
## Why

The automated release for `2.12.0` is stuck on two independent problems:

1. **GitHub tag rule (phantom):** every tag push (`refs/tags/v2.12.0`) is rejected with `GH013: Cannot create ref due to creations being restricted`, even though no ruleset targets tags (verified via `/settings/rules` and `…/rules?ref=refs/tags/v2.11.0`). semantic-release dies at the tag push *before* npm publish runs. A GitHub Support ticket is open to purge the stuck rule.
2. **npm tombstone:** `2.12.0` was published then unpublished on npm, so npm permanently blocks republishing that exact version.

This PR unblocks the npm release without depending on either fix.

## Changes

- **`release.yml`:** gate the `Release` (semantic-release) step with `if: github.event.inputs.republish != 'true'`. The `republish` input is documented as "re-publish current package.json version to npm without a new semantic-release bump" — running semantic-release (and its tag push) in that mode was a bug. With it gated off, a `republish=true` dispatch performs only the OIDC npm publish, which is unaffected by the tag-creation block.
- **Version → `2.12.1`** across the parity files (`package.json`, `.claude-plugin`, `.cursor-plugin`, marketplace + codex manifests), since `2.12.0` is permanently tombstoned on npm. Asset-integrity hashes regenerated; `npm run validate` passes.

## Release path after merge

Trigger `release.yml` with `republish=true` on `master` → publishes `@raishin/vanguard-frontier-agentic@2.12.1` to npm with provenance via the existing OIDC trusted publisher.

## Follow-ups (not in this PR)

- GitHub Support to clear the phantom tag rule so normal automated releases (tag + GitHub Release + npm) work again.
- Once the tag rule is fixed, the pipeline still needs to skip the tombstoned `2.12.0` (e.g. land a small `feat:`/`fix:` so the next computed version is past it, or create a `v2.12.1` tag as the new semantic-release baseline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThudxML5gWs7nQjdQMzLg3)_