### PR TITLE
chore(vfa-tui): lower version to 0.0.0 to bootstrap release-plz PR flow

### DIFF
--- a/tools/vfa-tui/Cargo.lock
+++ b/tools/vfa-tui/Cargo.lock
@@ -2350,7 +2350,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vfa-tui"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/tools/vfa-tui/Cargo.toml
+++ b/tools/vfa-tui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vfa-tui"
-version = "0.1.0"
+version = "0.0.0"
 edition = "2021"
 rust-version = "1.75"
 description = "Enterprise-grade terminal UI for the Vanguard Frontier Agentic marketplace catalog"


### PR DESCRIPTION
## Problem

After merging #102, the `vfa-tui Release` workflow ran but both jobs were no-ops:

- **`release-pr`**: `INFO vfa-tui: next version is 0.1.0` → `INFO the repository is already up-to-date` — Cargo.toml is already at `0.1.0` (the computed next version), so there's nothing to bump and no Release PR is opened.
- **`release`**: `INFO skipping release: current commit is not from a release PR` — release-plz v0.5 only publishes when HEAD is a release-plz-authored merge commit.

This is a catch-22: `release-pr` won't open a PR (nothing to bump), and `release` won't publish without one.

## Fix

Temporarily lower `Cargo.toml` version to `0.0.0`. After this merges:

1. `release-plz release-pr` sees: current = `0.0.0`, next = `0.1.0` → opens a Release PR
2. **Merge that Release PR** → the merge commit IS from a release PR
3. `release-plz release` publishes `vfa-tui@0.1.0` to crates.io + tags `vfa-tui-v0.1.0` + creates GitHub Release with binaries and SBOM

The `0.0.0` version is never published to crates.io — it exists only to give release-plz something to bump.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XraW3U9JH1eiqBQLNEQGuX)_