### PR TITLE
fix(vfa-tui): gate Istio catalog compatibility

### DIFF
--- a/tools/vfa-tui/tests/integration/catalog_loading.rs
+++ b/tools/vfa-tui/tests/integration/catalog_loading.rs
@@ -117,6 +117,33 @@ fn agents_by_provider_returns_correct_subset() {
 }
 
 #[test]
+fn repository_catalog_exposes_istio_review_suite() {
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("vfa-tui must remain under tools/ in the repository");
+    let store = CatalogStore::load(workspace_root);
+
+    assert!(
+        store.load_errors.is_empty(),
+        "unexpected repository catalog load errors: {:?}",
+        store.load_errors
+    );
+
+    let istio_agents = store.agents_by_provider("istio");
+    assert!(
+        !istio_agents.is_empty(),
+        "Istio agents must be discoverable"
+    );
+    assert!(istio_agents
+        .iter()
+        .any(|agent| agent.id == "istio-maestro-agent"));
+    assert!(istio_agents
+        .iter()
+        .all(|agent| !agent.companion_skills.is_empty()));
+}
+
+#[test]
 fn agents_for_role_returns_correct_agents() {
     let store = CatalogStore::load(&fixtures_root());
 


### PR DESCRIPTION
## Summary

- add a TUI integration test against the repository catalog
- verify the new Istio review agents are discoverable through the TUI provider filter
- verify the Istio maestro and companion-skill bindings load without schema errors

## Why

The Istio suite changed catalog data but not `tools/vfa-tui/**`, so the separate TUI release workflow had no release-worthy crate change after `vfa-tui-v0.0.18`. This regression gate both proves compatibility and gives release-plz a scoped patch change from which to create the next TUI release PR.

## Verification

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- positive probe: `repository_catalog_exposes_istio_review_suite`
- negative probe: existing invalid-catalog parsing tests
- `npm run validate`
- `npm run lint:spell`
- `npx --yes markdownlint-cli2 "**/*.md" "#node_modules"`
- `git diff --check`

Versioning and publication remain owned by release-plz; no version was edited manually.
