### PR TITLE
fix(release): restore changelog preset compatibility

### DIFF
--- a/catalog/asset-integrity.json
+++ b/catalog/asset-integrity.json
@@ -36700,7 +36700,7 @@
     },
     {
       "tree": "tests",
-      "aggregate_sha256": "1a9f77f13af78a68edad41cd609b0c7460d2996b8e8a09d9181698e19eca62de",
+      "aggregate_sha256": "45273c023437e4ac1e8e4a8ff2ee59bec373e83025a6c6fbef5a902a4d55d657",
       "files": [
         {
           "path": "tests/AGENTS.md",
@@ -47163,6 +47163,11 @@
           "bytes": 8324
         },
         {
+          "path": "tests/validate-release-notes.mjs",
+          "sha256": "0b287df8091bb93b90d00574ef1f7f5c28e9fe7dd89d5479e5d31e5af0770a1d",
+          "bytes": 1140
+        },
+        {
           "path": "tests/validate-skill-allowed-tools.py",
           "sha256": "e493b5f0432a6ed74e064e66095d3519f8b16e2631111605910ae96d54fff037",
           "bytes": 4523
@@ -47228,8 +47233,8 @@
     },
     {
       "path": "package.json",
-      "sha256": "774f160fe4d1f11fb6b9678ebd8b5309ca4b2184965a79de9ba7522fbcf6665a",
-      "bytes": 7327
+      "sha256": "5f8fd7ae21974e9d27e24e8fdf58f8ea997823fee5c68eb88061ce2110113977",
+      "bytes": 7431
     },
     {
       "path": ".releaserc.js",
@@ -47237,5 +47242,5 @@
       "bytes": 8340
     }
   ],
-  "aggregate_sha256": "a17ea10de7fb9e6879ca15603c2b25b455da818156fdfae4e99cbfbf9b65c8ed"
+  "aggregate_sha256": "30556de282ecaf4deff42456e1a437317049c0274e2dad41c68b57af2e5a535c"
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -16,7 +16,7 @@ The `package.json` defines all build, validation, and generation commands.
 
 ### Validation Gates (run via `npm run validate`)
 
-These <!-- count:global:gates -->27<!-- /count --> `validate:*` gates run sequentially in CI and must all pass, in the order `npm run validate` invokes them (the table also lists `manifest:check`, which runs in the same sequence but is not a `validate:*` script):
+These <!-- count:global:gates -->28<!-- /count --> `validate:*` gates run sequentially in CI and must all pass, in the order `npm run validate` invokes them (the table also lists `manifest:check`, which runs in the same sequence but is not a `validate:*` script):
 
 | # | Script | Command | Purpose |
 |---|--------|---------|---------|

--- a/docs/marketplace-model.md
+++ b/docs/marketplace-model.md
@@ -18,7 +18,7 @@ cataloged before they are published.
 
 The marketplace grows slowly with strong review. A small catalog of high-trust
 assets is better than a large catalog nobody should run. Every submitted agent
-or skill must pass all <!-- count:global:gates -->27<!-- /count --> validation gates before merging.
+or skill must pass all <!-- count:global:gates -->28<!-- /count --> validation gates before merging.
 
 ## Supported harness marketplaces
 
@@ -103,7 +103,7 @@ One repo → eight install surfaces
 
 ## Validation
 
-Marketplace manifests are validated by the <!-- count:global:gates -->27<!-- /count -->-gate `npm run validate` suite.
+Marketplace manifests are validated by the <!-- count:global:gates -->28<!-- /count -->-gate `npm run validate` suite.
 The four marketplace-specific gates are:
 
 | Gate | What it checks |
@@ -122,7 +122,7 @@ npm run manifest:write          # re-index catalog/agents.json
 npm run plugin-manifest:write   # .claude-plugin/plugin.json
 npm run cursor-plugin:write     # .cursor-plugin/plugin.json
 npm run kiro-powers:write       # powers/*/POWER.md (if provider configs changed)
-npm run validate                # all <!-- count:global:gates -->27<!-- /count --> gates
+npm run validate                # all <!-- count:global:gates -->28<!-- /count --> gates
 ```
 
 ## See also

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@semantic-release/github": "12.0.9",
         "@semantic-release/npm": "^13.1.5",
         "@semantic-release/release-notes-generator": "14.1.1",
-        "conventional-changelog-conventionalcommits": "10.4.0",
+        "conventional-changelog-conventionalcommits": "9.3.1",
         "fast-check": "^4.7.0",
         "semantic-release": "25.0.9"
       }
@@ -107,16 +107,6 @@
       "optional": true,
       "engines": {
         "node": ">=0.1.90"
-      }
-    },
-    "node_modules/@conventional-changelog/template": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@conventional-changelog/template/-/template-1.4.0.tgz",
-      "integrity": "sha512-aalGyl7dbB5PArRebDIX43ZvBlXrYm9uWzGJ26t+4SzJVPsOuvfILGGbw5X4yX7i50YEmJ8zvbiWnqH/AAnZqg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=22"
       }
     },
     "node_modules/@octokit/auth-token": {
@@ -1198,16 +1188,16 @@
       }
     },
     "node_modules/conventional-changelog-conventionalcommits": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-10.4.0.tgz",
-      "integrity": "sha512-Rriac6ZrAlVm6cy9Bz4NSp+WMHpwNXoPIYex+HjCgduAVUSbnew29DQjQw0C4g9u3HtSYzGiGY+pdBXAZo+4aA==",
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-9.3.1.tgz",
+      "integrity": "sha512-dTYtpIacRpcZgrvBYvBfArMmK2xvIpv2TaxM0/ZI5CBtNUzvF2x0t15HsbRABWprS6UPmvj+PzHVjSx4qAVKyw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "@conventional-changelog/template": "^1.4.0"
+        "compare-func": "^2.0.0"
       },
       "engines": {
-        "node": ">=22"
+        "node": ">=18"
       }
     },
     "node_modules/conventional-changelog-writer": {

--- a/package.json
+++ b/package.json
@@ -85,13 +85,14 @@
     "test:gemini-bundling": "python3 tests/test-gemini-skill-bundling.py",
     "test:cursor-kiro-notices": "node tests/export-cursor-kiro-skill-notice.test.mjs",
     "test:fuzz": "node tests/fuzz-properties.test.mjs",
-    "validate": "npm run validate:catalog && npm run validate:aws && npm run manifest:check && npm run validate:allowed-tools && npm run validate:skill-coherence && npm run validate:skill-schema && npm run validate:agent-schema && npm run validate:model-policy && npm run validate:model-params && npm run validate:links && npm run validate:asset-integrity && npm run validate:mcp-trust-matrix && npm run validate:no-lifecycle-scripts && npm run validate:promotion-gatekeeper && npm run validate:install-coverage && npm run validate:maestro-routing && npm run validate:plugin-manifest && npm run validate:kiro-powers && npm run validate:multi-harness-marketplace && npm run validate:codex-marketplace && npm run validate:finops-fixtures && npm run validate:readme-counts && npm run validate:board-counts && npm run validate:qa-cluster && npm run validate:frontend-security-detection && npm run validate:agent-tool-tiers && npm run validate:istio-review-suite && npm run validate:workflow-catalog",
+    "validate": "npm run validate:catalog && npm run validate:aws && npm run manifest:check && npm run validate:allowed-tools && npm run validate:skill-coherence && npm run validate:skill-schema && npm run validate:agent-schema && npm run validate:model-policy && npm run validate:model-params && npm run validate:links && npm run validate:asset-integrity && npm run validate:mcp-trust-matrix && npm run validate:no-lifecycle-scripts && npm run validate:promotion-gatekeeper && npm run validate:install-coverage && npm run validate:maestro-routing && npm run validate:plugin-manifest && npm run validate:kiro-powers && npm run validate:multi-harness-marketplace && npm run validate:codex-marketplace && npm run validate:finops-fixtures && npm run validate:readme-counts && npm run validate:board-counts && npm run validate:qa-cluster && npm run validate:frontend-security-detection && npm run validate:agent-tool-tiers && npm run validate:istio-review-suite && npm run validate:workflow-catalog && npm run validate:release-notes",
     "release:sbom": "command -v syft >/dev/null 2>&1 && syft scan dir:. -o spdx-json=sbom.spdx.json || echo 'syft not installed; SBOM is generated in CI by anchore/sbom-action'",
     "lint:md": "npx --yes markdownlint-cli2 \"**/*.md\" \"#node_modules\" \"#.git\" \"#.code-review-graph\" \"#CHANGELOG.md\"",
     "lint:spell": "codespell",
     "lint:docs": "npm run lint:md && npm run lint:spell",
     "workflow-catalog:write": "node scripts/generate-workflow-catalog.mjs",
-    "validate:workflow-catalog": "node scripts/generate-workflow-catalog.mjs --check"
+    "validate:workflow-catalog": "node scripts/generate-workflow-catalog.mjs --check",
+    "validate:release-notes": "node tests/validate-release-notes.mjs"
   },
   "devDependencies": {
     "@semantic-release/changelog": "7.0.0",
@@ -101,7 +102,7 @@
     "@semantic-release/github": "12.0.9",
     "@semantic-release/npm": "^13.1.5",
     "@semantic-release/release-notes-generator": "14.1.1",
-    "conventional-changelog-conventionalcommits": "10.4.0",
+    "conventional-changelog-conventionalcommits": "9.3.1",
     "fast-check": "^4.7.0",
     "semantic-release": "25.0.9"
   },

--- a/tests/validate-release-notes.mjs
+++ b/tests/validate-release-notes.mjs
@@ -1,0 +1,35 @@
+import { createRequire } from "node:module";
+import { generateNotes } from "@semantic-release/release-notes-generator";
+
+const require = createRequire(import.meta.url);
+const config = require("../.releaserc.js");
+const pluginConfig = config.plugins.find(
+  ([name]) => name === "@semantic-release/release-notes-generator",
+)?.[1];
+
+if (!pluginConfig) {
+  throw new Error("release-notes-generator configuration is missing");
+}
+
+const notes = await generateNotes(pluginConfig, {
+  commits: [
+    {
+      hash: "1234567890abcdef",
+      message: "feat(istio): add evidence-bounded review suite",
+    },
+  ],
+  lastRelease: { gitTag: "v3.11.1", gitHead: "old" },
+  nextRelease: { version: "3.12.0", gitTag: "v3.12.0", gitHead: "new" },
+  options: {
+    repositoryUrl:
+      "https://github.com/VincentChuWaiChow/vanguard-frontier-agentic.git",
+  },
+  cwd: process.cwd(),
+  logger: console,
+});
+
+if (!notes.includes("v3.12.0") || !notes.includes("evidence-bounded review suite")) {
+  throw new Error("release notes are missing the expected version or feature");
+}
+
+console.log("OK: semantic-release notes generated with the configured preset");


### PR DESCRIPTION
## Summary

- pin `conventional-changelog-conventionalcommits` to `9.3.1`, which is compatible with semantic-release's `conventional-changelog-writer@8`
- add an offline release-notes validation that exercises the repository's actual semantic-release configuration
- update the generated validation-gate count and asset-integrity manifest

## Root cause

The Istio release reached `@semantic-release/release-notes-generator`, but preset `10.4.0` requires `conventional-changelog-writer@9` or newer. `@semantic-release/release-notes-generator@14.1.1` currently installs writer `8.4.0`, so release-note rendering failed before publication.

## Verification

- `npm run validate`
- `npm run lint:spell`
- `npm run lint:md`
- `git diff --check`

This repairs the publication pipeline; semantic-release remains responsible for selecting and publishing the next version from the commits on `master`.
