### PR TITLE
ci(scanner): drop checkout credentials and pin the guide's scanner SHA

### DIFF
--- a/.github/workflows/hol-plugin-scanner.yml
+++ b/.github/workflows/hol-plugin-scanner.yml
@@ -1,13 +1,22 @@
 name: HOL Plugin Scanner
 
-# HOL AI Plugin Scanner — mandatory gate for listing on the Awesome Codex
-# Plugins marketplace (hashgraph-online/awesome-codex-plugins). Listing
-# requires score >= 80 with no critical or high findings, and the scanner
-# must run in the plugin repo's own GitHub Actions.
+# HOL AI Plugin Scanner — continuous self-check against the bar HOL applies
+# when listing on its plugin catalogs (hashgraph-online/awesome-ai-plugins,
+# hashgraph-online/awesome-codex-plugins). The scanner's passing criteria are
+# score >= 80 with no critical or high findings.
+#
+# Source-repository scanner CI is NOT itself a listing requirement: per
+# SCANNER_GUIDE.md (retrieved 2026-09-11) HOL scans listed projects
+# independently, projects without scanner CI remain eligible but take a 10%
+# trust-score reduction, and catalog scan results are advisory for admission.
+# We run it anyway so findings surface here, on the commit that caused them,
+# instead of on a catalog pull request.
 #
 # Two jobs:
-#   gate        — scans the submitted Codex plugin bundle; this is the
-#                 blocking listing gate.
+#   gate        — scans the submitted Codex plugin bundle and enforces the
+#                 >= 80 / no-high-critical bar. Blocking: this is the gate we
+#                 hold ourselves to, so a regression fails here rather than
+#                 being discovered during a catalog review.
 #   marketplace — scans the repo root so the marketplace metadata
 #                 (.agents/plugins/marketplace.json) and the second plugin
 #                 (cross-platform-agent-template) are validated for
@@ -20,6 +29,7 @@ name: HOL Plugin Scanner
 # that reads the action's score/max_severity outputs.
 #
 # Docs:
+#   https://github.com/hashgraph-online/awesome-ai-plugins/blob/main/SCANNER_GUIDE.md
 #   https://github.com/hashgraph-online/awesome-codex-plugins (SCANNER_GUIDE.md)
 #   https://github.com/hashgraph-online/ai-plugin-scanner-action
 
@@ -45,10 +55,16 @@ jobs:
       actions: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # The scanner only reads the tree; leaving the checkout token in
+          # .git/config would hand write-capable credentials to a third-party
+          # action for no benefit. Matches the HOL scanner guide's recommended
+          # workflow and this repo's other read-only jobs.
+          persist-credentials: false
 
       - name: HOL AI Plugin Scanner (report + upload SARIF)
         id: scan
-        uses: hashgraph-online/ai-plugin-scanner-action@b5ded48595ed489e35f2b92f7fb32e3b16960417 # v1.2.265
+        uses: hashgraph-online/ai-plugin-scanner-action@caba2e96aa8ad2feb6cf6fca52442b52e22e779f # v1.2.635
         with:
           plugin_dir: "plugins/vanguard-frontier-agentic"
           mode: scan
@@ -101,10 +117,14 @@ jobs:
       actions: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Same rationale as the gate job above: read-only scan, so the
+          # checkout credential is dropped rather than persisted.
+          persist-credentials: false
 
       - name: HOL AI Plugin Scanner (marketplace root)
         id: scan
-        uses: hashgraph-online/ai-plugin-scanner-action@b5ded48595ed489e35f2b92f7fb32e3b16960417 # v1.2.265
+        uses: hashgraph-online/ai-plugin-scanner-action@caba2e96aa8ad2feb6cf6fca52442b52e22e779f # v1.2.635
         with:
           plugin_dir: "."
           mode: scan


### PR DESCRIPTION
## Summary

Follow-up to the scanner review on [hashgraph-online/awesome-ai-plugins#228](https://github.com/hashgraph-online/awesome-ai-plugins/pull/228) (now merged at 96/100). The reviewer asked that scanner results stay reproducible in this repository; the workflow already existed and was already pinned, so this closes the three remaining deltas against the current [SCANNER_GUIDE.md](https://github.com/hashgraph-online/awesome-ai-plugins/blob/main/SCANNER_GUIDE.md) (retrieved 2026-09-11).

- **`persist-credentials: false` on both checkouts.** The scanner only reads the tree, so persisting a write-capable checkout token into `.git/config` for a third-party action buys nothing. The guide's recommended workflow sets it, and `scorecard.yml`, `vfa-tui-ci.yml`, `fix-asset-integrity.yml`, and both `vfa-tui-release.yml` checkouts already do. Plausibly one of the 3 low findings in the latest catalog scan.
- **Scanner action pin v1.2.265 → v1.2.635**, the exact SHA published in the guide. Upstream releases several times a day (`v1.2.667` landed today); pinning the version the vendor's own guide documents keeps us on a reviewed release rather than chasing a same-day tag. Dependabot's actions group carries it forward from here.
- **Header comment corrected.** It claimed source-repository scanner CI was a *mandatory* listing gate. The guide now states scanner CI is optional, that HOL scans listed projects independently, and that projects without it stay eligible with a 10% trust-score reduction — and the reviewer's own merge comment called catalog scan results "advisory for admission." The >= 80 / no-high-critical bar this workflow enforces is unchanged, but it is our own gate, not an admission requirement.

No behavioral change to the gate logic, job structure, permissions, or `.plugin-scanner.toml` suppressions.

## Verification

- Both tag → SHA mappings verified against upstream refs before pinning: `caba2e96aa8ad2feb6cf6fca52442b52e22e779f` = `v1.2.635`, and the outgoing `b5ded48595ed489e35f2b92f7fb32e3b16960417` = `v1.2.265`.
- YAML re-parsed after editing to assert both jobs carry `persist-credentials: false` and the new pin, rather than eyeballing the diff.
- `npm run validate` — green (exit 0), including `validate:asset-integrity`. The integrity manifest tracks `.github/plugin`, not `.github/workflows`, so no manifest refresh is required for this change.
- `codespell` — clean.
- No markdown and no `tools/vfa-tui/**` changes, so markdownlint and the cargo gates are not in scope.

## Test plan

- [ ] `HOL Plugin Scanner / Listing gate (Codex plugin bundle)` passes on this PR — this is the real probe for the version bump, since ~370 releases of new rules could surface findings the old pin did not.
- [ ] `HOL Plugin Scanner / Marketplace scan (repo root, non-blocking)` reports a score; confirm it has not regressed below the previous run.
- [ ] SARIF still uploads to code scanning under both categories (`vfa-plugin-bundle`, `vfa-marketplace-root`) — confirms `persist-credentials: false` did not break the embedded `upload-sarif` step.
- [ ] If the gate fails on new rules, remediate or extend `.plugin-scanner.toml` with per-alert rationale rather than reverting the pin.