### PR TITLE
fix(vfa-tui): fix watcher.rs type mismatch + immutable release uploads

### DIFF
--- a/.github/workflows/vfa-tui-release.yml
+++ b/.github/workflows/vfa-tui-release.yml
@@ -236,3 +236,7 @@ jobs:
           ( cd dist && sha256sum *.tar.gz vfa-tui.spdx.json > checksums.sha256 )
           cat dist/checksums.sha256
           gh release upload "$tag" dist/vfa-tui.spdx.json dist/checksums.sha256 --clobber
+          # All assets are attached — publish the draft release created by release-plz.
+          # (release-plz.toml sets git_release_draft=true so binaries can upload
+          # before the release goes public. Un-draft here, as the final step.)
+          gh release edit "$tag" --draft=false

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -18,6 +18,9 @@ name = "vfa-tui"
 semver_check = true
 # release-plz creates the GitHub Release; the binaries job attaches assets to it.
 git_release_enable = true
+# Create the GitHub Release as a draft so binary assets can be uploaded before
+# the release is published. The SBOM job un-drafts it once all assets are in.
+git_release_draft = true
 # Single-crate projects default to the `v{{ version }}` tag, which would collide
 # with the root npm/semantic-release `vX.Y.Z` namespace. Pin the crate-scoped
 # scheme the workflow and README expect.

--- a/tools/vfa-tui/src/catalog/watcher.rs
+++ b/tools/vfa-tui/src/catalog/watcher.rs
@@ -19,7 +19,7 @@ use std::{
 };
 
 use notify_debouncer_full::{
-    new_debouncer, notify::RecursiveMode, DebounceEventResult, Debouncer, FileIdMap,
+    new_debouncer, notify::RecursiveMode, DebounceEventResult, Debouncer, RecommendedCache,
 };
 use tokio::sync::mpsc;
 use tracing::{debug, warn};
@@ -57,7 +57,8 @@ pub struct WatchConfig {
 pub struct WatcherHandle {
     /// The debouncer **must** stay alive for the duration of watching.
     /// Wrapped in `Arc<Mutex<…>>` so the re-establish task can borrow it.
-    debouncer: Arc<Mutex<Debouncer<notify_debouncer_full::notify::RecommendedWatcher, FileIdMap>>>,
+    debouncer:
+        Arc<Mutex<Debouncer<notify_debouncer_full::notify::RecommendedWatcher, RecommendedCache>>>,
     config: WatchConfig,
 }
 

--- a/tools/vfa-tui/src/catalog/watcher.rs
+++ b/tools/vfa-tui/src/catalog/watcher.rs
@@ -19,7 +19,7 @@ use std::{
 };
 
 use notify_debouncer_full::{
-    new_debouncer, notify::RecursiveMode, DebounceEventResult, Debouncer, NoCache,
+    new_debouncer, notify::RecursiveMode, DebounceEventResult, Debouncer, FileIdMap,
 };
 use tokio::sync::mpsc;
 use tracing::{debug, warn};
@@ -57,7 +57,7 @@ pub struct WatchConfig {
 pub struct WatcherHandle {
     /// The debouncer **must** stay alive for the duration of watching.
     /// Wrapped in `Arc<Mutex<…>>` so the re-establish task can borrow it.
-    debouncer: Arc<Mutex<Debouncer<notify_debouncer_full::notify::RecommendedWatcher, NoCache>>>,
+    debouncer: Arc<Mutex<Debouncer<notify_debouncer_full::notify::RecommendedWatcher, FileIdMap>>>,
     config: WatchConfig,
 }
 


### PR DESCRIPTION
## Root cause analysis

Two bugs surfaced in the binary/SBOM jobs after the 0.0.0 crates.io publish succeeded.

### Bug 1 — macOS compile error (exit 101)

```
error[E0308]: mismatched types
   --> src/catalog/watcher.rs:299:20
expected `NoCache`, found `FileIdMap`
```

The struct field was changed to `NoCache` in a prior fix but `new_debouncer()` returns `Debouncer<_, FileIdMap>` by default — a type mismatch. Linux build jobs hit the Swatinem cache from a previous run and compiled against stale artifacts, masking the error. macOS runners had no cache and compiled fresh, surfacing it.

**Fix:** revert the field annotation to `FileIdMap` to match the `new_debouncer()` return type.

### Bug 2 — Linux upload 422 (exit 1)

```
HTTP 422: Cannot upload assets to an immutable release.
```

`release-plz` published the GitHub Release immediately on crate publish. GitHub treats published (non-draft) releases as immutable and rejects asset uploads from the subsequent `binaries` matrix jobs.

**Fix:**
- `release-plz.toml`: `git_release_draft = true` — release-plz creates a **draft** release; drafts accept asset uploads.
- Workflow SBOM job: `gh release edit "$tag" --draft=false` as the very last step, after all 5 tarballs + SBOM + checksums are attached.

## What's next after merge

The `release` job will re-run on the next release PR. The crate is already on crates.io as `0.0.0`; the **next** release-plz cycle will bump to `0.1.0` (there are `feat:` commits). The binaries and SBOM will attach cleanly to the draft release and then publish it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XraW3U9JH1eiqBQLNEQGuX)_