### PR TITLE
fix: reject symlinked export destination ancestors

### DIFF
--- a/catalog/asset-integrity.json
+++ b/catalog/asset-integrity.json
@@ -28968,7 +28968,7 @@
     },
     {
       "tree": "scripts",
-      "aggregate_sha256": "db4bd93be8066b5265477e477704183162962e9f0166fd3fe63d3e1faa6f38b3",
+      "aggregate_sha256": "ce5d7d297fec4a8fb096413d766d941200fe6568f0f7e1e6f947f473efcdeadc",
       "files": [
         {
           "path": "scripts/apply-skill-allowed-tools.py",
@@ -28982,8 +28982,8 @@
         },
         {
           "path": "scripts/export-marketplace-agents.mjs",
-          "sha256": "c79e3e7decbb3b9ba77f33e05145a22892bcfbf6a15231a74191a1d60e47cbac",
-          "bytes": 27654
+          "sha256": "0624a3ae7d7aa250985dd5e3763a1f9266bc46722c7f5f7620f0859dccf38f37",
+          "bytes": 28726
         },
         {
           "path": "scripts/gen_azure_live_guards.py",
@@ -29485,7 +29485,7 @@
     },
     {
       "tree": "tests",
-      "aggregate_sha256": "8382df613db41b771c34920817ec5891475cd8e99cff5e1e6f2b8ddb57050cfb",
+      "aggregate_sha256": "f4056e5dacbb3c0e960409c6065a627d1cadc32ce69019a5183563328d6f0ce5",
       "files": [
         {
           "path": "tests/AGENTS.md",
@@ -37059,8 +37059,8 @@
         },
         {
           "path": "tests/test-vfa-export-coverage.test.mjs",
-          "sha256": "d9ba3f88b05a05f433e1f9750047ae88d29263e3206c05829b9190611fc601c1",
-          "bytes": 45467
+          "sha256": "a054c8b1e0acc8e96da9f99f7442aa7396858e46d0894c8e6f0a010119c798ea",
+          "bytes": 46776
         },
         {
           "path": "tests/validate-agent-frontmatter-schema.py",
@@ -37222,5 +37222,5 @@
       "bytes": 8340
     }
   ],
-  "aggregate_sha256": "9ff94ce2ca1a8c12f1f0c8d5447928d929238653af00ad4858b58990a39c6fb1"
+  "aggregate_sha256": "c86844c4ab331de4844efe31dbde5fc5f30f3ad99ce49f404a1ffc22d3f1976c"
 }

--- a/scripts/export-marketplace-agents.mjs
+++ b/scripts/export-marketplace-agents.mjs
@@ -273,16 +273,6 @@ function ensurePlatform(platform) {
 }
 
 function assertWithin(parent, child, label) {
-  // Lexical containment check — path.resolve() is purely string-based and does
-  // NOT follow symlinks. This guards against traversal strings (../../) and
-  // metadata.json with absolute paths outside the repo.
-  //
-  // Residual TOCTOU: if an adversary races to create a symlink at `child`
-  // AFTER this check but BEFORE the actual write, the symlink target would be
-  // written to. copyFile()/copySkillTree() use lstatSync on source AND
-  // destination to detect pre-existing symlinks, which closes the window for
-  // the common case. A fully TOCTOU-proof solution requires O_NOFOLLOW at the
-  // kernel level, which is not exposed by Node.js fs APIs.
   const resolvedParent = path.resolve(parent);
   const resolvedChild = path.resolve(child);
   const sep = path.sep;
@@ -293,6 +283,47 @@ function assertWithin(parent, child, label) {
       `This indicates a malformed metadata.json or path traversal attempt.`
     );
   }
+}
+
+function assertNoSymlinkAncestor(parent, child, label) {
+  assertWithin(parent, child, label);
+
+  const resolvedParent = path.resolve(parent);
+  const resolvedChild = path.resolve(child);
+  const relativeParent = path.dirname(path.relative(resolvedParent, resolvedChild));
+  if (!relativeParent || relativeParent === ".") return;
+
+  let current = resolvedParent;
+  for (const part of relativeParent.split(path.sep)) {
+    current = path.join(current, part);
+    let stat;
+    try {
+      stat = fs.lstatSync(current);
+    } catch (err) {
+      if (err && err.code === "ENOENT") return;
+      throw err;
+    }
+    if (stat.isSymbolicLink()) {
+      throw new Error(
+        `Refusing to ${label}: symbolic link ancestor '${current}' would redirect writes outside '${resolvedParent}'. ` +
+        `Remove the symlink and retry.`
+      );
+    }
+    if (!stat.isDirectory()) {
+      throw new Error(
+        `Refusing to ${label}: path ancestor '${current}' is not a directory.`
+      );
+    }
+  }
+}
+
+function assertSafeWriteDestination(parent, destination, label) {
+  // Lexical containment blocks traversal strings and absolute-path metadata.
+  // The ancestor walk then rejects pre-existing symlinks such as `.codex -> /x`
+  // before mkdir/copy can follow them. Node does not expose fully race-proof
+  // O_NOFOLLOW directory creation, so this intentionally closes the reachable
+  // planted-symlink case without pretending to solve privileged TOCTOU races.
+  assertNoSymlinkAncestor(parent, destination, label);
 }
 
 function loadSkills() {
@@ -325,11 +356,12 @@ function loadSkills() {
   return byName;
 }
 
-function copySkillTree(sourceDir, destDir, force) {
+function copySkillTree(sourceDir, destDir, force, targetRoot) {
   assertWithin(repoRoot, sourceDir, "read skill source");
   for (const entry of fs.readdirSync(sourceDir, { withFileTypes: true })) {
     const src = path.join(sourceDir, entry.name);
     const dst = path.join(destDir, entry.name);
+    assertSafeWriteDestination(targetRoot, dst, "write skill tree destination");
     if (entry.isSymbolicLink()) {
       throw new Error(`Refusing to copy symbolic link in skill tree: ${src}`);
     }
@@ -342,7 +374,7 @@ function copySkillTree(sourceDir, destDir, force) {
       );
     }
     if (entry.isDirectory()) {
-      copySkillTree(src, dst, force);
+      copySkillTree(src, dst, force, targetRoot);
       continue;
     }
     if (!entry.isFile()) continue;
@@ -404,7 +436,8 @@ function resolveCompanionSkills(selectedAgents, skillsByName, role, includeAll, 
   return { skillNames: [...skillNames].sort(), orphans };
 }
 
-function copyFile(source, destination, force) {
+function copyFile(source, destination, force, targetRoot) {
+  assertSafeWriteDestination(targetRoot, destination, "write file destination");
   const sourceStat = fs.lstatSync(source);
   if (sourceStat.isSymbolicLink()) {
     throw new Error(`Refusing to copy symbolic link as harness source: ${source}`);
@@ -662,7 +695,7 @@ function main() {
 
   for (const operation of operations) {
     assertWithin(args.repo, operation.dest, "write destination");
-    copyFile(operation.source, operation.dest, args.force);
+    copyFile(operation.source, operation.dest, args.force, args.repo);
     if (platform === "codex") {
       rewriteCodexAgentSkillPaths(operation.dest, args.repo);
     }
@@ -705,7 +738,7 @@ function main() {
       if (!sourceDir) continue;
       const destDir = path.join(args.repo, skillsDestRoot, skillName);
       assertWithin(args.repo, destDir, "write skill destination");
-      copySkillTree(sourceDir, destDir, args.force);
+      copySkillTree(sourceDir, destDir, args.force, args.repo);
       console.log(`installed\tskill:${skillName}\t${platform}\t${path.relative(args.repo, destDir)}`);
       bundled += 1;
     }

--- a/tests/test-vfa-export-coverage.test.mjs
+++ b/tests/test-vfa-export-coverage.test.mjs
@@ -864,6 +864,36 @@ const onDiskSkillNames = new Set(skillProviderByName.keys());
   }
 }
 
+// F28c: codex export rejects symlinked platform directory ancestors.
+{
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vfa-test-codex-parent-symlink-"));
+  const outsideDir = fs.mkdtempSync(path.join(os.tmpdir(), "vfa-test-outside-"));
+  try {
+    fs.symlinkSync(outsideDir, path.join(tmpDir, ".codex"));
+    const r = run([
+      "--platform", "codex",
+      "--agents", "aws-iam-least-privilege-review-agent",
+      "--repo", tmpDir,
+      "--force",
+    ]);
+    const outsideAgent = path.join(outsideDir, "agents", "aws-iam-least-privilege-review-agent.toml");
+    const outsideSkill = path.join(outsideDir, "skills", "aws-iam-least-privilege-review", "SKILL.md");
+    if (
+      r.exitCode !== 0 &&
+      /symbolic link ancestor/i.test(r.stderr) &&
+      !fs.existsSync(outsideAgent) &&
+      !fs.existsSync(outsideSkill)
+    ) {
+      ok("F28c codex export rejects symlinked .codex ancestor without outside writes");
+    } else {
+      fail(`F28c expected symlink ancestor rejection without outside writes; exit=${r.exitCode} agentOutside=${fs.existsSync(outsideAgent)} skillOutside=${fs.existsSync(outsideSkill)} stderr=${r.stderr.slice(0, 300)}`);
+    }
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(outsideDir, { recursive: true, force: true });
+  }
+}
+
 // F29: two-stage installer dry-run composes marketplace-safe export path.
 {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vfa-test-two-stage-"));


### PR DESCRIPTION
### Summary

Fixes a validated exporter path-containment issue where a symlinked platform directory inside the target repo, such as `.codex -> /outside`, could redirect exported agent and skill writes outside the selected `--repo` root.

### Changes

- Add destination ancestor symlink checks before exporter file and skill-tree writes.
- Reject pre-existing symlink ancestors below the selected target root before `mkdirSync` / `copyFileSync`.
- Preserve normal exports to legitimate target directories.
- Add regression coverage for the original `.codex` parent symlink escape.
- Regenerate `catalog/asset-integrity.json`.

### Security impact

Before this fix, a malicious target repository/home could pre-create a symlinked platform directory and cause `vfa-export-agents` to write outside the intended target root while reporting an in-repo relative path.

After this fix, the exporter fails closed with an error like:

```text
Refusing to write file destination: symbolic link ancestor '.../target/.codex' would redirect writes outside '.../target'. Remove the symlink and retry.
```

### Validation

Passed:

```bash
npm run validate:install-coverage
npm run validate:asset-integrity
npm run validate:no-lifecycle-scripts
npm run validate:catalog
git diff --check
```

Manual original PoC was also re-run and is now blocked: non-zero exit and no files written under the outside symlink target.

### Notes

This closes the validated planted-symlink-ancestor exploit path. Node.js does not expose a fully race-proof `O_NOFOLLOW` directory-creation flow for every path component, so this does not claim to solve privileged local TOCTOU races.## Title

fix: reject symlinked export destination ancestors

## Description

### Summary

Fixes a validated exporter path-containment issue where a symlinked platform directory inside the target repo, such as `.codex -> /outside`, could redirect exported agent and skill writes outside the selected `--repo` root.

### Changes

- Add destination ancestor symlink checks before exporter file and skill-tree writes.
- Reject pre-existing symlink ancestors below the selected target root before `mkdirSync` / `copyFileSync`.
- Preserve normal exports to legitimate target directories.
- Add regression coverage for the original `.codex` parent symlink escape.
- Regenerate `catalog/asset-integrity.json`.

### Security impact

Before this fix, a malicious target repository/home could pre-create a symlinked platform directory and cause `vfa-export-agents` to write outside the intended target root while reporting an in-repo relative path.

After this fix, the exporter fails closed with an error like:

```text
Refusing to write file destination: symbolic link ancestor '.../target/.codex' would redirect writes outside '.../target'. Remove the symlink and retry.
```

### Validation

Passed:

```bash
npm run validate:install-coverage
npm run validate:asset-integrity
npm run validate:no-lifecycle-scripts
npm run validate:catalog
git diff --check
```

Manual original PoC was also re-run and is now blocked: non-zero exit and no files written under the outside symlink target.

### Notes

This closes the validated planted-symlink-ancestor exploit path. Node.js does not expose a fully race-proof `O_NOFOLLOW` directory-creation flow for every path component, so this does not claim to solve privileged local TOCTOU races