### PR TITLE
chore: release 2.13.0 — SAP role-based agents &amp; skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Cloud and zero-trust agentic workflow marketplace for skills, agents, rules, MCP references, and compliance-aware architecture.",
-    "version": "2.12.1"
+    "version": "2.13.0"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vanguard-frontier-agentic",
-  "version": "2.12.1",
+  "version": "2.13.0",
   "description": "Cloud and zero-trust agentic workflow marketplace for skills, agents, rules, MCP references, and compliance-aware architecture.",
   "author": {
     "name": "Raishin",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vanguard-frontier-agentic",
-  "version": "2.12.1",
+  "version": "2.13.0",
   "description": "Cloud and zero-trust agentic workflow marketplace for skills, agents, rules, MCP references, and compliance-aware architecture.",
   "author": {
     "name": "Raishin",

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/github/copilot-cli/main/schemas/marketplace.schema.json",
   "name": "vanguard-frontier-agentic",
   "description": "Curated marketplace for cloud, zero-trust, and compliance-aware AI workflows — agents, skills, and rules spanning cloud, security, ERP, and platform providers.",
-  "version": "2.12.1",
+  "version": "2.13.0",
   "owner": {
     "name": "Raishin",
     "url": "https://github.com/Raishin"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 🛡️ v2.13.0 — *SAP Role-Based Agents & Skills* &mdash; 2026-06-21
+
+> _Multi-cloud agent marketplace · `AWS` · `Azure` · `OCI` · `Terraform` · `SAP`_
+>
+> Built for operators on the cloud frontier — least privilege, live evidence, safe rollback paths.
+
+### Features
+
+* **sap:** add SAP role-based agent and skill board (40 agents, 46 skills)
+
 ## 🛡️ v2.12.0 — *Provenance, Policy, Portability* &mdash; 2026-06-21
 
 > _Multi-cloud agent marketplace · `AWS` · `Azure` · `OCI` · `Terraform`_

--- a/catalog/asset-integrity.json
+++ b/catalog/asset-integrity.json
@@ -27805,7 +27805,7 @@
     },
     {
       "tree": "plugins",
-      "aggregate_sha256": "ec7231e46a1893a41afdbf4eba30c01f5ae0a3c6e9edffad03a68f31f9bc6806",
+      "aggregate_sha256": "56ab2300274c6d42d7209ad545b0ad339f38c31cb752de9a752e554970863577",
       "files": [
         {
           "path": "plugins/cross-platform-agent-template/.codex-plugin/plugin.json",
@@ -27814,7 +27814,7 @@
         },
         {
           "path": "plugins/vanguard-frontier-agentic/.codex-plugin/plugin.json",
-          "sha256": "4c58c9643ebc8bd85f6f77d1fb58067c92fe9b1f424e75bbcc0a8c37731647c4",
+          "sha256": "e6e5d0c96be16fcd19f4a98522853ba1d076d34da28b4a0ce19b630ccbab6e23",
           "bytes": 1876
         },
         {
@@ -27826,7 +27826,7 @@
     },
     {
       "tree": ".claude-plugin",
-      "aggregate_sha256": "5913ff69bbcf6ba265e29ebb41e71af4ddd0b40d2af2319d58d7da6a8c8ae6a5",
+      "aggregate_sha256": "d0cf42499c3885943c74ed063bb76049176b07ead82bb4b4bb585db77a0b3669",
       "files": [
         {
           "path": ".claude-plugin/README.md",
@@ -27835,19 +27835,19 @@
         },
         {
           "path": ".claude-plugin/marketplace.json",
-          "sha256": "58f73a7e1d4a7e0c764e188c71d6fb39a7731a2d59c77cf2eac06ec17fe78aa4",
+          "sha256": "919409c82dac00517b833ecdd866734d48f6bccc4e4432a208328d8281f4db92",
           "bytes": 835
         },
         {
           "path": ".claude-plugin/plugin.json",
-          "sha256": "59b52f7c03164c7763e4a82ad48a070d2a5a892e174986109180b9a80b9c1eaf",
+          "sha256": "6489d365edb55d2ad1daa7112d9482241f08f38e16d75278afcd887390288892",
           "bytes": 51745
         }
       ]
     },
     {
       "tree": ".cursor-plugin",
-      "aggregate_sha256": "5499a1cb9378136733fa84b3c2c371b30f4326989193f3596b69add831264117",
+      "aggregate_sha256": "3e8c26a08cc7a74cfb4597b9abdc223ccc7e52136eeaefb61b5c2d08483fcb3c",
       "files": [
         {
           "path": ".cursor-plugin/README.md",
@@ -27856,14 +27856,14 @@
         },
         {
           "path": ".cursor-plugin/plugin.json",
-          "sha256": "e3c2ff225d7ae0341b22946e9bf2c3f570621ca1d02ac64660279d7fdb7c7d4d",
+          "sha256": "12d5b1824ce57e7746ddbcd983a58541984edbbb75abed766843a532511ac423",
           "bytes": 48926
         }
       ]
     },
     {
       "tree": ".github/plugin",
-      "aggregate_sha256": "6e88755465d98a39217aa172ba056bcf133bb9b03f9691ea5d3296b2a5b9993d",
+      "aggregate_sha256": "2df1f6445a0358864952c96f90f4c1cd377f981ffa0295cbfd13dde8304563b6",
       "files": [
         {
           "path": ".github/plugin/README.md",
@@ -27872,7 +27872,7 @@
         },
         {
           "path": ".github/plugin/marketplace.json",
-          "sha256": "a77bf32ce202858cad4c567bb6110d4400b521f88c6ec75ad7e78f7f32a2f525",
+          "sha256": "0dcbd0200028f5b8956e25fe5b181a40d400a7dc236273dd90378c84e5274493",
           "bytes": 771
         }
       ]
@@ -34403,7 +34403,7 @@
     },
     {
       "path": "package.json",
-      "sha256": "703fa0860889734f3e46fa03a6a709f46981c20cff9994a981962e1965c35833",
+      "sha256": "5a680368461e492e272b4dabc87a39568b6e31a82813d8da3c6d5078f7d57ffa",
       "bytes": 5785
     },
     {
@@ -34412,5 +34412,5 @@
       "bytes": 4523
     }
   ],
-  "aggregate_sha256": "92a54f7a79473028eabd9d4383634a274e2d812da75cba90acda6170d69f0892"
+  "aggregate_sha256": "24fb239835c9df76cbb246bb997a182058a83afdcea196b095fb4297d99ff01a"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@raishin/vanguard-frontier-agentic",
-  "version": "2.12.1",
+  "version": "2.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@raishin/vanguard-frontier-agentic",
-      "version": "2.12.1",
+      "version": "2.13.0",
       "license": "Apache-2.0",
       "bin": {
         "vfa-export-agents": "scripts/export-marketplace-agents.mjs"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@raishin/vanguard-frontier-agentic",
-  "version": "2.12.1",
+  "version": "2.13.0",
   "description": "Cloud and zero-trust agentic workflow marketplace for skills, agents, rules, MCP references, and compliance-aware architecture.",
   "license": "Apache-2.0",
   "repository": {

--- a/plugins/vanguard-frontier-agentic/.codex-plugin/plugin.json
+++ b/plugins/vanguard-frontier-agentic/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vanguard-frontier-agentic",
-  "version": "2.12.1",
+  "version": "2.13.0",
   "description": "Curated marketplace for cloud and zero-trust AI workflows. 331 agents, 286 skills, and rules across AWS, Azure, OCI, GCP, Alibaba Cloud, Huawei Cloud, Kubernetes, and Terraform.",
   "author": {
     "name": "Raishin",


### PR DESCRIPTION
## Release 2.13.0

Publishes `@raishin/vanguard-frontier-agentic@2.13.0` to npm via the `republish` CI path (the semantic-release gate from #95 means a `republish=true` dispatch performs only the OIDC publish, unaffected by the still-stuck `GH013` tag rule).

### Why 2.13.0 (not 2.12.x)
`2.12.0`, `2.12.1`, and `2.12.2` were each published then unpublished on npm. npm **permanently tombstones** unpublished version numbers, so none can be reused — `2.13.0` is the next clean version.

### Changes
- Version bump → `2.13.0` across the parity trio (`package.json`, `.claude-plugin/plugin.json`, `.cursor-plugin/plugin.json`) + regenerated harness manifests.
- **CHANGELOG**: new `2.13.0` entry **scoped to the SAP board only** (40 agents, 46 skills).
- Asset-integrity hashes regenerated; `npm run validate` passes (QA cluster 80/80).

### Release path
After merge (with `[skip ci]` so no normal-mode run reverts the bump), dispatch `release.yml` with `republish=true` on `master` → publishes `2.13.0` with provenance.

### Follow-ups
- GitHub Support ticket open to purge the phantom tag rule → restores fully-automated releases (tag + GitHub Release + npm).
- Once tags work again, create the `v2.13.0` tag/GitHub Release and realign semantic-release's baseline past the tombstoned `2.12.x`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThudxML5gWs7nQjdQMzLg3)_