### PR TITLE
docs(vfa-tui): document dynamic Istio discovery

### DIFF
--- a/tools/vfa-tui/README.md
+++ b/tools/vfa-tui/README.md
@@ -39,13 +39,13 @@ Each release also includes a `checksums.sha256` file and an SPDX 2.3 SBOM (`vfa-
 
 ## Overview
 
-`vfa-tui` provides a fast, keyboard-driven terminal interface for browsing the VFA catalog of 300+ security agents across 30+ providers. It supports fuzzy search, provider/harness filtering, role-based views, validation gate execution with real-time streaming output, export command building with dry-run preview, and structured audit logging.
+`vfa-tui` provides a fast, keyboard-driven terminal interface for browsing the generated VFA catalog. It reads providers, agents, and companion skills at runtime, so catalog additions such as the Istio review suite appear without compiled-in lists or counts. It supports fuzzy search, provider/harness filtering, role-based views, validation gate execution with real-time streaming output, export command building with dry-run preview, and structured audit logging.
 
 Key capabilities:
 
 - Browse agents, skills, roles, providers, MCP references, and rules interactively
 - Fuzzy search across all catalog entities (powered by nucleo-matcher)
-- Run any of the 17+ validation gates with streaming output
+- Run repository validation gates with streaming output
 - Build and preview export commands before execution
 - Manage per-harness model/reasoning-effort policy for providers, roles, and agents — batch assignment with dry-run preview and automatic integrity refresh
 - View asset integrity manifests with SHA-256 hashes


### PR DESCRIPTION
## Summary

- document that the TUI discovers providers, agents, and companion skills from generated catalogs at runtime
- explicitly cover the new Istio review suite
- remove stale hard-coded catalog and validation-gate counts from the packaged crate README

## Release impact

`tools/vfa-tui/README.md` is included in the crates.io package. This gives release-plz a real packaged-crate delta after `vfa-tui-v0.0.18`; the prior integration-test-only change was correctly ignored because `tests/` is excluded from the crate tarball.

## Verification

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `npm run validate`
- `npm run lint:spell`
- `npx --yes markdownlint-cli2 "**/*.md" "#node_modules"`
- `git diff --check`

Versioning remains owned by release-plz.
